### PR TITLE
allow different baseHttpUrl

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lmnr-ai/lmnr",
-  "version": "0.6.15",
+  "version": "0.6.16",
   "description": "TypeScript SDK for Laminar AI",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -39,9 +39,9 @@ const createSkipDynamicImportsPlugin = (skipModules: string[]): esbuild.Plugin =
 });
 
 declare global {
-
+  // eslint-disable-next-line no-var
   var _evaluations: Evaluation<any, any, any>[] | undefined;
-
+  // eslint-disable-next-line no-var
   var _set_global_evaluation: boolean;
 }
 

--- a/src/evaluations.ts
+++ b/src/evaluations.ts
@@ -326,7 +326,7 @@ export class Evaluation<D, T, O> {
       httpUrl.match(/:\d{1,5}$/g)
         ? parseInt(httpUrl.match(/:\d{1,5}$/g)![0].slice(1))
         : 443);
-    const urlWithoutSlash = url.replace(/\/$/, '').replace(/:\d{1,5}$/g, '');
+    const urlWithoutSlash = httpUrl.replace(/\/$/, '').replace(/:\d{1,5}$/g, '');
     const baseHttpUrl = `${urlWithoutSlash}:${httpPort}`;
 
     this.client = new LaminarClient({
@@ -350,9 +350,9 @@ export class Evaluation<D, T, O> {
 
     Laminar.initialize({
       projectApiKey: config?.projectApiKey,
-      baseUrl: config?.baseUrl,
-      baseHttpUrl: config?.baseHttpUrl,
-      httpPort: config?.httpPort,
+      baseUrl: url,
+      baseHttpUrl,
+      httpPort,
       grpcPort: config?.grpcPort,
       instrumentModules: config?.instrumentModules,
       disableBatch: this.traceDisableBatch,

--- a/src/evaluations.ts
+++ b/src/evaluations.ts
@@ -21,10 +21,10 @@ const DEFAULT_CONCURRENCY = 5;
 const MAX_EXPORT_BATCH_SIZE = 64;
 
 declare global {
-
+  // eslint-disable-next-line no-var
   var _evaluations: Evaluation<any, any, any>[] | undefined;
   // If true, then we need to set the evaluation globally without running it
-
+  // eslint-disable-next-line no-var
   var _set_global_evaluation: boolean;
 }
 
@@ -89,6 +89,11 @@ interface EvaluatorConfig {
    * Do NOT include the port in the URL, use `httpPort` and `grpcPort` instead.
    */
   baseUrl?: string;
+  /**
+   * The base HTTP URL of the Laminar API. If not provided, the default is
+   * `baseUrl`. Only use this if you want to proxy HTTP requests through a different host.
+   */
+  baseHttpUrl?: string;
   /**
    * The HTTP port of the Laminar API. If not provided, the default is 443.
    */
@@ -316,9 +321,10 @@ export class Evaluation<D, T, O> {
     }
 
     const url = config?.baseUrl ?? process?.env?.LMNR_BASE_URL ?? 'https://api.lmnr.ai';
+    const httpUrl = config?.baseHttpUrl ?? url;
     const httpPort = config?.httpPort ?? (
-      url.match(/:\d{1,5}$/g)
-        ? parseInt(url.match(/:\d{1,5}$/g)![0].slice(1))
+      httpUrl.match(/:\d{1,5}$/g)
+        ? parseInt(httpUrl.match(/:\d{1,5}$/g)![0].slice(1))
         : 443);
     const urlWithoutSlash = url.replace(/\/$/, '').replace(/:\d{1,5}$/g, '');
     const baseHttpUrl = `${urlWithoutSlash}:${httpPort}`;
@@ -345,6 +351,7 @@ export class Evaluation<D, T, O> {
     Laminar.initialize({
       projectApiKey: config?.projectApiKey,
       baseUrl: config?.baseUrl,
+      baseHttpUrl: config?.baseHttpUrl,
       httpPort: config?.httpPort,
       grpcPort: config?.grpcPort,
       instrumentModules: config?.instrumentModules,

--- a/src/opentelemetry-lib/interfaces/initialize-options.interface.ts
+++ b/src/opentelemetry-lib/interfaces/initialize-options.interface.ts
@@ -36,6 +36,13 @@ export interface InitializeOptions {
   baseUrl?: string;
 
   /**
+   * The Laminar API HTTP endpoint for sending traces data. Optional.
+   * Defaults to baseUrl. Only use this if you want to proxy HTTP requests
+   * through a different host.
+   */
+  baseHttpUrl?: string;
+
+  /**
    * Whether to disable batching. Optional.
    * Defaults to false.
    */

--- a/src/opentelemetry-lib/tracing/index.ts
+++ b/src/opentelemetry-lib/tracing/index.ts
@@ -31,7 +31,7 @@ let _apiKey: string | undefined;
  * for details.
  */
 export const startTracing = (options: InitializeOptions) => {
-  _baseHttpUrl = `${options.baseUrl}:${options.httpPort ?? 443}`;
+  _baseHttpUrl = `${options.baseHttpUrl ?? options.baseUrl}:${options.httpPort ?? 443}`;
   _apiKey = options.apiKey;
 
   const instrumentations = initializeLaminarInstrumentations({


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds `baseHttpUrl` option to allow proxying HTTP requests through a different host, affecting `Evaluation`, `Laminar`, and tracing initialization.
> 
>   - **Behavior**:
>     - Adds `baseHttpUrl` option to `EvaluatorConfig` in `evaluations.ts` and `LaminarInitializeProps` in `laminar.ts`.
>     - `baseHttpUrl` allows proxying HTTP requests through a different host, defaulting to `baseUrl` if not provided.
>     - Updates `Evaluation` class in `evaluations.ts` to use `baseHttpUrl` for HTTP requests.
>     - Updates `Laminar` class in `laminar.ts` to use `baseHttpUrl` for initialization.
>     - Modifies `startTracing` in `tracing/index.ts` to use `baseHttpUrl`.
>   - **Interfaces**:
>     - Adds `baseHttpUrl` to `InitializeOptions` in `initialize-options.interface.ts`.
>   - **Misc**:
>     - Bumps version in `package.json` from 0.6.15 to 0.6.16.
>     - Adds ESLint disable comments for `no-var` in `cli.ts` and `evaluations.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr-ts&utm_source=github&utm_medium=referral)<sup> for 0fac790a3a37c4b42135a55bcbace996bd7bf1b8. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->