### PR TITLE
updates to trace metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lmnr-ai/lmnr",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "description": "TypeScript SDK for Laminar AI",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,6 +6,7 @@ import { fileURLToPath } from "url";
 import { v4 as uuidv4 } from 'uuid';
 
 import { LaminarSpanContext } from './types';
+import { ASSOCIATION_PROPERTIES } from './opentelemetry-lib/tracing/attributes';
 
 export function initializeLogger(options?: { colorize?: boolean, level?: Level }) {
   const colorize = options?.colorize ?? true;
@@ -227,4 +228,16 @@ export const isOtelAttributeValueType = (value: unknown): value is AttributeValu
     return allStrings || allNumbers || allBooleans;
   }
   return false;
+};
+
+export const metadataToAttributes = (metadata: Record<string, unknown>): Record<string, AttributeValue> => {
+  return Object.fromEntries(
+    Object.entries(metadata).map(([key, value]) => {
+      if (isOtelAttributeValueType(value)) {
+        return [`${ASSOCIATION_PROPERTIES}.metadata.${key}`, value];
+      } else {
+        return [`${ASSOCIATION_PROPERTIES}.metadata.${key}`, JSON.stringify(value)];
+      }
+    }),
+  );
 };

--- a/test/tracing.test.ts
+++ b/test/tracing.test.ts
@@ -341,6 +341,21 @@ void describe("tracing", () => {
     assert.strictEqual(spans[0].attributes['lmnr.span.instrumentation_source'], "javascript");
   });
 
+  void it("can process empty metadata or tags", () => {
+    const span = Laminar.startSpan({ name: "test", metadata: {}, tags: [], userId: "", sessionId: "" });
+    const result = Laminar.withSpan(span, () => 3, true);
+    assert.strictEqual(result, 3);
+
+    const spans = exporter.getFinishedSpans();
+    assert.strictEqual(spans.length, 1);
+    assert.strictEqual(spans[0].name, "test");
+    assert.strictEqual(spans[0].attributes['lmnr.association.properties.user_id'], undefined);
+    assert.strictEqual(spans[0].attributes['lmnr.association.properties.session_id'], undefined);
+    assert.strictEqual(spans[0].attributes['lmnr.association.properties.metadata'], undefined);
+    assert.deepStrictEqual(spans[0].attributes['lmnr.association.properties.tags'], []);
+    assert.strictEqual(spans[0].attributes['lmnr.span.instrumentation_source'], "javascript");
+  });
+
   void it("observes nested functions", async () => {
     const double = (a: number) => a * 2;
     const fn = async (a: number, b: number) => a + await observe({ name: "double" }, double, b);
@@ -745,7 +760,6 @@ void describe("tracing", () => {
     const spans = exporter.getFinishedSpans();
     assert.strictEqual(spans.length, 1);
     assert.strictEqual(spans[0].name, "test");
-    console.log(spans[0].attributes);
     assert.strictEqual(spans[0].attributes['lmnr.association.properties.metadata.k1'], "v1");
     assert.strictEqual(spans[0].attributes['lmnr.association.properties.metadata.k2'], JSON.stringify({ obj: "shall be stringified" }));
     assert.strictEqual(spans[0].attributes['lmnr.span.input'], JSON.stringify([1, 2]));

--- a/test/tracing.test.ts
+++ b/test/tracing.test.ts
@@ -270,6 +270,77 @@ void describe("tracing", () => {
     assert.deepEqual(spans[0].attributes['lmnr.span.path'], ["test"]);
   });
 
+  void it("sets the tags in observe", async () => {
+    const fn = (a: number, b: number) => a + b;
+    const result = await observe({
+      name: "test",
+      tags: ["tag1", "tag2"],
+    }, fn, 1, 2);
+
+    assert.strictEqual(result, 3);
+    const spans = exporter.getFinishedSpans();
+
+    assert.strictEqual(spans.length, 1);
+    assert.strictEqual(spans[0].attributes['lmnr.span.input'], JSON.stringify([1, 2]));
+    assert.strictEqual(spans[0].attributes['lmnr.span.output'], "3");
+    assert.strictEqual(spans[0].name, "test");
+
+    assert.deepStrictEqual(spans[0].attributes['lmnr.association.properties.tags'], ["tag1", "tag2"]);
+    assert.strictEqual(spans[0].attributes['lmnr.span.instrumentation_source'], "javascript");
+    assert.deepEqual(spans[0].attributes['lmnr.span.path'], ["test"]);
+  });
+
+  void it("sets the session id in startSpan", () => {
+    const span = Laminar.startSpan({ name: "test", sessionId: "123" });
+    const result = Laminar.withSpan(span, () => 3, true);
+    assert.strictEqual(result, 3);
+
+    const spans = exporter.getFinishedSpans();
+    assert.strictEqual(spans.length, 1);
+    assert.strictEqual(spans[0].name, "test");
+    assert.strictEqual(spans[0].attributes['lmnr.association.properties.session_id'], "123");
+    assert.strictEqual(spans[0].attributes['lmnr.span.instrumentation_source'], "javascript");
+  });
+
+  void it("sets the user id in startSpan", () => {
+    const span = Laminar.startSpan({ name: "test", userId: "123" });
+    const result = Laminar.withSpan(span, () => 3, true);
+    assert.strictEqual(result, 3);
+
+    const spans = exporter.getFinishedSpans();
+    assert.strictEqual(spans.length, 1);
+    assert.strictEqual(spans[0].name, "test");
+    assert.strictEqual(spans[0].attributes['lmnr.association.properties.user_id'], "123");
+    assert.strictEqual(spans[0].attributes['lmnr.span.instrumentation_source'], "javascript");
+  });
+
+  void it("sets the metadata in startSpan", () => {
+    const span = Laminar.startSpan({ name: "test", metadata: { key: "value", nested: { key2: "value2" } } });
+    const result = Laminar.withSpan(span, () => 3, true);
+    assert.strictEqual(result, 3);
+
+    const spans = exporter.getFinishedSpans();
+    assert.strictEqual(spans.length, 1);
+    assert.strictEqual(spans[0].name, "test");
+    assert.strictEqual(spans[0].attributes['lmnr.association.properties.metadata.key'], "value");
+    assert.deepStrictEqual(
+      JSON.parse(spans[0].attributes['lmnr.association.properties.metadata.nested'] as string),
+      { key2: "value2" },
+    );
+  });
+
+  void it("sets the tags in startSpan", () => {
+    const span = Laminar.startSpan({ name: "test", tags: ["tag1", "tag2"] });
+    const result = Laminar.withSpan(span, () => 3, true);
+    assert.strictEqual(result, 3);
+
+    const spans = exporter.getFinishedSpans();
+    assert.strictEqual(spans.length, 1);
+    assert.strictEqual(spans[0].name, "test");
+    assert.deepStrictEqual(spans[0].attributes['lmnr.association.properties.tags'], ["tag1", "tag2"]);
+    assert.strictEqual(spans[0].attributes['lmnr.span.instrumentation_source'], "javascript");
+  });
+
   void it("observes nested functions", async () => {
     const double = (a: number) => a * 2;
     const fn = async (a: number, b: number) => a + await observe({ name: "double" }, double, b);
@@ -622,5 +693,79 @@ void describe("tracing", () => {
         .startsWith('Error: test error\n    at'),
       true,
     );
+  });
+
+  void it("sets the session id on the current span when setTraceSessionId is used", async () => {
+    const fn = (a: number, b: number) => {
+      Laminar.setTraceSessionId("123");
+      return a + b;
+    };
+    const result = await observe({ name: "test" }, fn, 1, 2);
+
+    assert.strictEqual(result, 3);
+
+    const spans = exporter.getFinishedSpans();
+    assert.strictEqual(spans.length, 1);
+    assert.strictEqual(spans[0].name, "test");
+    assert.strictEqual(spans[0].attributes['lmnr.association.properties.session_id'], "123");
+    assert.strictEqual(spans[0].attributes['lmnr.span.input'], JSON.stringify([1, 2]));
+    assert.strictEqual(spans[0].attributes['lmnr.span.output'], "3");
+  });
+
+  void it("sets the user id on the current span when setTraceUserId is used", async () => {
+    const fn = (a: number, b: number) => {
+      Laminar.setTraceUserId("123");
+      return a + b;
+    };
+    const result = await observe({ name: "test" }, fn, 1, 2);
+
+    assert.strictEqual(result, 3);
+
+    const spans = exporter.getFinishedSpans();
+    assert.strictEqual(spans.length, 1);
+    assert.strictEqual(spans[0].name, "test");
+    assert.strictEqual(spans[0].attributes['lmnr.association.properties.user_id'], "123");
+    assert.strictEqual(spans[0].attributes['lmnr.span.input'], JSON.stringify([1, 2]));
+    assert.strictEqual(spans[0].attributes['lmnr.span.output'], "3");
+  });
+
+  void it("sets metadata on the current span when setTraceMetadata is used", async () => {
+    const fn = (a: number, b: number) => {
+      Laminar.setTraceMetadata({
+        k1: "v1", k2: {
+          obj: "shall be stringified"
+        }
+      });
+      return a + b;
+    };
+    const result = await observe({ name: "test" }, fn, 1, 2);
+
+    assert.strictEqual(result, 3);
+
+    const spans = exporter.getFinishedSpans();
+    assert.strictEqual(spans.length, 1);
+    assert.strictEqual(spans[0].name, "test");
+    console.log(spans[0].attributes);
+    assert.strictEqual(spans[0].attributes['lmnr.association.properties.metadata.k1'], "v1");
+    assert.strictEqual(spans[0].attributes['lmnr.association.properties.metadata.k2'], JSON.stringify({ obj: "shall be stringified" }));
+    assert.strictEqual(spans[0].attributes['lmnr.span.input'], JSON.stringify([1, 2]));
+    assert.strictEqual(spans[0].attributes['lmnr.span.output'], "3");
+  });
+
+  void it("sets tags on the current span when setSpanTags is used", async () => {
+    const fn = (a: number, b: number) => {
+      Laminar.setSpanTags(["tag1", "tag2"]);
+      return a + b;
+    };
+    const result = await observe({ name: "test" }, fn, 1, 2);
+
+    assert.strictEqual(result, 3);
+
+    const spans = exporter.getFinishedSpans();
+    assert.strictEqual(spans.length, 1);
+    assert.strictEqual(spans[0].name, "test");
+    assert.deepStrictEqual(spans[0].attributes['lmnr.association.properties.tags'], ["tag1", "tag2"]);
+    assert.strictEqual(spans[0].attributes['lmnr.span.input'], JSON.stringify([1, 2]));
+    assert.strictEqual(spans[0].attributes['lmnr.span.output'], "3");
   });
 });


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enhance tracing with new methods for setting metadata, session IDs, user IDs, and tags on spans, and deprecate older methods.
> 
>   - **Behavior**:
>     - Adds `tags` to `ObserveOptions` in `decorators.ts` for associating tags with spans.
>     - Introduces `setTraceMetadata`, `setTraceSessionId`, `setTraceUserId`, and `setSpanTags` methods in `Laminar` class in `laminar.ts` for setting metadata, session ID, user ID, and tags on the current span.
>     - Deprecates `withSession` and `withMetadata` methods in `Laminar` class in `laminar.ts`.
>   - **Utilities**:
>     - Adds `metadataToAttributes` function in `utils.ts` for converting metadata to span attributes.
>   - **Tests**:
>     - Adds tests in `tracing.test.ts` for new methods `setTraceMetadata`, `setTraceSessionId`, `setTraceUserId`, and `setSpanTags`.
>     - Updates existing tests to cover `tags` in `observe` and `startSpan` methods.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr-ts&utm_source=github&utm_medium=referral)<sup> for ee70c6d2aae75e0841ee299307d2d5e29b681d71. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->