### PR TITLE
fix: write executor output to executor span output

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lmnr-ai/lmnr",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "TypeScript SDK for Laminar AI",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/evaluations.ts
+++ b/src/evaluations.ts
@@ -431,7 +431,7 @@ export class Evaluation<D, T, O> {
     return observe({ name: "evaluation", traceType: "EVALUATION" }, async () => {
 
       trace.getSpan(LaminarContextManager.getContext())!.setAttribute(SPAN_TYPE, "EVALUATION");
-      const executorSpan = Laminar.startActiveSpan({
+      const executorSpan = Laminar.startSpan({
         name: "executor",
         input: datapoint.data,
       });
@@ -459,7 +459,11 @@ export class Evaluation<D, T, O> {
 
       const output = await Laminar.withSpan(
         executorSpan,
-        async () => await this.executor(datapoint.data),
+        async () => {
+          const result = await this.executor(datapoint.data);
+          Laminar.setSpanOutput(result);
+          return result;
+        },
         true,
       );
       const target = datapoint.target;

--- a/test/evaluate.test.ts
+++ b/test/evaluate.test.ts
@@ -94,6 +94,10 @@ void describe("evaluate", () => {
       (span) => span.attributes['lmnr.span.type'] === "EVALUATION",
     );
     const executorSpan = spans.find((span) => span.attributes['lmnr.span.type'] === "EXECUTOR");
+    assert.strictEqual(
+      JSON.parse(String(executorSpan?.attributes['lmnr.span.output'])),
+      "a".repeat(150),
+    );
     const evaluatorSpans = spans.filter(
       (span) => span.attributes['lmnr.span.type'] === "EVALUATOR",
     );


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Write executor output to executor span output in `Evaluation` class and update tests accordingly.
> 
>   - **Behavior**:
>     - In `evaluations.ts`, `Evaluation` class now writes executor output to executor span output using `Laminar.setSpanOutput()`.
>   - **Tests**:
>     - In `evaluate.test.ts`, added assertions to check executor span output matches executor result.
>   - **Misc**:
>     - Bump version in `package.json` from `0.7.1` to `0.7.2`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr-ts&utm_source=github&utm_medium=referral)<sup> for eb0c31c032b67d920596efdc8dfc0ee6135be91a. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->