### PR TITLE
v0.6.2 fix the error causing next.js builds to fail

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lmnr-ai/lmnr",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "TypeScript SDK for Laminar AI",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/laminar.ts
+++ b/src/laminar.ts
@@ -155,6 +155,8 @@ export class Laminar {
    * Next.js place Laminar initialize in `instrumentation.ts`, and then patch
    * the modules in server components or API routes.
    *
+   * Make sure to call this after {@link Laminar.initialize()}.
+   *
    * @param {InitializeOptions["instrumentModules"]} modules - Record of modules to instrument.
    */
   public static patch(modules: InitializeOptions["instrumentModules"]) {

--- a/src/laminar.ts
+++ b/src/laminar.ts
@@ -159,7 +159,8 @@ export class Laminar {
    */
   public static patch(modules: InitializeOptions["instrumentModules"]) {
     if (!this.isInitialized) {
-      throw new Error("Laminar must be initialized before patching modules");
+      logger.warn("Laminar must be initialized before patching modules. Skipping patch.");
+      return;
     }
     if (!modules || Object.keys(modules).length === 0) {
       throw new Error("Pass at least one module to patch");


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fix Next.js build failure by modifying `Laminar.patch()` to log a warning and skip patching if uninitialized, and update version to 0.6.2.
> 
>   - **Behavior**:
>     - In `src/laminar.ts`, `Laminar.patch()` now logs a warning and skips patching if `Laminar` is not initialized, instead of throwing an error.
>   - **Versioning**:
>     - Update version in `package.json` from `0.6.1` to `0.6.2`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr-ts&utm_source=github&utm_medium=referral)<sup> for 185f8b17f89c9efd0eb03c285c64441aa861eb3b. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->