### PR TITLE
feat: add auth and docs links to CLI help

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,4 +67,4 @@ pnpm lint:fix
 
 - [Main SDK Documentation](packages/lmnr/README.md)
 - [CLI Documentation](packages/cli/README.md)
-- [Shared Laminar Documentation](https://docs.lmnr.ai)
+- [Shared Laminar Documentation](https://laminar.sh/docs)

--- a/examples/nextjs-aisdk/README.md
+++ b/examples/nextjs-aisdk/README.md
@@ -28,7 +28,7 @@ cd lmnr-ts/examples/nextjs-aisdk
 cp .env.local.example .env.local
 ```
 
-And then fill in the `.env.local` file. Get [Laminar project API key](https://docs.lmnr.ai/tracing/introduction#2-initialize-laminar-in-your-application). Get [OpenAI API key](https://platform.openai.com/api-keys)
+And then fill in the `.env.local` file. Get [Laminar project API key](https://laminar.sh). Get [OpenAI API key](https://platform.openai.com/api-keys)
 
 ### 4. Install the dependencies
 
@@ -131,7 +131,7 @@ In this example, Laminar span processor will make sure traces created by the def
 By default, Laminar span processor sends the data to Laminar cloud using an OTLP/grpc exporter.
 
 
-Configuring Laminar span processor to send traces to self-hosted Laminar instance. Also see [Laminar self-hosting docs](https://docs.lmnr.ai/self-hosting)
+Configuring Laminar span processor to send traces to self-hosted Laminar instance. Also see [Laminar self-hosting docs](https://laminar.sh/docs/hosting-options)
 
 ```javascript
 new LaminarSpanProcessor({
@@ -160,6 +160,6 @@ new LaminarSpanProcessor({
 
 #### [Advanced] What is a span processor and a span exporter?
 
-**Span exporter** is an OpenTelemetry object that is responsible for encoding finished spans and sending them to the backend. Exporters carry the information about the backend, such as the endpoint and port. In addition, exporters differ by type based on the encoding that a backend accepts. To learn more about the encodings, read our docs on [exporters](https://docs.lmnr.ai/tracing/otel#exporters). Default Laminar span exporter is OTLP/gRPC configured to send data to `https://api.lmnr.ai:8443`.
+**Span exporter** is an OpenTelemetry object that is responsible for encoding finished spans and sending them to the backend. Exporters carry the information about the backend, such as the endpoint and port. In addition, exporters differ by type based on the encoding that a backend accepts. To learn more about the encodings, read our docs on [exporters](https://laminar.sh/docs/tracing/otel#exporters). Default Laminar span exporter is OTLP/gRPC configured to send data to `https://api.lmnr.ai:8443`.
 
 **Span processor** is an OpenTelemetry object that is responsible for pre-processing spans before export. One span processor may have one span exporter, and span processors are responsible for calling `export` methods on exporters, when they are ready to export spans. Exporters may batch spans before exporting or sending spans as soon as they are finished. Most of the pre-processing happens in `onStart` on span processors. Laminar span processor adds Laminar specific attributes on spans.

--- a/examples/nextjs/README.md
+++ b/examples/nextjs/README.md
@@ -28,7 +28,7 @@ cd lmnr-ts/examples/nextjs
 cp .env.local.example .env.local
 ```
 
-And then fill in the `.env.local` file. Get [Laminar project API key](https://docs.lmnr.ai/tracing/introduction#2-initialize-laminar-in-your-application). Get [OpenAI API key](https://platform.openai.com/api-keys). Get [Anthropic API key](https://console.anthropic.com/settings/keys)
+And then fill in the `.env.local` file. Get [Laminar project API key](https://laminar.sh/). Get [OpenAI API key](https://platform.openai.com/api-keys). Get [Anthropic API key](https://console.anthropic.com/settings/keys)
 
 ### 4. Install the dependencies
 
@@ -130,7 +130,7 @@ In this example, Laminar span processor will make sure traces created by the def
 By default, Laminar span processor sends the data to Laminar cloud using an OTLP/grpc exporter.
 
 
-Configuring Laminar span processor to send traces to self-hosted Laminar instance. Also see [Laminar self-hosting docs](https://docs.lmnr.ai/self-hosting)
+Configuring Laminar span processor to send traces to self-hosted Laminar instance. Also see [Laminar self-hosting docs](https://laminar.sh/docs/hosting-options)
 
 ```javascript
 new LaminarSpanProcessor({
@@ -159,6 +159,6 @@ new LaminarSpanProcessor({
 
 #### [Advanced] What is a span processor and a span exporter?
 
-**Span exporter** is an OpenTelemetry object that is responsible for encoding finished spans and sending them to the backend. Exporters carry the information about the backend, such as the endpoint and port. In addition, exporters differ by type based on the encoding that a backend accepts. To learn more about the encodings, read our docs on [exporters](https://docs.lmnr.ai/tracing/otel#exporters). Default Laminar span exporter is OTLP/gRPC configured to send data to `https://api.lmnr.ai:8443`.
+**Span exporter** is an OpenTelemetry object that is responsible for encoding finished spans and sending them to the backend. Exporters carry the information about the backend, such as the endpoint and port. In addition, exporters differ by type based on the encoding that a backend accepts. To learn more about the encodings, read our docs on [exporters](https://laminar.sh/docs/tracing/otel#exporters). Default Laminar span exporter is OTLP/gRPC configured to send data to `https://api.lmnr.ai:8443`.
 
 **Span processor** is an OpenTelemetry object that is responsible for pre-processing spans before export. One span processor may have one span exporter, and span processors are responsible for calling `export` methods on exporters, when they are ready to export spans. Exporters may batch spans before exporting or sending spans as soon as they are finished. Most of the pre-processing happens in `onStart` on span processors. Laminar span processor adds Laminar specific attributes on spans.

--- a/packages/lmnr-cli/src/index.ts
+++ b/packages/lmnr-cli/src/index.ts
@@ -1,98 +1,103 @@
 #!/usr/bin/env node
 
-import { Command } from 'commander';
+import { Command } from "commander";
 
-import { version } from '../package.json';
+import { version } from "../package.json";
 import {
   handleDatasetsCreate,
   handleDatasetsList,
   handleDatasetsPull,
   handleDatasetsPush,
-} from './commands/dataset';
-import { runDev } from './commands/dev';
-import { handleSqlQuery } from './commands/sql';
-import { SQL_SCHEMA_HELP } from './commands/sql/schema';
+} from "./commands/dataset";
+import { runDev } from "./commands/dev";
+import { handleSqlQuery } from "./commands/sql";
+import { SQL_SCHEMA_HELP } from "./commands/sql/schema";
 
 async function main() {
   const program = new Command();
 
   program
-    .name('lmnr-cli')
-    .description('CLI for the Laminar agent observability platform')
-    .version(version, '-v, --version', 'display version number');
-
+    .name("lmnr-cli")
+    .description("CLI for the Laminar agent observability platform")
+    .version(version, "-v, --version", "display version number");
 
   program
-    .command('dev')
-    .description('Start a debugging session')
+    .command("dev")
+    .description("Start a debugging session")
     .argument(
-      '[file]',
-      'Path to file containing the entrypoint function(s). Either `file` or `-m` must be provided.',
+      "[file]",
+      "Path to file containing the entrypoint function(s). Either `file` or `-m` must be provided.",
     )
     .option(
-      '-m, --python-module <module>',
-      'Python module path (e.g., src.myfile). Either `file` or `-m` must be provided.',
+      "-m, --python-module <module>",
+      "Python module path (e.g., src.myfile). Either `file` or `-m` must be provided.",
     )
     .option(
-      '--function <name>',
-      'Specific function to serve (if multiple entrypoint functions found)',
+      "--function <name>",
+      "Specific function to serve (if multiple entrypoint functions found)",
     )
     .option(
-      '--project-api-key <key>',
-      'Project API key. If not provided, reads from LMNR_PROJECT_API_KEY env variable',
+      "--project-api-key <key>",
+      "Project API key. If not provided, reads from LMNR_PROJECT_API_KEY env variable",
     )
     .option(
-      '--base-url <url>',
-      'Base URL for the Laminar API. Defaults to https://api.lmnr.ai or LMNR_BASE_URL env variable',
-    )
-    .option('--port <port>', 'Port for the Laminar API. Defaults to 443', (val) =>
-      parseInt(val, 10),
+      "--base-url <url>",
+      "Base URL for the Laminar API. Defaults to https://api.lmnr.ai or LMNR_BASE_URL env variable",
     )
     .option(
-      '--grpc-port <port>',
-      'Port for the Laminar gRPC backend. Defaults to 8443',
+      "--port <port>",
+      "Port for the Laminar API. Defaults to 443",
       (val) => parseInt(val, 10),
     )
     .option(
-      '--frontend-port <port>',
-      'Port for the Laminar frontend. Defaults to 5667',
+      "--grpc-port <port>",
+      "Port for the Laminar gRPC backend. Defaults to 8443",
       (val) => parseInt(val, 10),
     )
     .option(
-      '--external-packages <packages...>',
-      '[ADVANCED] List of packages to pass as external to esbuild. This will not link ' +
-      'the packages directly into the dev file, but will instead require them at runtime. ' +
-      'Read more: https://esbuild.github.io/api/#external',
+      "--frontend-port <port>",
+      "Port for the Laminar frontend. Defaults to 5667",
+      (val) => parseInt(val, 10),
     )
     .option(
-      '--dynamic-imports-to-skip <modules...>',
-      '[ADVANCED] List of module names to skip when encountered as dynamic imports. ' +
-      'These dynamic imports will resolve to an empty module to prevent build failures. ' +
-      'This is meant to skip the imports that are not used in the entrypoint function itself.',
+      "--external-packages <packages...>",
+      "[ADVANCED] List of packages to pass as external to esbuild. This will not link " +
+        "the packages directly into the dev file, but will instead require them at runtime. " +
+        "Read more: https://esbuild.github.io/api/#external",
     )
     .option(
-      '--command <command>',
-      '[ADVANCED] Custom command to run the worker (e.g., python3, node)',
+      "--dynamic-imports-to-skip <modules...>",
+      "[ADVANCED] List of module names to skip when encountered as dynamic imports. " +
+        "These dynamic imports will resolve to an empty module to prevent build failures. " +
+        "This is meant to skip the imports that are not used in the entrypoint function itself.",
     )
     .option(
-      '--command-args <args...>',
-      '[ADVANCED] Arguments for the custom command',
+      "--command <command>",
+      "[ADVANCED] Custom command to run the worker (e.g., python3, node)",
+    )
+    .option(
+      "--command-args <args...>",
+      "[ADVANCED] Arguments for the custom command",
     )
     .action(async (file: string | undefined, options) => {
       // Validation: must have either file or python-module, but not both
       if (!file && !options.pythonModule) {
-        console.error('Error: Must provide either a file path or --python-module (-m) flag');
+        console.error(
+          "Error: Must provide either a file path or --python-module (-m) flag",
+        );
         process.exit(1);
       }
       if (file && options.pythonModule) {
-        console.error('Error: Cannot specify both file path and --python-module (-m) flag');
+        console.error(
+          "Error: Cannot specify both file path and --python-module (-m) flag",
+        );
         process.exit(1);
       }
 
       await runDev(file, options);
     })
     .addHelpText(
-      'after',
+      "after",
       `
 Examples:
   $ lmnr-cli dev agent.ts                    # TypeScript file
@@ -132,9 +137,18 @@ Examples:
   datasetsCmd
     .command("push")
     .description("Push datapoints to an existing dataset")
-    .argument("<paths...>", "Paths to files or directories containing data to push")
-    .option("-n, --name <name>", "Name of the dataset (either name or id must be provided)")
-    .option("--id <id>", "ID of the dataset (either name or id must be provided)")
+    .argument(
+      "<paths...>",
+      "Paths to files or directories containing data to push",
+    )
+    .option(
+      "-n, --name <name>",
+      "Name of the dataset (either name or id must be provided)",
+    )
+    .option(
+      "--id <id>",
+      "ID of the dataset (either name or id must be provided)",
+    )
     .option("-r, --recursive", "Recursively read files in directories", false)
     .option(
       "--batch-size <size>",
@@ -150,9 +164,18 @@ Examples:
   datasetsCmd
     .command("pull")
     .description("Pull data from a dataset")
-    .argument("[output-path]", "Path to save the data. If not provided, prints to console")
-    .option("-n, --name <name>", "Name of the dataset (either name or id must be provided)")
-    .option("--id <id>", "ID of the dataset (either name or id must be provided)")
+    .argument(
+      "[output-path]",
+      "Path to save the data. If not provided, prints to console",
+    )
+    .option(
+      "-n, --name <name>",
+      "Name of the dataset (either name or id must be provided)",
+    )
+    .option(
+      "--id <id>",
+      "ID of the dataset (either name or id must be provided)",
+    )
     .option(
       "--output-format <format>",
       "Output format (json, csv, jsonl). Inferred from file extension if not provided",
@@ -163,8 +186,15 @@ Examples:
       (val) => parseInt(val, 10),
       100,
     )
-    .option("--limit <limit>", "Limit number of datapoints to pull", (val) => parseInt(val, 10))
-    .option("--offset <offset>", "Offset for pagination", (val) => parseInt(val, 10), 0)
+    .option("--limit <limit>", "Limit number of datapoints to pull", (val) =>
+      parseInt(val, 10),
+    )
+    .option(
+      "--offset <offset>",
+      "Offset for pagination",
+      (val) => parseInt(val, 10),
+      0,
+    )
     .action(async (outputPath: string | undefined, _options, cmd) => {
       await handleDatasetsPull(outputPath, cmd.optsWithGlobals());
     });
@@ -174,7 +204,10 @@ Examples:
     .command("create")
     .description("Create a dataset from input files")
     .argument("<name>", "Name of the dataset to create")
-    .argument("<paths...>", "Paths to files or directories containing data to push")
+    .argument(
+      "<paths...>",
+      "Paths to files or directories containing data to push",
+    )
     .requiredOption("-o, --output-file <file>", "Path to save the pulled data")
     .option(
       "--output-format <format>",
@@ -190,7 +223,6 @@ Examples:
     .action(async (name: string, paths: string[], _options, cmd) => {
       await handleDatasetsCreate(name, paths, cmd.optsWithGlobals());
     });
-
 
   const sqlCmd = program
     .command("sql")
@@ -217,12 +249,16 @@ Examples:
     .action(async (query: string, _options, cmd) => {
       await handleSqlQuery(query, cmd.optsWithGlobals());
     })
-    .addHelpText("after", SQL_SCHEMA_HELP + `
+    .addHelpText(
+      "after",
+      SQL_SCHEMA_HELP +
+        `
 Examples:
   $ lmnr-cli sql query "SELECT * FROM spans LIMIT 10"
   $ lmnr-cli sql query "SELECT id, total_cost, status FROM traces LIMIT 20"
   $ lmnr-cli sql query "SELECT * FROM spans LIMIT 10" --json
-`);
+`,
+    );
 
   sqlCmd
     .command("schema")
@@ -231,7 +267,9 @@ Examples:
       process.stdout.write(SQL_SCHEMA_HELP);
     });
 
-  program.addHelpText('after', `
+  program.addHelpText(
+    "after",
+    `
 Authentication:
   Most commands require a project API key. Provide it in one of two ways:
     1. Environment variable: export LMNR_PROJECT_API_KEY=<your-key>
@@ -250,9 +288,10 @@ Examples:
   lmnr-cli sql schema                                      # Show available tables
 
 For more information about the Laminar platfrom:
-  Documentation: https://docs.laminar.sh
+  Documentation: https://laminar.sh/docs
   Dashboard:     https://www.laminar.sh
-`);
+`,
+  );
 
   await program.parseAsync();
 }

--- a/packages/lmnr-cli/src/index.ts
+++ b/packages/lmnr-cli/src/index.ts
@@ -232,6 +232,12 @@ Examples:
     });
 
   program.addHelpText('after', `
+Authentication:
+  Most commands require a project API key. Provide it in one of two ways:
+    1. Environment variable: export LMNR_PROJECT_API_KEY=<your-key>
+    2. CLI flag:             --project-api-key <your-key>
+  Get your key at https://www.laminar.sh (Settings > Project API Keys).
+
 Examples:
   lmnr-cli dev agent.ts                                    # Debugger TypeScript entrypoint
   lmnr-cli dev agent.py                                    # Debugger Python script mode
@@ -242,6 +248,10 @@ Examples:
   lmnr-cli sql query "SELECT * FROM spans LIMIT 10" --json # Query spans
   lmnr-cli sql query "SELECT t.id, s.name FROM traces t JOIN spans s ON t.id = s.trace_id" --json
   lmnr-cli sql schema                                      # Show available tables
+
+For more information about the Laminar platfrom:
+  Documentation: https://docs.laminar.sh
+  Dashboard:     https://www.laminar.sh
 `);
 
   await program.parseAsync();

--- a/packages/lmnr/README.md
+++ b/packages/lmnr/README.md
@@ -26,9 +26,7 @@ Laminar.initialize({ projectApiKey: '<PROJECT_API_KEY>' })
 This will automatically instrument most of the LLM, Vector DB, and related
 calls with OpenTelemetry-compatible instrumentation.
 
-[Read docs](https://docs.lmnr.ai) to learn more.
-
-Auto-instrumentations are provided by [OpenLLMetry](https://github.com/traceloop/openllmetry-js).
+[Read docs](https://laminar.sh/docs) to learn more.
 
 ### Where to place Laminar.initialize()
 
@@ -126,8 +124,8 @@ You can run evaluations locally by providing executor (part of the logic used in
 
 \* If you already have the outputs of executors you want to evaluate, you can specify the executor as an identity function, that takes in `data` and returns only needed value(s) from it.
 
-[Read docs](https://docs.lmnr.ai/evaluations/introduction) to learn more about evaluations.
+[Read docs](https://laminar.sh/docs/evaluations/introduction) to learn more about evaluations.
 
 ## Client for HTTP operations
 
-Various interactions with Laminar [API](https://docs.lmnr.ai/api-reference/) are available in `LaminarClient`
+Various interactions with Laminar API are available in `LaminarClient`. [Learn more](https://laminar.sh/docs/sdk/client)

--- a/packages/lmnr/src/evaluations.ts
+++ b/packages/lmnr/src/evaluations.ts
@@ -7,7 +7,10 @@ import { EvaluationDataset, LaminarDataset } from "./datasets";
 import { observe } from "./decorators";
 import { Laminar } from "./laminar";
 import { InitializeOptions } from "./opentelemetry-lib/interfaces";
-import { HUMAN_EVALUATOR_OPTIONS, SPAN_TYPE } from "./opentelemetry-lib/tracing/attributes";
+import {
+  HUMAN_EVALUATOR_OPTIONS,
+  SPAN_TYPE,
+} from "./opentelemetry-lib/tracing/attributes";
 import { LaminarContextManager } from "./opentelemetry-lib/tracing/context";
 import {
   getFrontendUrl,
@@ -43,28 +46,30 @@ const getEvaluationUrl = (
   return `${url}/project/${projectId}/evaluations/${evaluationId}`;
 };
 
-const getAverageScores =
-  <D, T, O>(results: EvaluationDatapoint<D, T, O>[]): Record<string, number> => {
-    const perScoreValues: Record<string, number[]> = {};
-    for (const result of results) {
-      for (const key in result.scores) {
-        const score = result.scores[key];
-        if (perScoreValues[key] && score !== null) {
-          perScoreValues[key].push(score);
-        } else {
-          perScoreValues[key] = score !== null ? [score] : [];
-        }
+const getAverageScores = <D, T, O>(
+  results: EvaluationDatapoint<D, T, O>[],
+): Record<string, number> => {
+  const perScoreValues: Record<string, number[]> = {};
+  for (const result of results) {
+    for (const key in result.scores) {
+      const score = result.scores[key];
+      if (perScoreValues[key] && score !== null) {
+        perScoreValues[key].push(score);
+      } else {
+        perScoreValues[key] = score !== null ? [score] : [];
       }
     }
+  }
 
-    const averageScores: Record<string, number> = {};
-    for (const key in perScoreValues) {
-      averageScores[key] = perScoreValues[key].reduce((a, b) => a + b, 0)
-        / perScoreValues[key].length;
-    }
+  const averageScores: Record<string, number> = {};
+  for (const key in perScoreValues) {
+    averageScores[key] =
+      perScoreValues[key].reduce((a, b) => a + b, 0) /
+      perScoreValues[key].length;
+  }
 
-    return averageScores;
-  };
+  return averageScores;
+};
 
 /**
  * Configuration for the Evaluator
@@ -101,9 +106,9 @@ interface EvaluationConfig {
   /**
    * Object with modules to instrument. If not provided, all
    * available modules are instrumented.
-   * See {@link https://docs.lmnr.ai/tracing/automatic-instrumentation}
+   * See {@link https://laminar.sh/docs/sdk/typescript/instrumentation#instrumentmodules}
    */
-  instrumentModules?: InitializeOptions['instrumentModules'];
+  instrumentModules?: InitializeOptions["instrumentModules"];
   /**
    * If true, then the spans will not be batched.
    */
@@ -175,15 +180,19 @@ export type EvaluatorFunctionReturn = number | Record<string, number>;
  * of string keys and number values. The latter is useful for evaluating
  * multiple criteria in one go instead of running multiple evaluators.
  */
-export type EvaluatorFunction<O, T, D = any> = (output: O, target?: T, data?: D, ...args: any[]) =>
-  EvaluatorFunctionReturn | Promise<EvaluatorFunctionReturn>;
+export type EvaluatorFunction<O, T, D = any> = (
+  output: O,
+  target?: T,
+  data?: D,
+  ...args: any[]
+) => EvaluatorFunctionReturn | Promise<EvaluatorFunctionReturn>;
 
 interface EvaluationConstructorProps<D, T, O> {
   /**
    * List of data points to evaluate. `data` is the input to the executor function,
    * `target` is the input to the evaluator function.
    */
-  data: (Datapoint<D, T>[]) | EvaluationDataset<D, T>;
+  data: Datapoint<D, T>[] | EvaluationDataset<D, T>;
   /**
    * The executor function. Takes the data point + any additional arguments
    * and returns the output to evaluate.
@@ -237,11 +246,8 @@ class EvaluationReporter {
   public baseUrl: string;
   public frontendPort?: number;
 
-  constructor(
-    baseUrl?: string,
-    frontendPort?: number,
-  ) {
-    this.baseUrl = baseUrl ?? 'https://api.lmnr.ai';
+  constructor(baseUrl?: string, frontendPort?: number) {
+    this.baseUrl = baseUrl ?? "https://api.lmnr.ai";
     this.frontendPort = frontendPort;
   }
 
@@ -265,11 +271,20 @@ class EvaluationReporter {
     averageScores,
     projectId,
     evaluationId,
-  }: { averageScores: Record<string, number>, projectId: string, evaluationId: string }) {
+  }: {
+    averageScores: Record<string, number>;
+    projectId: string;
+    evaluationId: string;
+  }) {
     this.cliProgress.stop();
-    const url = getEvaluationUrl(projectId, evaluationId, this.baseUrl, this.frontendPort);
-    process.stdout.write('\n');
-    process.stdout.write('\nAverage scores:\n');
+    const url = getEvaluationUrl(
+      projectId,
+      evaluationId,
+      this.baseUrl,
+      this.frontendPort,
+    );
+    process.stdout.write("\n");
+    process.stdout.write("\nAverage scores:\n");
     for (const key in averageScores) {
       process.stdout.write(`${key}: ${averageScores[key]}\n`);
     }
@@ -282,7 +297,10 @@ export class Evaluation<D, T, O> {
   private progressReporter: EvaluationReporter;
   private data: Datapoint<D, T>[] | EvaluationDataset<D, T>;
   private executor: (data: D, ...args: any[]) => O | Promise<O>;
-  private evaluators: Record<string, EvaluatorFunction<O, T, D> | HumanEvaluator>;
+  private evaluators: Record<
+    string,
+    EvaluatorFunction<O, T, D> | HumanEvaluator
+  >;
   private groupName?: string;
   private frontendPort?: number;
   private name?: string;
@@ -295,10 +313,16 @@ export class Evaluation<D, T, O> {
   private client: LaminarClient;
 
   constructor({
-    data, executor, evaluators, groupName, name, metadata, config,
+    data,
+    executor,
+    evaluators,
+    groupName,
+    name,
+    metadata,
+    config,
   }: EvaluationConstructorProps<D, T, O>) {
     if (Object.keys(evaluators).length === 0) {
-      throw new Error('No evaluators provided');
+      throw new Error("No evaluators provided");
     }
 
     const evaluatorNameRegex = /^[\w\s-]+$/;
@@ -307,13 +331,16 @@ export class Evaluation<D, T, O> {
       if (!evaluatorNameRegex.test(key)) {
         throw new Error(
           `Invalid evaluator key: "${key}".` +
-          "Keys must only contain letters, digits, hyphens, underscores, or spaces.",
+            "Keys must only contain letters, digits, hyphens, underscores, or spaces.",
         );
       }
     }
 
     this.frontendPort = config?.frontendPort;
-    this.progressReporter = new EvaluationReporter(config?.baseUrl, config?.frontendPort);
+    this.progressReporter = new EvaluationReporter(
+      config?.baseUrl,
+      config?.frontendPort,
+    );
     this.data = data;
     this.executor = executor;
     this.evaluators = evaluators;
@@ -322,7 +349,10 @@ export class Evaluation<D, T, O> {
     this.name = name;
 
     if (config) {
-      if (config.concurrencyLimit !== undefined && config.concurrencyLimit < 1) {
+      if (
+        config.concurrencyLimit !== undefined &&
+        config.concurrencyLimit < 1
+      ) {
         logger.warn(
           `concurrencyLimit must be greater than 0. Setting to default of ${DEFAULT_CONCURRENCY}`,
         );
@@ -332,7 +362,8 @@ export class Evaluation<D, T, O> {
       }
       this.traceDisableBatch = config.traceDisableBatch ?? false;
       this.traceExportTimeoutMillis = config.traceExportTimeoutMillis;
-      this.traceExportBatchSize = config.traceExportBatchSize ?? MAX_EXPORT_BATCH_SIZE;
+      this.traceExportBatchSize =
+        config.traceExportBatchSize ?? MAX_EXPORT_BATCH_SIZE;
     }
 
     if (Laminar.initialized()) {
@@ -340,9 +371,14 @@ export class Evaluation<D, T, O> {
         baseUrl: Laminar.getHttpUrl(),
         projectApiKey: Laminar.getProjectApiKey(),
       });
-      if (config?.projectApiKey && config.projectApiKey !== Laminar.getProjectApiKey()) {
-        logger.warn('Laminar was already initialized with a different project API key. ' +
-          'Ignoring the project API key from the evaluation config.');
+      if (
+        config?.projectApiKey &&
+        config.projectApiKey !== Laminar.getProjectApiKey()
+      ) {
+        logger.warn(
+          "Laminar was already initialized with a different project API key. " +
+            "Ignoring the project API key from the evaluation config.",
+        );
       }
       return;
     }
@@ -350,18 +386,22 @@ export class Evaluation<D, T, O> {
     const key = config?.projectApiKey ?? process.env.LMNR_PROJECT_API_KEY;
     if (key === undefined) {
       throw new Error(
-        'Please initialize the Laminar object with your project API key ' +
-        'or set the LMNR_PROJECT_API_KEY environment variable',
+        "Please initialize the Laminar object with your project API key " +
+          "or set the LMNR_PROJECT_API_KEY environment variable",
       );
     }
 
-    const url = config?.baseUrl ?? process?.env?.LMNR_BASE_URL ?? 'https://api.lmnr.ai';
+    const url =
+      config?.baseUrl ?? process?.env?.LMNR_BASE_URL ?? "https://api.lmnr.ai";
     const httpUrl = config?.baseHttpUrl ?? url;
-    const httpPort = config?.httpPort ?? (
-      httpUrl.match(/:\d{1,5}$/g)
+    const httpPort =
+      config?.httpPort ??
+      (httpUrl.match(/:\d{1,5}$/g)
         ? parseInt(httpUrl.match(/:\d{1,5}$/g)![0].slice(1))
         : 443);
-    const urlWithoutSlash = httpUrl.replace(/\/$/, '').replace(/:\d{1,5}$/g, '');
+    const urlWithoutSlash = httpUrl
+      .replace(/\/$/, "")
+      .replace(/:\d{1,5}$/g, "");
     const baseHttpUrl = `${urlWithoutSlash}:${httpPort}`;
 
     this.client = new LaminarClient({
@@ -384,7 +424,7 @@ export class Evaluation<D, T, O> {
 
   public async run(): Promise<EvaluationRunResult> {
     if (this.isFinished) {
-      throw new Error('Evaluation is already finished');
+      throw new Error("Evaluation is already finished");
     }
     if (this.data instanceof LaminarDataset) {
       this.data.setClient(this.client);
@@ -402,8 +442,8 @@ export class Evaluation<D, T, O> {
         } catch (error) {
           // Backward compatibility with old Laminar API (self-hosted)
           logger.warn(
-            `Error getting dataset ${(this.data).name}: `
-            + `${error instanceof Error ? error.message : String(error)}`,
+            `Error getting dataset ${this.data.name}: ` +
+              `${error instanceof Error ? error.message : String(error)}`,
           );
         }
       }
@@ -411,7 +451,11 @@ export class Evaluation<D, T, O> {
 
     let resultDatapoints: EvaluationDatapoint<D, T, O>[];
     try {
-      const evaluation = await this.client.evals.init(this.name, this.groupName, this.metadata);
+      const evaluation = await this.client.evals.init(
+        this.name,
+        this.groupName,
+        this.metadata,
+      );
       const url = getEvaluationUrl(
         evaluation.projectId,
         evaluation.id,
@@ -445,10 +489,10 @@ export class Evaluation<D, T, O> {
       this.isFinished = true;
       return {
         averageScores: {},
-        projectId: '',
-        evaluationId: '',
-        url: '',
-        errorMessage: (e instanceof Error) ? e.message : String(e),
+        projectId: "",
+        evaluationId: "",
+        url: "",
+        errorMessage: e instanceof Error ? e.message : String(e),
       };
     }
   }
@@ -472,9 +516,11 @@ export class Evaluation<D, T, O> {
       }
     };
 
-    for (let i = 0; i < await this.getLength(); i++) {
+    for (let i = 0; i < (await this.getLength()); i++) {
       await semaphore.acquire();
-      const datapoint = Array.isArray(this.data) ? this.data[i] : await this.data.get(i);
+      const datapoint = Array.isArray(this.data)
+        ? this.data[i]
+        : await this.data.get(i);
       tasks.push(evaluateTask(datapoint, i));
     }
     const results = await Promise.all(tasks);
@@ -488,141 +534,162 @@ export class Evaluation<D, T, O> {
     datapoint: Datapoint<D, T>,
     index: number,
   ): Promise<EvaluationDatapoint<D, T, O>> {
-    return observe({ name: "evaluation", traceType: "EVALUATION" }, async () => {
-
-      trace.getSpan(LaminarContextManager.getContext())!.setAttribute(SPAN_TYPE, "EVALUATION");
-      const executorSpan = Laminar.startSpan({
-        name: "executor",
-        input: datapoint.data,
-      });
-      executorSpan.setAttribute(SPAN_TYPE, "EXECUTOR");
-      const executorSpanId = otelSpanIdToUUID(executorSpan.spanContext().spanId);
-      const datapointId = newUUID();
-      const partialDatapoint = {
-        id: datapointId,
-        data: datapoint.data,
-        target: datapoint.target,
-        metadata: datapoint.metadata,
-        traceId: otelTraceIdToUUID(
-          trace.getSpan(LaminarContextManager.getContext())!.spanContext().traceId,
-        ),
-        executorSpanId,
-        index,
-      } as EvaluationDatapoint<D, T, O>;
-
-      // Add dataset link if data is from LaminarDataset
-      if (
-        this.data instanceof LaminarDataset
-        && this.data.id && datapoint.id && datapoint.createdAt
-      ) {
-        partialDatapoint.datasetLink = {
-          datasetId: this.data.id,
-          datapointId: datapoint.id,
-          createdAt: datapoint.createdAt,
-        };
-      }
-
-      // first create the datapoint in the database and await
-      await this.client.evals.saveDatapoints({
-        evalId,
-        datapoints: [partialDatapoint],
-        groupName: this.groupName,
-      });
-
-      const output = await Laminar.withSpan(
-        executorSpan,
-        async () => {
-          const result = await this.executor(datapoint.data);
-          Laminar.setSpanOutput(result);
-          return result;
-        },
-        true,
-      );
-      const target = datapoint.target;
-
-      let scores: Record<string, number | null> = {};
-      for (const [evaluatorName, evaluator] of Object.entries(this.evaluators)) {
-        const value = await observe(
-          { name: evaluatorName },
-          async (output: O, target?: T, data?: D) => {
-            if (evaluator instanceof HumanEvaluator) {
-              const activeSpan = trace.getSpan(LaminarContextManager.getContext());
-              if (activeSpan) {
-                activeSpan.setAttribute(SPAN_TYPE, "HUMAN_EVALUATOR");
-                if (evaluator.options) {
-                  activeSpan.setAttribute(
-                    HUMAN_EVALUATOR_OPTIONS,
-                    JSON.stringify(evaluator.options),
-                  );
-                }
-              }
-              return null;
-            } else {
-              const activeSpan = trace.getSpan(LaminarContextManager.getContext());
-              if (activeSpan) {
-                activeSpan.setAttribute(SPAN_TYPE, "EVALUATOR");
-              }
-              return await evaluator(output, target, data);
-            }
-          },
-          output,
-          datapoint.target,
-          datapoint.data,
+    return observe(
+      { name: "evaluation", traceType: "EVALUATION" },
+      async () => {
+        trace
+          .getSpan(LaminarContextManager.getContext())!
+          .setAttribute(SPAN_TYPE, "EVALUATION");
+        const executorSpan = Laminar.startSpan({
+          name: "executor",
+          input: datapoint.data,
+        });
+        executorSpan.setAttribute(SPAN_TYPE, "EXECUTOR");
+        const executorSpanId = otelSpanIdToUUID(
+          executorSpan.spanContext().spanId,
         );
+        const datapointId = newUUID();
+        const partialDatapoint = {
+          id: datapointId,
+          data: datapoint.data,
+          target: datapoint.target,
+          metadata: datapoint.metadata,
+          traceId: otelTraceIdToUUID(
+            trace.getSpan(LaminarContextManager.getContext())!.spanContext()
+              .traceId,
+          ),
+          executorSpanId,
+          index,
+        } as EvaluationDatapoint<D, T, O>;
 
-        if (evaluator instanceof HumanEvaluator) {
-          scores[evaluatorName] = null;
-          continue;
+        // Add dataset link if data is from LaminarDataset
+        if (
+          this.data instanceof LaminarDataset &&
+          this.data.id &&
+          datapoint.id &&
+          datapoint.createdAt
+        ) {
+          partialDatapoint.datasetLink = {
+            datasetId: this.data.id,
+            datapointId: datapoint.id,
+            createdAt: datapoint.createdAt,
+          };
         }
 
-        if (typeof value === "number") {
-          if (isNaN(value)) {
-            throw new Error(`Evaluator ${evaluatorName} returned NaN`);
+        // first create the datapoint in the database and await
+        await this.client.evals.saveDatapoints({
+          evalId,
+          datapoints: [partialDatapoint],
+          groupName: this.groupName,
+        });
+
+        const output = await Laminar.withSpan(
+          executorSpan,
+          async () => {
+            const result = await this.executor(datapoint.data);
+            Laminar.setSpanOutput(result);
+            return result;
+          },
+          true,
+        );
+        const target = datapoint.target;
+
+        let scores: Record<string, number | null> = {};
+        for (const [evaluatorName, evaluator] of Object.entries(
+          this.evaluators,
+        )) {
+          const value = await observe(
+            { name: evaluatorName },
+            async (output: O, target?: T, data?: D) => {
+              if (evaluator instanceof HumanEvaluator) {
+                const activeSpan = trace.getSpan(
+                  LaminarContextManager.getContext(),
+                );
+                if (activeSpan) {
+                  activeSpan.setAttribute(SPAN_TYPE, "HUMAN_EVALUATOR");
+                  if (evaluator.options) {
+                    activeSpan.setAttribute(
+                      HUMAN_EVALUATOR_OPTIONS,
+                      JSON.stringify(evaluator.options),
+                    );
+                  }
+                }
+                return null;
+              } else {
+                const activeSpan = trace.getSpan(
+                  LaminarContextManager.getContext(),
+                );
+                if (activeSpan) {
+                  activeSpan.setAttribute(SPAN_TYPE, "EVALUATOR");
+                }
+                return await evaluator(output, target, data);
+              }
+            },
+            output,
+            datapoint.target,
+            datapoint.data,
+          );
+
+          if (evaluator instanceof HumanEvaluator) {
+            scores[evaluatorName] = null;
+            continue;
           }
-          scores[evaluatorName] = value;
-        } else if (value !== null) {
-          scores = { ...scores, ...value };
+
+          if (typeof value === "number") {
+            if (isNaN(value)) {
+              throw new Error(`Evaluator ${evaluatorName} returned NaN`);
+            }
+            scores[evaluatorName] = value;
+          } else if (value !== null) {
+            scores = { ...scores, ...value };
+          }
         }
-      }
 
-      const resultDatapoint = {
-        id: datapointId,
-        executorOutput: output,
-        data: datapoint.data,
-        target,
-        metadata: datapoint.metadata,
-        scores,
-        traceId: otelTraceIdToUUID(
-          trace.getSpan(LaminarContextManager.getContext())!.spanContext().traceId,
-        ),
-        executorSpanId,
-        index,
-      } as EvaluationDatapoint<D, T, O>;
+        const resultDatapoint = {
+          id: datapointId,
+          executorOutput: output,
+          data: datapoint.data,
+          target,
+          metadata: datapoint.metadata,
+          scores,
+          traceId: otelTraceIdToUUID(
+            trace.getSpan(LaminarContextManager.getContext())!.spanContext()
+              .traceId,
+          ),
+          executorSpanId,
+          index,
+        } as EvaluationDatapoint<D, T, O>;
 
-      // Add dataset link if data is from LaminarDataset
-      if (this.data instanceof LaminarDataset
-        && this.data.id && datapoint.id && datapoint.createdAt
-      ) {
-        resultDatapoint.datasetLink = {
-          datasetId: this.data.id,
-          datapointId: datapoint.id,
-          createdAt: datapoint.createdAt,
-        };
-      }
+        // Add dataset link if data is from LaminarDataset
+        if (
+          this.data instanceof LaminarDataset &&
+          this.data.id &&
+          datapoint.id &&
+          datapoint.createdAt
+        ) {
+          resultDatapoint.datasetLink = {
+            datasetId: this.data.id,
+            datapointId: datapoint.id,
+            createdAt: datapoint.createdAt,
+          };
+        }
 
-      const uploadPromise = this.client.evals.saveDatapoints({
-        evalId,
-        datapoints: [resultDatapoint],
-        groupName: this.groupName,
-      });
-      this.uploadPromises.push(uploadPromise);
+        const uploadPromise = this.client.evals.saveDatapoints({
+          evalId,
+          datapoints: [resultDatapoint],
+          groupName: this.groupName,
+        });
+        this.uploadPromises.push(uploadPromise);
 
-      return resultDatapoint;
-    });
+        return resultDatapoint;
+      },
+    );
   }
 
   private async getLength(): Promise<number> {
-    return this.data instanceof EvaluationDataset ? await this.data.size() : this.data.length;
+    return this.data instanceof EvaluationDataset
+      ? await this.data.size()
+      : this.data.length;
   }
 
   public setFrontendPort(port: number) {
@@ -650,8 +717,16 @@ export class Evaluation<D, T, O> {
  * @param props.config Optional override configurations for the evaluator.
  */
 export async function evaluate<D, T, O>({
-  data, executor, evaluators, groupName, name, metadata, config,
-}: EvaluationConstructorProps<D, T, O>): Promise<EvaluationRunResult | undefined> {
+  data,
+  executor,
+  evaluators,
+  groupName,
+  name,
+  metadata,
+  config,
+}: EvaluationConstructorProps<D, T, O>): Promise<
+  EvaluationRunResult | undefined
+> {
   const evaluation = new Evaluation<D, T, O>({
     data,
     executor,


### PR DESCRIPTION
## Summary
- Add authentication section to `--help` explaining how to provide an API key (env var or `--project-api-key` flag)
- Add resources section with links to docs and dashboard

## Test plan
- [x] `lmnr-cli --help` shows new sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to CLI `--help` text and documentation link updates, plus formatting-only refactors with no functional behavior changes expected.
> 
> **Overview**
> Updates docs across the repo to point to `laminar.sh` (and new hosting/instrumentation URLs) instead of `docs.lmnr.ai`, including the root README, SDK README, and Next.js example READMEs.
> 
> Enhances `lmnr-cli --help` output with an **Authentication** section explaining how to supply `LMNR_PROJECT_API_KEY` (env var vs `--project-api-key`) and adds links to the Laminar docs/dashboard; remaining edits in `packages/lmnr/src/evaluations.ts` are primarily formatting and doc-link tweaks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39119d46f640efcccc023b1f3cfc65ed7d1c7e99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->