### PR TITLE
v0.4.41 send browser events from client, not browser

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lmnr-ai/lmnr",
-  "version": "0.4.40",
+  "version": "0.4.41",
   "description": "TypeScript SDK for Laminar AI",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/browser/playwright.ts
+++ b/src/browser/playwright.ts
@@ -1,10 +1,13 @@
 import { trace } from '@opentelemetry/api';
 import { Laminar } from '../laminar';
-import { newUUID } from '../utils';
+import { observe } from '../decorators';
+import { newUUID, NIL_UUID, StringUUID } from '../utils';
 import { TRACE_HAS_BROWSER_SESSION } from '../sdk/tracing/attributes';
 import { readFile } from 'fs/promises';
 import path from 'path';
 import { fileURLToPath } from 'url';
+
+import { getLangVersion, SDK_VERSION } from '../version';
 
 type BrowserNewPageType = (...args: Parameters<any['newPage']>) => ReturnType<any['newPage']>;
 type BrowserContextNewPageType = (...args: Parameters<any['newPage']>) => ReturnType<any['newPage']>;
@@ -37,17 +40,9 @@ const injectRrweb = async (page: any) => {
     }
   };
 
-  const isRrwebPresent = await page.evaluate(() => {
-    return typeof (window as any).lmnrRrweb !== 'undefined';
-  });
-
-  // Get current trace ID from active span
-  const currentSpan = trace.getActiveSpan();
-  const traceId = (currentSpan?.spanContext().traceId || '').padStart(32, '0');
-  currentSpan?.setAttribute(TRACE_HAS_BROWSER_SESSION, true);
-  if (!Laminar.initialized()) {
-    throw new Error('Laminar is not initialized. Make sure to call Laminar.initalize() before using browser wrappers.');
-  }
+  const isRrwebPresent = await page.evaluate(() =>
+    typeof (window as any).lmnrRrweb !== 'undefined'
+  );
 
   // Load rrweb and set up recording
   if (!isRrwebPresent) {
@@ -68,154 +63,87 @@ const injectRrweb = async (page: any) => {
    
   }
 
-  const httpUrl = Laminar.getHttpUrl();
-  const projectApiKey = Laminar.getProjectApiKey();
-  const sessionId = newUUID();
-
-  // Generate UUID session ID and set trace ID
-  await tryRunScript(async () => {
-    await page.evaluate((args: string[]) => {
-      const traceId = args[0];
-      const sessionId = args[1];
-      (window as any).lmnrRrwebSessionId = sessionId;
-      (window as any).lmnrTraceId = traceId;
-    }, [traceId, sessionId]);
-  });
-
   // Update the recording setup to include trace ID
   await tryRunScript(async () => {
-    await page.evaluate((args: string[]) => {
-      const baseUrl = args[0];
-      const projectApiKey = args[1];
-      const serverUrl = `${baseUrl}/v1/browser-sessions/events`;
-      const FLUSH_INTERVAL = 1000;
+    await page.evaluate(() => {
+      const BATCH_SIZE = 1000; // Maximum events to store in memory
       const HEARTBEAT_INTERVAL = 1000;  // 1 second heartbeat
 
       (window as any).lmnrRrwebEventsBatch = [];
       
-      (window as any).lmnrSendRrwebEventsBatch = async () => {
-        if ((window as any).lmnrRrwebEventsBatch.length === 0) return;
-                
-        const eventsPayload = {
-          sessionId: (window as any).lmnrRrwebSessionId,
-          traceId: (window as any).lmnrTraceId,
-          events: (window as any).lmnrRrwebEventsBatch,
+      const compressEventData = async (data: any) => {
+        const jsonString = JSON.stringify(data);
+        const blob = new Blob([jsonString], { type: 'application/json' });
+        const compressedStream = blob.stream().pipeThrough(new CompressionStream('gzip'));
+        const compressedResponse = new Response(compressedStream);
+        const compressedData = await compressedResponse.arrayBuffer();
+        return Array.from(new Uint8Array(compressedData));
+      }
+
+      (window as any).lmnrGetAndClearEvents = () => {
+        const events = (window as any).lmnrRrwebEventsBatch;
+        (window as any).lmnrRrwebEventsBatch = [];
+        return events;
+      }
+
+      // heartbeat and limit buffer size
+      setInterval(async () => {
+        const heartbeatEvent = {
+          type: 6, // Custom event type
+          data: await compressEventData({ source: 'heartbeat' }),
+          timestamp: Date.now()
         };
 
-        try {
-          const jsonString = JSON.stringify(eventsPayload);
-          const uint8Array = new TextEncoder().encode(jsonString);
+        (window as any).lmnrRrwebEventsBatch?.push(heartbeatEvent);
 
-          const cs = new CompressionStream('gzip');
-          const compressedStream = await new Response(
-            new Response(uint8Array).body?.pipeThrough(cs)
-          ).arrayBuffer();
-
-          const compressedArray = new Uint8Array(compressedStream);
-          const blob = new Blob([compressedArray], { type: 'application/octet-stream' });
-
-          const response = await fetch(serverUrl, {
-            method: 'POST',
-            headers: { 
-              'Content-Type': 'application/json',
-              'Content-Encoding': 'gzip',
-              'Authorization': `Bearer ${projectApiKey}`,
-              'Accept': 'application/json',
-            },
-            body: blob,
-            credentials: 'omit',
-            mode: 'cors',
-          });
-
-          if (!response.ok) {
-            console.error(`HTTP error! status: ${response.status}`);
-            if (response.status === 0) {
-                console.error('Possible CORS issue - check network tab for details');
-            }
-          }
-          (window as any).lmnrRrwebEventsBatch = [];
-        } catch (error) {
-          console.error('Failed to send events:', error);
+        if ((window as any).lmnrRrwebEventsBatch?.length > BATCH_SIZE) {
+          // Drop oldest events to prevent memory issues
+          (window as any).lmnrRrwebEventsBatch.slice(-BATCH_SIZE);
         }
-      };
-
-      setInterval(() => (window as any).lmnrSendRrwebEventsBatch(), FLUSH_INTERVAL);
-
-      // Add heartbeat event
-      setInterval(() => {
-        (window as any).lmnrRrwebEventsBatch.push({
-          type: 6, // Custom event type
-          data: { source: 'heartbeat' },
-          timestamp: Date.now()
-        });
       }, HEARTBEAT_INTERVAL);
 
       (window as any).lmnrRrweb.record({
-        emit(event: any) {
-          (window as any).lmnrRrwebEventsBatch.push(event);
+        async emit(event: any) {
+          const compressedEvent = {
+            ...event,
+            data: await compressEventData(event.data)
+          };
+          (window as any).lmnrRrwebEventsBatch.push(compressedEvent);
         }
       });
-
-      window.addEventListener('beforeunload', async () => {
-        await (window as any).lmnrSendRrwebEventsBatch();
-      });
-    }, [httpUrl, projectApiKey]);
+    });
   });
 
 };
-
-const handleRoute = async (route: any) => {
-  if (!Laminar.initialized()) {
-    throw new Error('Laminar is not initialized. Make sure to call Laminar.initalize() before using browser wrappers.');
-  }
-
-  const httpUrl = Laminar.getHttpUrl();
-  try {
-    const response = await route.fetch();
-    const headers = response.headers();
-    const newHeaders: {[key: string]: string} = {};
-
-    for (const [key, value] of Object.entries(headers)) {
-      if (key.toLowerCase() == "content-security-policy") {
-        const csp = value as string;
-        const cspParts = csp.split(";");
-        const modifiedParts = cspParts.map(part => {
-          if (part.includes('connect-src')) {
-            return `${part.trim()} ${httpUrl}`;
-          }
-          return part;
-        });
-        const modifiedCsp = modifiedParts.join(';');
-        newHeaders['Content-Security-Policy'] = modifiedCsp;
-      } else {
-        newHeaders[key] = value as string;
-      }
-    }
-    await route.fulfill({
-      response,
-      headers: newHeaders,
-    })
-  } catch (error) {
-    await route.continue();
-  }
-}
 
 let _originalWrapBrowserNewPage: BrowserNewPageType | undefined;
 let _originalWrapBrowserContextNewPage: BrowserContextNewPageType | undefined;
 let _originalWrapBrowserNewContext: BrowserNewContextType | undefined;
 
 const patchedBrowserNewPage = async (...args: Parameters<any['newPage']>) => {
-  const page = await _originalWrapBrowserNewPage?.call(this, ...args);
-  if (!page) throw new Error('Failed to create new page');
-  await wrapPlaywrightPage(page);
-  return page;
+  return observe({
+    name: 'browser.new_page',
+    ignoreInput: true,
+    ignoreOutput: true,
+  }, async () => {
+    const page = await _originalWrapBrowserNewPage?.call(this, ...args);
+    if (!page) throw new Error('Failed to create new page');
+    await wrapPlaywrightPage(page);
+    return page;
+  })
 }
 
 const patchedBrowserContextNewPage = async (...args: Parameters<any['newPage']>) => {
-  const page = await _originalWrapBrowserContextNewPage?.call(this, ...args);
-  if (!page) throw new Error('Failed to create new page');
-  await wrapPlaywrightPage(page);
-  return page;
+  return observe({
+    name: 'browser_context.new_page',
+    ignoreInput: true,
+    ignoreOutput: true,
+  }, async () => {
+    const page = await _originalWrapBrowserContextNewPage?.call(this, ...args);
+    if (!page) throw new Error('Failed to create new page');
+    await wrapPlaywrightPage(page);
+    return page;
+  })
 }
 
 const patchedBrowserNewContext = async (...args: Parameters<any['newContext']>) => {
@@ -232,7 +160,6 @@ export const wrapPlaywrightBrowser = async (browser: any) => {
     if (_originalWrapBrowserContextNewPage === undefined) {
       _originalWrapBrowserContextNewPage = context.newPage.bind(context);
     }
-    context.route('**/*', handleRoute);
     context.newPage = patchedBrowserContextNewPage;
   }
   _originalWrapBrowserNewContext = browser.newContext.bind(browser);
@@ -240,7 +167,6 @@ export const wrapPlaywrightBrowser = async (browser: any) => {
 };
 
 export const wrapPlaywrightContext = async (context: any) => {
-  context.route('**/*', handleRoute);
   _originalWrapBrowserContextNewPage = context.newPage.bind(context);
   context.newPage = patchedBrowserContextNewPage;
 };
@@ -248,10 +174,77 @@ export const wrapPlaywrightContext = async (context: any) => {
 export const wrapPlaywrightPage = async (page: any) => {
   // NOTE: Do not reorder `addListener` and `injectRrweb`. It only works
   // this way.
-  page.addListener("load", (p: any) => {
-    injectRrweb(p).catch(error => {
-      console.error('Failed to inject rrweb:', error);
+  return observe({
+    name: 'page',
+    ignoreInput: true,
+    ignoreOutput: true,
+  }, async () => {
+    page.addListener("load", (p: any) => {
+      injectRrweb(p).catch(error => {
+        console.error('Failed to inject rrweb:', error);
+      });
     });
-  });
-  await injectRrweb(page);
+    await injectRrweb(page);
+
+    trace.getActiveSpan()?.setAttribute(TRACE_HAS_BROWSER_SESSION, true);
+
+    const traceId = trace.getActiveSpan()?.spanContext().traceId as StringUUID ?? NIL_UUID;
+    const sessionId = newUUID();
+    const interval = setInterval(async () => {
+      if (page.isClosed()) {
+        return;
+      }
+      try {
+        await collectAndSendPageEvents(page, sessionId, traceId);
+      } catch (error) {
+        console.error('Event collection stopped:', error);
+      }
+    }, 2000);
+
+    page.on('close', () => clearInterval(interval));
+  })
 };
+
+const collectAndSendPageEvents = async (page: any, sessionId: StringUUID, traceId: StringUUID) => {
+  try {
+    const hasFunction = await page.evaluate(() => typeof (window as any).lmnrGetAndClearEvents === 'function');
+    if (!hasFunction) {
+      return;
+    }
+
+    const events = await page.evaluate(() => (window as any).lmnrGetAndClearEvents());
+    if (events == null && events.length === 0) {
+      return;
+    }
+
+    const source = getLangVersion() ?? 'javascript';
+
+    const payload = {
+      sessionId,
+      traceId,
+      events,
+      source,
+      sdkVersion: SDK_VERSION 
+    };
+
+    const headers = new Headers();
+    headers.set('Content-Type', 'application/json');
+    headers.set('Authorization', `Bearer ${Laminar.getProjectApiKey()}`);
+    headers.set('Accept', 'application/json');
+
+    const response = await fetch(
+      `${Laminar.getHttpUrl()}/v1/browser-sessions/events`,
+      {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(payload),
+      },
+    );
+
+    if (!response.ok) {
+      console.error('Failed to send events:', response.statusText);
+    }
+  } catch (error) {
+    console.error('Error sending events:', error);
+  }
+}

--- a/src/browser/playwright.ts
+++ b/src/browser/playwright.ts
@@ -98,7 +98,7 @@ const injectRrweb = async (page: any) => {
 
         if ((window as any).lmnrRrwebEventsBatch?.length > BATCH_SIZE) {
           // Drop oldest events to prevent memory issues
-          (window as any).lmnrRrwebEventsBatch.slice(-BATCH_SIZE);
+          (window as any).lmnrRrwebEventsBatch = (window as any).lmnrRrwebEventsBatch.slice(-BATCH_SIZE);
         }
       }, HEARTBEAT_INTERVAL);
 
@@ -213,7 +213,7 @@ const collectAndSendPageEvents = async (page: any, sessionId: StringUUID, traceI
     }
 
     const events = await page.evaluate(() => (window as any).lmnrGetAndClearEvents());
-    if (events == null && events.length === 0) {
+    if (events == null || events.length === 0) {
       return;
     }
 

--- a/src/browser/utils.ts
+++ b/src/browser/utils.ts
@@ -1,0 +1,20 @@
+type LLMClient = any; // import { LLMClient } from "@browserbasehq/stagehand";
+
+export function cleanStagehandLLMClientForLaminarObserve(
+    llmClient: any,
+  ): Omit<LLMClient, "client"> {
+    return Object.fromEntries(
+      Object.entries(llmClient)
+        .filter(([key]) => key !== "client")
+        .map(([key, value]) =>
+          key === "clientOptions"
+            ? [
+                key,
+                Object.fromEntries(
+                  Object.entries(value as Record<string, unknown>).filter(([key]) => key !== "apiKey"),
+                ),
+              ]
+            : [key, value],
+        ),
+    ) as Omit<LLMClient, "client">;
+  }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,6 +6,8 @@ export const isStringUUID = (id: string): id is StringUUID => {
   return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/.test(id);
 }
 
+export const NIL_UUID: StringUUID = '00000000-0000-0000-0000-000000000000';
+
 export const newUUID = (): StringUUID => {
   // crypto.randomUUID is available in most of the modern browsers and node,
   // but is not available in "insecure" contexts, e.g. not https, not localhost

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,5 +1,5 @@
 
-export const SDK_VERSION = '0.4.40';
+export const SDK_VERSION = '0.4.41';
 
 export const getLangVersion: () => string | undefined = () => {
   if (process?.versions?.node) {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Shift browser event sending from server to client with client-side batching and compression in `playwright.ts`.
> 
>   - **Behavior**:
>     - Shift event sending from browser to client in `playwright.ts`.
>     - Implement client-side event batching and compression.
>     - Remove server-side event sending logic.
>   - **Utilities**:
>     - Add `cleanStagehandLLMClientForLaminarObserve()` in `utils.ts` to clean LLM client objects.
>     - Introduce `NIL_UUID` constant in `utils.ts`.
>   - **Versioning**:
>     - Update version to `0.4.41` in `package.json` and `version.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr-ts&utm_source=github&utm_medium=referral)<sup> for e7e639412dfab9d0cba2a926d7ebcf827d2b8b97. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->