### PR TITLE
allow multiple files in the CLI

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -73,10 +73,11 @@ async function cli() {
     help: "Run an evaluation",
   });
 
-  parserEval.add_argument("file", {
-    help: "A file containing the evaluation to run. If no file is provided, " +
-      "the evaluation will run all `*.eval.ts|js` files in the `evals` directory.",
-    nargs: "?",
+  parserEval.add_argument("files", {
+    help: "A file or files containing the evaluation to run. If no file is provided, " +
+      "the evaluation will run all `*.eval.ts|js` files in the `evals` directory. " +
+      "If multiple files are provided, the evaluation will run each file in order.",
+    nargs: "*",
   });
 
   parserEval.add_argument("--fail-on-error", {
@@ -86,8 +87,8 @@ async function cli() {
 
   parserEval.set_defaults({
     func: async (args: any) => {
-      const files = args.file
-        ? [args.file]
+      const files = args.files
+        ? Array.isArray(args.files) ? args.files : [args.files]
         : glob.sync('evals/**/*.eval.{ts,js}');
 
       files.sort();
@@ -99,8 +100,10 @@ async function cli() {
         process.exit(1);
       }
 
-      if (!args.file) {
+      if (!args.files) {
         logger.info(`Located ${files.length} evaluation files in evals/`);
+      } else {
+        logger.info(`Running ${files.length} evaluation files.`);
       }
 
       // Laminar should be marked external by passing 'node_modules/*' to the


### PR DESCRIPTION
now it's possible to do

```sh
npx lmnr eval **/*.eval.ts
# or even
npx lmnr eval first-eval.eval.ts second-eval.eval.ts
```
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enhance CLI in `src/cli.ts` to support multiple file inputs for evaluation and remove unused code.
> 
>   - **CLI Behavior**:
>     - `parserEval` in `src/cli.ts` now accepts multiple files via `files` argument with `nargs: "*"`.
>     - If no files are provided, defaults to `evals/**/*.eval.{ts,js}` pattern.
>     - Logs the number of files being evaluated.
>   - **Code Cleanup**:
>     - Removes unused import from `@opentelemetry/api`.
>     - Removes `setLaminarAsExternalPlugin` from esbuild options.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr-ts&utm_source=github&utm_medium=referral)<sup> for 15004e22fb532ceffcc7aa370527a202ae25d043. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->