### PR TITLE
fix pinoPretty import w/o synthetic default

### DIFF
--- a/src/evaluations.ts
+++ b/src/evaluations.ts
@@ -1,5 +1,5 @@
 import { trace } from "@opentelemetry/api";
-import cliProgress from "cli-progress";
+import * as cliProgress from "cli-progress";
 
 import { LaminarClient } from "./client";
 import { EvaluationDataset, LaminarDataset } from "./datasets";
@@ -7,7 +7,7 @@ import { observe } from "./decorators";
 import { Laminar } from "./laminar";
 import { InitializeOptions } from "./opentelemetry-lib/interfaces";
 import { SPAN_TYPE } from "./opentelemetry-lib/tracing/attributes";
-import {EvaluationDatapoint} from "./types";
+import { EvaluationDatapoint } from "./types";
 import {
   initializeLogger,
   newUUID,
@@ -48,27 +48,27 @@ const getEvaluationUrl = (projectId: string, evaluationId: string, baseUrl?: str
 };
 
 const getAverageScores =
-    <D, T, O>(results: EvaluationDatapoint<D, T, O>[]): Record<string, number> => {
-      const perScoreValues: Record<string, number[]> = {};
-      for (const result of results) {
-        for (const key in result.scores) {
-          const score = result.scores[key];
-          if (perScoreValues[key] && score !== null) {
-            perScoreValues[key].push(score);
-          } else {
-            perScoreValues[key] = score !== null ? [score] : [];
-          }
+  <D, T, O>(results: EvaluationDatapoint<D, T, O>[]): Record<string, number> => {
+    const perScoreValues: Record<string, number[]> = {};
+    for (const result of results) {
+      for (const key in result.scores) {
+        const score = result.scores[key];
+        if (perScoreValues[key] && score !== null) {
+          perScoreValues[key].push(score);
+        } else {
+          perScoreValues[key] = score !== null ? [score] : [];
         }
       }
+    }
 
-      const averageScores: Record<string, number> = {};
-      for (const key in perScoreValues) {
-        averageScores[key] = perScoreValues[key].reduce((a, b) => a + b, 0)
-            / perScoreValues[key].length;
-      }
+    const averageScores: Record<string, number> = {};
+    for (const key in perScoreValues) {
+      averageScores[key] = perScoreValues[key].reduce((a, b) => a + b, 0)
+        / perScoreValues[key].length;
+    }
 
-      return averageScores;
-    };
+    return averageScores;
+  };
 
 /**
  * Configuration for the Evaluator
@@ -146,7 +146,7 @@ export type Datapoint<D, T> = {
 /**
  * HumanEvaluator is a class to register a human evaluator.
  */
-export class HumanEvaluator {}
+export class HumanEvaluator { }
 
 export type EvaluatorFunctionReturn = number | Record<string, number>;
 
@@ -387,8 +387,10 @@ export class Evaluation<D, T, O> {
     const semaphore = new Semaphore(this.concurrencyLimit);
     const tasks: Promise<any>[] = [];
 
-    const evaluateTask = async (datapoint: Datapoint<D, T>, index: number):
-    Promise<[number, EvaluationDatapoint<D, T, O>]> => {
+    const evaluateTask = async (
+      datapoint: Datapoint<D, T>,
+      index: number,
+    ): Promise<[number, EvaluationDatapoint<D, T, O>]> => {
       try {
         const result = await this.evaluateDatapoint(evalId, datapoint, index);
         this.progressReporter.update(1);

--- a/src/opentelemetry-lib/tracing/decorators.ts
+++ b/src/opentelemetry-lib/tracing/decorators.ts
@@ -49,9 +49,9 @@ export function observeBase<
   // withMetadata, withSession.
   if (associationProperties) {
   // Remove span type from association properties after the span is created
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  // TODO: Remove this once we've removed older deprecated methods, such as
-  // withMetadata, withSession.
+
+    // TODO: Remove this once we've removed older deprecated methods, such as
+    // withMetadata, withSession.
     entityContext = entityContext.setValue(
       ASSOCIATION_PROPERTIES_KEY,
       { ...(currentAssociationProperties ?? {}), ...rest },

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,5 @@
 import { AttributeValue, SpanContext, TraceFlags } from '@opentelemetry/api';
-import path from "path";
+import * as path from "path";
 import pino, { Level } from 'pino';
 import { PinoPretty } from 'pino-pretty';
 import { fileURLToPath } from "url";

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,7 @@
 import { AttributeValue, SpanContext, TraceFlags } from '@opentelemetry/api';
 import path from "path";
 import pino, { Level } from 'pino';
-import pinoPretty from 'pino-pretty';
+import { PinoPretty } from 'pino-pretty';
 import { fileURLToPath } from "url";
 import { v4 as uuidv4 } from 'uuid';
 
@@ -14,7 +14,7 @@ export function initializeLogger(options?: { colorize?: boolean, level?: Level }
     ?? (process.env.LMNR_LOG_LEVEL?.toLowerCase()?.trim() as Level)
     ?? 'info';
 
-  return pino(pinoPretty({
+  return pino(PinoPretty({
     colorize,
     minimumLevel: level,
   }));

--- a/test/tracing.test.ts
+++ b/test/tracing.test.ts
@@ -809,18 +809,26 @@ void describe("tracing", () => {
     const fn = (a: number, b: number) => a + b;
 
     await observe(
-      { name: "evaluator", spanType: 'EVALUATOR' }, async () => {
-        return await observe({ name: 'default' }, fn, 1, 2);
-      }, 1, 2);
+      { name: "evaluator", spanType: 'EVALUATOR' },
+      async () => await observe({ name: 'default' }, fn, 1, 2),
+      1,
+      2,
+    );
 
     const spans = exporter.getFinishedSpans();
 
     assert.strictEqual(spans.length, 2);
 
-    assert.strictEqual(spans.some((s) => s.name === 'evaluator'), true)
-    assert.strictEqual(spans.some((s)=> s.name === 'default'), true)
+    assert.strictEqual(spans.some((s) => s.name === 'evaluator'), true);
+    assert.strictEqual(spans.some((s) => s.name === 'default'), true);
 
-    assert.strictEqual(spans.find((s)=> s.name === 'evaluator')?.attributes['lmnr.span.type'], 'EVALUATOR');
-    assert.strictEqual(spans.find((s)=> s.name === 'default')?.attributes['lmnr.span.type'], undefined);
+    assert.strictEqual(
+      spans.find((s) => s.name === 'evaluator')?.attributes['lmnr.span.type'],
+      'EVALUATOR',
+    );
+    assert.strictEqual(
+      spans.find((s) => s.name === 'default')?.attributes['lmnr.span.type'],
+      undefined,
+    );
   });
 });


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fix import issues with `pino-pretty` and `cli-progress`, and update tests for span type handling.
> 
>   - **Imports**:
>     - Change `pino-pretty` import to named import `PinoPretty` in `utils.ts`.
>     - Change `cli-progress` import to namespace import in `evaluations.ts`.
>   - **Formatting**:
>     - Fix spacing and indentation in `evaluations.ts` and `decorators.ts`.
>   - **Tests**:
>     - Update `tracing.test.ts` to ensure span type is not overridden in nested `observe` calls.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr-ts&utm_source=github&utm_medium=referral)<sup> for 6cae3b590d6f6331b408477283f9db8e647cfa97. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->