### PR TITLE
fix options passing in method overload in LaminarTracer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lmnr-ai/lmnr",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "TypeScript SDK for Laminar AI",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/opentelemetry-lib/tracing/tracer.ts
+++ b/src/opentelemetry-lib/tracing/tracer.ts
@@ -58,7 +58,12 @@ export class LaminarTracer implements Tracer {
       return this._tracer.startActiveSpan(name, {}, contextToUse, wrapped(optionsOrFn));
     }
     if (typeof contextOrFn === "function") {
-      return this._tracer.startActiveSpan(name, {}, contextToUse, wrapped(contextOrFn));
+      return this._tracer.startActiveSpan(
+        name,
+        optionsOrFn as SpanOptions,
+        contextToUse,
+        wrapped(contextOrFn),
+      );
     }
 
     // Use the provided context or the current Laminar context

--- a/test/aisdk.test.ts
+++ b/test/aisdk.test.ts
@@ -16,7 +16,7 @@ import { getTracer } from "../src/opentelemetry-lib/tracing";
 import { getParentSpanId } from "../src/opentelemetry-lib/tracing/compat";
 import { decompressRecordingResponse } from "./utils";
 
-void describe("openai instrumentation", () => {
+void describe("aisdk instrumentation", () => {
   const model = openai("gpt-4.1-nano");
   const exporter = new InMemorySpanExporter();
   const dirname = typeof __dirname !== 'undefined'
@@ -107,6 +107,24 @@ void describe("openai instrumentation", () => {
     assert.strictEqual(getParentSpanId(innerSpan), outerSpan.spanContext().spanId);
 
     assert.strictEqual((innerSpan.attributes['lmnr.span.path']! as string[]).length, 2);
+    assert.strictEqual(
+      outerSpan.attributes['ai.prompt'],
+      '{"prompt":"What is the capital of France?"}',
+    );
+    assert.strictEqual(
+      outerSpan.attributes['ai.response.text'],
+      "The capital of France is Paris.",
+    );
+    assert.deepStrictEqual(JSON.parse(innerSpan.attributes['ai.prompt.messages']! as string), [{
+      "role": "user",
+      "content": [
+        {
+          "type": "text",
+          "text": "What is the capital of France?",
+        },
+      ],
+    }]);
+    assert.strictEqual(innerSpan.attributes['ai.response.text'], "The capital of France is Paris.");
   });
 
   void it("creates AI SDK spans inside observe", async () => {
@@ -129,6 +147,24 @@ void describe("openai instrumentation", () => {
     assert.strictEqual(getParentSpanId(outerAiSDKSpan), observeSpan.spanContext().spanId);
     assert.strictEqual(observeSpan.spanContext().traceId, outerAiSDKSpan.spanContext().traceId);
     assert.strictEqual((innerSpan.attributes['lmnr.span.path']! as string[]).length, 3);
+    assert.strictEqual(
+      outerAiSDKSpan.attributes['ai.prompt'],
+      '{"prompt":"What is the capital of France?"}',
+    );
+    assert.strictEqual(
+      outerAiSDKSpan.attributes['ai.response.text'],
+      "The capital of France is Paris.",
+    );
+    assert.deepStrictEqual(JSON.parse(innerSpan.attributes['ai.prompt.messages']! as string), [{
+      "role": "user",
+      "content": [
+        {
+          "type": "text",
+          "text": "What is the capital of France?",
+        },
+      ],
+    }]);
+    assert.strictEqual(innerSpan.attributes['ai.response.text'], "The capital of France is Paris.");
   });
 
   void it("creates AI SDK spans inside withSpan", async () => {
@@ -153,6 +189,27 @@ void describe("openai instrumentation", () => {
     assert.strictEqual(getParentSpanId(outerAiSDKSpan), testSpan.spanContext().spanId);
     assert.strictEqual(testSpan.spanContext().traceId, outerAiSDKSpan.spanContext().traceId);
     assert.strictEqual((innerSpan.attributes['lmnr.span.path']! as string[]).length, 3);
+    assert.strictEqual(
+      outerAiSDKSpan.attributes['ai.prompt'],
+      '{"prompt":"What is the capital of France?"}',
+    );
+    assert.strictEqual(
+      outerAiSDKSpan.attributes['ai.response.text'],
+      "The capital of France is Paris.",
+    );
+    assert.deepStrictEqual(JSON.parse(innerSpan.attributes['ai.prompt.messages']! as string), [{
+      "role": "user",
+      "content": [
+        {
+          "type": "text",
+          "text": "What is the capital of France?",
+        },
+      ],
+    }]);
+    assert.strictEqual(
+      innerSpan.attributes['ai.response.text'],
+      "The capital of France is Paris.",
+    );
   });
 
   void it("creates AI SDK spans inside startActiveSpan", async () => {
@@ -199,5 +256,23 @@ void describe("openai instrumentation", () => {
     assert.strictEqual(getParentSpanId(outerAiSDKSpan), undefined);
     assert.notStrictEqual(testSpan.spanContext().traceId, outerAiSDKSpan.spanContext().traceId);
     assert.strictEqual((innerSpan.attributes['lmnr.span.path']! as string[]).length, 2);
+    assert.strictEqual(
+      outerAiSDKSpan.attributes['ai.prompt'],
+      '{"prompt":"What is the capital of France?"}',
+    );
+    assert.strictEqual(
+      outerAiSDKSpan.attributes['ai.response.text'],
+      "The capital of France is Paris.",
+    );
+    assert.deepStrictEqual(JSON.parse(innerSpan.attributes['ai.prompt.messages']! as string), [{
+      "role": "user",
+      "content": [
+        {
+          "type": "text",
+          "text": "What is the capital of France?",
+        },
+      ],
+    }]);
+    assert.strictEqual(innerSpan.attributes['ai.response.text'], "The capital of France is Paris.");
   });
 });


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix options passing in `LaminarTracer` method overload and update tests for AI SDK spans.
> 
>   - **Bug Fix**:
>     - Fix options passing in `startActiveSpan()` overload in `LaminarTracer` in `tracer.ts`.
>   - **Tests**:
>     - Update `aisdk.test.ts` to verify AI SDK spans, including attributes like `ai.prompt` and `ai.response.text`.
>     - Ensure spans are correctly nested and attributes are accurately captured.
>   - **Misc**:
>     - Bump version in `package.json` from `0.7.0` to `0.7.1`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr-ts&utm_source=github&utm_medium=referral)<sup> for c7eb90a92a83dbb12cc8c9cf5ee2d736411ae93b. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->