### PR TITLE
install npm 11.1.1 first

### DIFF
--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -20,6 +20,10 @@ jobs:
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org
+      # temp fix, direct install of versions of 11.12.0+ fails to install
+      # promise-retry. This is the suggested fix, see
+      # https://github.com/npm/cli/issues/9151
+      - run: npm install -g npm@11.11.1
       - run: npm install -g npm@latest
       - run: pnpm install --frozen-lockfile
       - run: pnpm --filter lmnr-cli build
@@ -41,6 +45,10 @@ jobs:
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org
+      # temp fix, direct install of versions of 11.12.0+ fails to install
+      # promise-retry. This is the suggested fix, see
+      # https://github.com/npm/cli/issues/9151
+      - run: npm install -g npm@11.11.1
       - run: npm install -g npm@latest
       - run: pnpm install --frozen-lockfile
       - run: pnpm build


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk CI-only change; it only affects GitHub Actions publish jobs and is intended to avoid a known npm install failure when upgrading to newer npm versions.
> 
> **Overview**
> Adds a temporary workaround in `publish-to-npm.yml` to ensure npm upgrades succeed in CI.
> 
> Both release publish jobs now first `npm install -g npm@11.11.1` (to avoid an npm 11.12.0+ install bug) and then proceed to install `npm@latest` before running the existing pnpm build/test/publish steps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 107bd0024c5b7136b219d3a324afd07afd5d072f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->