### PR TITLE
add userId and sessionId in observe; allow multiple evals in CLI

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -151,7 +151,7 @@ async function cli() {
         const outputFileText = result.outputFiles[0].text;
 
         const evaluations = loadModule({
-          filename: args.file,
+          filename: file,
           moduleText: outputFileText,
         });
 

--- a/src/evaluations.ts
+++ b/src/evaluations.ts
@@ -525,6 +525,8 @@ export async function evaluate<D, T, O>({
     config,
   });
   if (globalThis._set_global_evaluation) {
+    // TODO: if we load files concurrently, we need to use a mutex to protect
+    // concurrent writes to globalThis._evaluations
     globalThis._evaluations = [...(globalThis._evaluations ?? []), evaluation];
   } else {
     await evaluation.run();

--- a/src/opentelemetry-lib/tracing/compat.ts
+++ b/src/opentelemetry-lib/tracing/compat.ts
@@ -36,6 +36,4 @@ export const createResource = (
   // For v2 this would be:
   // const { resourceFromAttributes } = require("@opentelemetry/resources");
   // return resourceFromAttributes(attributes);
-  new Resource(
-    attributes,
-  );
+  new Resource(attributes);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import { SpanContext, TraceFlags } from '@opentelemetry/api';
+import { AttributeValue, SpanContext, TraceFlags } from '@opentelemetry/api';
 import path from "path";
 import pino, { Level } from 'pino';
 import pinoPretty from 'pino-pretty';
@@ -205,4 +205,20 @@ export const slicePayload = <T>(value: T, length: number) => {
   }
 
   return (str.slice(0, length) + '...');
+};
+
+export const isOtelAttributeValueType = (value: unknown): value is AttributeValue => {
+  if (typeof value === 'string'
+    || typeof value === 'number'
+    || typeof value === 'boolean') {
+    return true;
+  }
+
+  if (Array.isArray(value)) {
+    const allStrings = value.every(value => (value == null) || typeof value === 'string');
+    const allNumbers = value.every(value => (value == null) || typeof value === 'number');
+    const allBooleans = value.every(value => (value == null) || typeof value === 'boolean');
+    return allStrings || allNumbers || allBooleans;
+  }
+  return false;
 };

--- a/test/evaluate.test.ts
+++ b/test/evaluate.test.ts
@@ -7,6 +7,7 @@ import nock from "nock";
 import { evaluate, Laminar } from "../src/index";
 import { _resetConfiguration, initializeTracing } from "../src/opentelemetry-lib/configuration";
 
+type RequestBody = Record<string, any>;
 
 void describe("evaluate", () => {
   const exporter = new InMemorySpanExporter();
@@ -28,7 +29,7 @@ void describe("evaluate", () => {
     const mockEvalId = "00000000-0000-0000-0000-000000000000";
 
     // spy into request body
-    let body: Record<string, any> = {};
+    let body: RequestBody = {};
 
     nock(baseUrl)
       .post('/v1/evals')
@@ -38,9 +39,9 @@ void describe("evaluate", () => {
       });
 
     nock(baseUrl)
-      .post(`/v1/evals/${mockEvalId}/datapoints`, <T>(requestBody: T): T => {
+      .post(`/v1/evals/${mockEvalId}/datapoints`, (requestBody: RequestBody): boolean => {
         body = requestBody;
-        return requestBody;
+        return true;
       })
       .times(2)
       .reply(200, {});


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enhance CLI to support multiple evaluations and add user/session IDs to observe function for improved traceability.
> 
>   - **CLI**:
>     - `cli.ts`: Support multiple evaluations by changing `_evaluation` to `_evaluations`.
>     - `loadModule()` now returns an array of evaluations.
>     - Logs the number of evaluations loaded from each file.
>   - **Observe Function**:
>     - `decorators.ts`: Add `userId` and `metadata` to `ObserveOptions`.
>     - `observe()` now includes `userId` and `metadata` in association properties.
>   - **Evaluations**:
>     - `evaluations.ts`: Change `_evaluation` to `_evaluations` to support multiple evaluations.
>     - `evaluate()` appends evaluations to `_evaluations` array.
>   - **Tests**:
>     - `evaluate.test.ts` and `tracing.test.ts`: Add tests for `userId` and `metadata` in `observe()`.
>     - Ensure multiple evaluations are handled correctly in CLI tests.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr-ts&utm_source=github&utm_medium=referral)<sup> for c65ab74a4ef6fcbe0aa15adfaa59d0d54553a558. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->