### PR TITLE
add --no-git-checks flag to pnpm publish

### DIFF
--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -18,6 +18,6 @@ jobs:
           registry-url: https://registry.npmjs.org
       - run: npm install -g pnpm
       - run: pnpm i --frozen-lockfile && pnpm build
-      - run: pnpm publish --provenance --access --no-git-checks public
+      - run: pnpm publish --provenance --no-git-checks --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
`pnpm` checks that you are publishing from main/master. This is good on its own, but breaks when publishing from a tag (github release). Related: https://github.com/pnpm/pnpm/issues/5894
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `--no-git-checks` to `pnpm publish` in GitHub Actions to allow publishing from tags.
> 
>   - **Behavior**:
>     - Adds `--no-git-checks` flag to `pnpm publish` command in `.github/workflows/publish-to-npm.yml`.
>     - Allows publishing from a tag, bypassing the default branch check (main/master).
>   - **Context**:
>     - Addresses issue where `pnpm` fails to publish from a GitHub release tag due to branch checks.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr-ts&utm_source=github&utm_medium=referral)<sup> for f6c8e19b79ca318b2298f346c1ab3384129bab0a. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->