### PR TITLE
throw an Error if observe does not pass a function

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lmnr-ai/lmnr",
-  "version": "0.4.19",
+  "version": "0.4.20",
   "description": "TypeScript SDK for Laminar AI",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -42,6 +42,10 @@ export async function observe<A extends unknown[], F extends (...args: A) => Ret
     spanType,
     traceId,
   }: ObserveOptions, fn: F, ...args: A): Promise<ReturnType<F>> {
+  if (fn === undefined || typeof fn !== "function") {
+    throw new Error("Invalid `observe` usage. Second argument `fn` must be a function.");
+  }
+
   let associationProperties = {};
   if (sessionId) {
     associationProperties = { ...associationProperties, "session_id": sessionId };


### PR DESCRIPTION
This just slightly enhances the user experience if they use `observe` incorrectly