### PR TITLE
action to publish to npm

### DIFF
--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -1,0 +1,23 @@
+name: Publish to npm
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish-to-npm:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+      - run: npm install -g pnpm
+      - run: pnpm i --frozen-lockfile && pnpm build
+      - run: pnpm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add GitHub Action to publish package to npm on release using `pnpm`.
> 
>   - **Workflow**:
>     - Adds `.github/workflows/publish-to-npm.yml` to automate npm publishing on release.
>     - Triggers on release events of type `published`.
>   - **Environment**:
>     - Runs on `ubuntu-latest`.
>     - Uses `actions/checkout@v4` and `actions/setup-node@v4` with Node.js version 22.
>   - **Package Management**:
>     - Installs `pnpm` globally.
>     - Runs `pnpm i --frozen-lockfile` and `pnpm build`.
>     - Publishes package with `pnpm publish --provenance --access public`.
>   - **Authentication**:
>     - Uses `NODE_AUTH_TOKEN` from GitHub secrets for npm authentication.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr-ts&utm_source=github&utm_medium=referral)<sup> for 89a8cd3de6846bbfdd117326100a4fa977eed1b0. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->