### PR TITLE
explicitly depend on otlp-exporter-base version

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "@opentelemetry/core": "^1.30.0",
     "@opentelemetry/exporter-trace-otlp-grpc": "^0.57.0",
     "@opentelemetry/exporter-trace-otlp-proto": "^0.57.0",
+    "@opentelemetry/otlp-exporter-base": "^0.57.0",
     "@opentelemetry/instrumentation": "^0.57.0",
     "@opentelemetry/sdk-node": "^0.57.0",
     "@opentelemetry/sdk-trace-base": "^1.30.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@opentelemetry/instrumentation':
         specifier: ^0.57.0
         version: 0.57.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-exporter-base':
+        specifier: ^0.57.0
+        version: 0.57.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-node':
         specifier: ^0.57.0
         version: 0.57.0(@opentelemetry/api@1.9.0)


### PR DESCRIPTION
For some reason, packages that used to depend on @lmnr-ai/lmnr before the update depended on `@opentelemetry/otlp-exporter-base` 0.53.0. i.e. didn't update it despite `pnpm update`. Adding an explicit dependency to address this and republishing this as 0.4.29.