### PR TITLE
disable posthog, minor documentation improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ This can be useful if you want to trace a request handler or a function which co
 ### Example
 
 ```javascript
-const { Configuration, OpenAIApi } = require("openai");
 import { OpenAI } from 'openai';
 import { Laminar as L, observe } from '@lmnr-ai/lmnr';
 
@@ -96,7 +95,7 @@ npm install @lmnr-ai/lmnr
 
 Create a file named `my-first-eval.ts` with the following code:
 
-```typescript
+```javascript
 import { evaluate } from '@lmnr-ai/lmnr';
 
 const writePoem = ({topic}: {topic: string}) => {
@@ -136,6 +135,7 @@ You can run evaluations locally by providing executor (part of the logic used in
 - `executor` – the logic you want to evaluate. This function must take `data` as the first argument, and produce any output.
 - `evaluators` – Object which maps evaluator names to evaluators. Each evaluator is a function that takes output of executor as the first argument, `target` as the second argument and produces numeric scores. Each function can produce either a single number or `Record<string, number>` of scores.
 - `name` – optional name for the evaluation. Automatically generated if not provided.
+- `groupId` – optional group name for evaluation. Evaluations within the same group can be compared visually side by side.
 - `config` – optional additional override parameters.
 
 \* If you already have the outputs of executors you want to evaluate, you can specify the executor as an identity function, that takes in `data` and returns only needed value(s) from it.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lmnr-ai/lmnr",
-  "version": "0.4.15",
+  "version": "0.4.16",
   "description": "TypeScript SDK for Laminar AI",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/datasets.ts
+++ b/src/datasets.ts
@@ -3,7 +3,7 @@ import { Laminar as L } from './laminar';
 
 const DEFAULT_FETCH_SIZE = 25;
 
-export abstract class Dataset<D, T> {
+export abstract class EvaluationDataset<D, T> {
   public async slice(start: number, end: number): Promise<Datapoint<D, T>[]> {
     const result = [];
     for (let i = Math.max(start, 0); i < Math.min(end, await this.size()); i++) {
@@ -15,7 +15,7 @@ export abstract class Dataset<D, T> {
   public abstract get(index: number): Promise<Datapoint<D, T>> | Datapoint<D, T>;
 }
 
-export class LaminarDataset<D, T> extends Dataset<D, T> {
+export class LaminarDataset<D, T> extends EvaluationDataset<D, T> {
   private fetchedItems: Datapoint<D, T>[] = [];
   private len: number | null = null;
   private offset: number = 0;

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,6 @@ export {
 
 export { Laminar } from './laminar';
 export { evaluate, Datapoint } from './evaluations';
-export { Dataset, LaminarDataset } from './datasets';
+export { EvaluationDataset as Dataset, LaminarDataset } from './datasets';
 export { observe } from './decorators';
 export { LaminarAttributes } from './sdk/tracing/attributes';

--- a/src/sdk/telemetry/telemetry.ts
+++ b/src/sdk/telemetry/telemetry.ts
@@ -3,7 +3,6 @@ import * as fs from "fs";
 import * as path from "path";
 import { v4 as uuid } from "uuid";
 import { PostHog } from "posthog-node";
-const { version } = require('../../../package.json');
 
 export class Telemetry {
   private static instance: Telemetry;
@@ -23,15 +22,7 @@ export class Telemetry {
   }
 
   private constructor() {
-    this.telemetryEnabled =
-      !process.env.LMNR_TELEMETRY ||
-      process.env.LMNR_TELEMETRY.toLowerCase() === "true";
-
-    if (this.telemetryEnabled) {
-      this.posthog = new PostHog(
-        "phc_dUMdjfNKf11jcHgtn7juSnT4P1pO0tafsPUWt4PuwG7",
-      );
-    }
+    this.telemetryEnabled = false;
   }
 
   private getAnonId() {
@@ -60,7 +51,7 @@ export class Telemetry {
   private getContext() {
     return {
       sdk: "typescript",
-      sdk_version: version,
+      sdk_version: "<null>",
     };
   }
 

--- a/src/sdk/tracing/decorators.ts
+++ b/src/sdk/tracing/decorators.ts
@@ -7,7 +7,6 @@ import {
   SPAN_PATH_KEY,
 } from "./tracing";
 import { shouldSendTraces } from ".";
-import { Telemetry } from "../telemetry/telemetry";
 import { SPAN_INPUT, SPAN_OUTPUT } from "./attributes";
 
 export type DecoratorConfig = {
@@ -77,7 +76,7 @@ export function withEntity<
               );
             }
           } catch (error) {
-            Telemetry.getInstance().logException(error as any);
+            console.warn("Failed to serialize input", error);
           }
         }
 
@@ -100,7 +99,7 @@ export function withEntity<
                 );
               }
             } catch (error) {
-              Telemetry.getInstance().logException(error as any);
+              console.warn("Failed to serialize async output", error);
             } finally {
               span.end();
             }
@@ -116,7 +115,7 @@ export function withEntity<
             );
           }
         } catch (error) {
-          Telemetry.getInstance().logException(error as any);
+          console.warn("Failed to serialize output", error);
         } finally {
           span.end();
         }

--- a/src/sdk/tracing/index.ts
+++ b/src/sdk/tracing/index.ts
@@ -299,7 +299,6 @@ export const startTracing = (options: InitializeOptions) => {
 
 export const shouldSendTraces = () => {
   if (!_configuration) {
-    diag.warn("Traceloop not initialized");
     return false;
   }
 


### PR DESCRIPTION
- Documentation and README improvements
- Disable posthog telemetry (TODO: remove completely)
- Rename some objects for consistency with Python
- Warnings to console when we fail to serialize `observe` input or output.