### PR TITLE
feat: human evaluator options

### DIFF
--- a/src/evaluations.ts
+++ b/src/evaluations.ts
@@ -147,7 +147,7 @@ export type Datapoint<D, T> = {
  * HumanEvaluator is a class to register a human evaluator.
  */
 export class HumanEvaluator {
-  public options?: { value: number; label: string }[]
+  public options?: { value: number; label: string }[];
 
   constructor(options?: { value: number; label: string }[]) {
     this.options = options;
@@ -466,7 +466,10 @@ export class Evaluation<D, T, O> {
               if (activeSpan) {
                 activeSpan.setAttribute(SPAN_TYPE, "HUMAN_EVALUATOR");
                 if (evaluator.options) {
-                  activeSpan.setAttribute(HUMAN_EVALUATOR_OPTIONS, JSON.stringify(evaluator.options));
+                  activeSpan.setAttribute(
+                    HUMAN_EVALUATOR_OPTIONS,
+                    JSON.stringify(evaluator.options)
+                  );
                 }
               }
               return null;

--- a/src/evaluations.ts
+++ b/src/evaluations.ts
@@ -6,7 +6,7 @@ import { EvaluationDataset, LaminarDataset } from "./datasets";
 import { observe } from "./decorators";
 import { Laminar } from "./laminar";
 import { InitializeOptions } from "./opentelemetry-lib/interfaces";
-import { SPAN_TYPE } from "./opentelemetry-lib/tracing/attributes";
+import {HUMAN_EVALUATOR_OPTIONS, SPAN_TYPE} from "./opentelemetry-lib/tracing/attributes";
 import { EvaluationDatapoint } from "./types";
 import {
   initializeLogger,
@@ -146,7 +146,13 @@ export type Datapoint<D, T> = {
 /**
  * HumanEvaluator is a class to register a human evaluator.
  */
-export class HumanEvaluator { }
+export class HumanEvaluator {
+  public options?: { value: number; label: string }[]
+
+  constructor(options: { value: number; label: string }[]) {
+    this.options = options;
+  }
+}
 
 export type EvaluatorFunctionReturn = number | Record<string, number>;
 
@@ -456,10 +462,19 @@ export class Evaluation<D, T, O> {
           { name: evaluatorName },
           async (output: O, target?: T) => {
             if (evaluator instanceof HumanEvaluator) {
-              trace.getActiveSpan()!.setAttribute(SPAN_TYPE, "HUMAN_EVALUATOR");
+              const activeSpan = trace.getActiveSpan();
+              if (activeSpan) {
+                activeSpan.setAttribute(SPAN_TYPE, "HUMAN_EVALUATOR");
+                if (evaluator.options) {
+                  activeSpan.setAttribute(HUMAN_EVALUATOR_OPTIONS, JSON.stringify(evaluator.options));
+                }
+              }
               return null;
             } else {
-              trace.getActiveSpan()!.setAttribute(SPAN_TYPE, "EVALUATOR");
+              const activeSpan = trace.getActiveSpan();
+              if (activeSpan) {
+                activeSpan.setAttribute(SPAN_TYPE, "EVALUATOR");
+              }
               return await evaluator(output, target);
             }
           },
@@ -472,7 +487,7 @@ export class Evaluation<D, T, O> {
           continue;
         }
 
-        if (typeof value === 'number') {
+        if (typeof value === "number") {
           if (isNaN(value)) {
             throw new Error(`Evaluator ${evaluatorName} returned NaN`);
           }

--- a/src/evaluations.ts
+++ b/src/evaluations.ts
@@ -6,7 +6,7 @@ import { EvaluationDataset, LaminarDataset } from "./datasets";
 import { observe } from "./decorators";
 import { Laminar } from "./laminar";
 import { InitializeOptions } from "./opentelemetry-lib/interfaces";
-import {HUMAN_EVALUATOR_OPTIONS, SPAN_TYPE} from "./opentelemetry-lib/tracing/attributes";
+import { HUMAN_EVALUATOR_OPTIONS, SPAN_TYPE } from "./opentelemetry-lib/tracing/attributes";
 import { EvaluationDatapoint } from "./types";
 import {
   initializeLogger,
@@ -149,7 +149,7 @@ export type Datapoint<D, T> = {
 export class HumanEvaluator {
   public options?: { value: number; label: string }[]
 
-  constructor(options: { value: number; label: string }[]) {
+  constructor(options?: { value: number; label: string }[]) {
     this.options = options;
   }
 }

--- a/src/evaluations.ts
+++ b/src/evaluations.ts
@@ -468,7 +468,7 @@ export class Evaluation<D, T, O> {
                 if (evaluator.options) {
                   activeSpan.setAttribute(
                     HUMAN_EVALUATOR_OPTIONS,
-                    JSON.stringify(evaluator.options)
+                    JSON.stringify(evaluator.options),
                   );
                 }
               }

--- a/src/opentelemetry-lib/tracing/attributes.ts
+++ b/src/opentelemetry-lib/tracing/attributes.ts
@@ -11,7 +11,7 @@ export const SPAN_LANGUAGE_VERSION = "lmnr.span.language_version";
 export const OVERRIDE_PARENT_SPAN = "lmnr.internal.override_parent_span";
 export const TRACE_HAS_BROWSER_SESSION = "lmnr.internal.has_browser_session";
 export const EXTRACTED_FROM_NEXT_JS = "lmnr.span.extracted_from.next_js";
-
+export const HUMAN_EVALUATOR_OPTIONS = 'lmnr.span.human_evaluator_options';
 export const ASSOCIATION_PROPERTIES = "lmnr.association.properties";
 export const SESSION_ID = "lmnr.association.properties.session_id";
 export const USER_ID = "lmnr.association.properties.user_id";

--- a/test/evaluate.test.ts
+++ b/test/evaluate.test.ts
@@ -137,7 +137,7 @@ void describe("evaluate", () => {
       evaluators: {
         "automatic": (output, target) => output.includes(target || "") ? 1 : 0,
         "human_quality": new HumanEvaluator(),
-        "human_relevance": new HumanEvaluator(),
+        "human_relevance": new HumanEvaluator([{ value: 1, label: 'label' }]),
       },
       config: {
         projectApiKey: "test",
@@ -181,6 +181,12 @@ void describe("evaluate", () => {
     const humanEvaluatorSpans = spans.filter(
       (span) => span.attributes['lmnr.span.type'] === "HUMAN_EVALUATOR",
     );
+
+    const humanEvaluatorSpanWithOptions = humanEvaluatorSpans.find((s) => s.name === "human_relevance");
+
+    const options = humanEvaluatorSpanWithOptions?.attributes?.['lmnr.span.human_evaluator_options']
+    assert.strictEqual(!!options, true);
+    assert.deepStrictEqual(JSON.parse(String(options)), [{ value: 1, label: 'label' }])
     assert.strictEqual(humanEvaluatorSpans.length, 2);
     assert.deepStrictEqual(
       humanEvaluatorSpans.map((span) => span.name).sort(),

--- a/test/evaluate.test.ts
+++ b/test/evaluate.test.ts
@@ -182,11 +182,13 @@ void describe("evaluate", () => {
       (span) => span.attributes['lmnr.span.type'] === "HUMAN_EVALUATOR",
     );
 
-    const humanEvaluatorSpanWithOptions = humanEvaluatorSpans.find((s) => s.name === "human_relevance");
+    const humanEvaluatorSpanWithOptions = humanEvaluatorSpans.find(
+      (s) => s.name === "human_relevance"
+    );
 
-    const options = humanEvaluatorSpanWithOptions?.attributes?.['lmnr.span.human_evaluator_options']
+    const options = humanEvaluatorSpanWithOptions?.attributes?.['lmnr.span.human_evaluator_options'];
     assert.strictEqual(!!options, true);
-    assert.deepStrictEqual(JSON.parse(String(options)), [{ value: 1, label: 'label' }])
+    assert.deepStrictEqual(JSON.parse(String(options)), [{ value: 1, label: 'label' }]);
     assert.strictEqual(humanEvaluatorSpans.length, 2);
     assert.deepStrictEqual(
       humanEvaluatorSpans.map((span) => span.name).sort(),

--- a/test/evaluate.test.ts
+++ b/test/evaluate.test.ts
@@ -183,10 +183,12 @@ void describe("evaluate", () => {
     );
 
     const humanEvaluatorSpanWithOptions = humanEvaluatorSpans.find(
-      (s) => s.name === "human_relevance"
+      (s) => s.name === "human_relevance",
     );
 
-    const options = humanEvaluatorSpanWithOptions?.attributes?.['lmnr.span.human_evaluator_options'];
+    const options =
+        humanEvaluatorSpanWithOptions?.attributes?.['lmnr.span.human_evaluator_options'];
+
     assert.strictEqual(!!options, true);
     assert.deepStrictEqual(JSON.parse(String(options)), [{ value: 1, label: 'label' }]);
     assert.strictEqual(humanEvaluatorSpans.length, 2);


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add support for human evaluator options in evaluations, updating `HumanEvaluator` and tracing attributes, with tests verifying the new functionality.
> 
>   - **Behavior**:
>     - `HumanEvaluator` class in `evaluations.ts` now accepts `options` parameter in constructor.
>     - In `Evaluation` class, if `HumanEvaluator` has options, they are set as `HUMAN_EVALUATOR_OPTIONS` attribute in active span.
>   - **Attributes**:
>     - Adds `HUMAN_EVALUATOR_OPTIONS` to `attributes.ts` for tracing human evaluator options.
>   - **Tests**:
>     - Updates `evaluate.test.ts` to test human evaluator options, ensuring spans include `HUMAN_EVALUATOR_OPTIONS` when options are provided.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr-ts&utm_source=github&utm_medium=referral)<sup> for 97e38fe277c55a5abd86982444ebf5a8687e6c7c. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->