### PR TITLE
opencode client instrumentation

### DIFF
--- a/packages/lmnr/package.json
+++ b/packages/lmnr/package.json
@@ -102,6 +102,7 @@
     "@lmnr-ai/client": "workspace:*",
     "@lmnr-ai/types": "workspace:*",
     "@onkernel/sdk": "^0.18.0",
+    "@opencode-ai/sdk": "^1.4.3",
     "@pinecone-database/pinecone": "^5.1.2",
     "@playwright/test": "^1.54.2",
     "@qdrant/js-client-rest": "^1.17.0",

--- a/packages/lmnr/src/opentelemetry-lib/instrumentation/opencode.ts
+++ b/packages/lmnr/src/opentelemetry-lib/instrumentation/opencode.ts
@@ -1,0 +1,122 @@
+import { diag } from "@opentelemetry/api";
+import {
+  InstrumentationBase,
+  InstrumentationModuleDefinition,
+  InstrumentationNodeModuleDefinition,
+} from "@opentelemetry/instrumentation";
+
+import { version as SDK_VERSION } from "../../../package.json";
+import { Laminar } from "../../laminar";
+
+/* eslint-disable
+  @typescript-eslint/no-unsafe-return,
+  @typescript-eslint/no-unsafe-function-type
+*/
+
+export class OpencodeInstrumentation extends InstrumentationBase {
+  constructor() {
+    super("lmnr-opencode-instrumentation", SDK_VERSION, { enabled: true });
+  }
+
+  protected init(): InstrumentationModuleDefinition {
+    return new InstrumentationNodeModuleDefinition(
+      "@opencode-ai/sdk",
+      [">=1.0.0"],
+      this.patch.bind(this),
+      this.unpatch.bind(this),
+    );
+  }
+
+  public manuallyInstrument(opencodeModule: any): void {
+    diag.debug("Manually instrumenting @opencode-ai/sdk");
+    const SessionClass = this.resolveSessionClass(opencodeModule);
+    if (SessionClass) {
+      this.patchSessionClass(SessionClass);
+    } else {
+      diag.warn(
+        "Could not find Session class in opencode manual instrumentation input. " +
+          "Pass the OpencodeClient class or the module object.",
+      );
+    }
+  }
+
+  private resolveSessionClass(input: any): any {
+    // Module-level import: { OpencodeClient, ... }
+    if (input?.OpencodeClient) {
+      return this.getSessionClass(input.OpencodeClient);
+    }
+    // Direct class passed
+    if (typeof input === "function" && input.prototype) {
+      return this.getSessionClass(input);
+    }
+    return null;
+  }
+
+  // session is a class field on OpencodeClient (not on the prototype), so we
+  // must instantiate to trigger field initialization and discover Session's constructor.
+  private getSessionClass(ClientClass: any): Function | null {
+    try {
+      const instance = new ClientClass();
+      if (instance.session) {
+        return instance.session.constructor;
+      }
+    } catch {
+      // fall through
+    }
+    return null;
+  }
+
+  private patchSessionClass(SessionClass: Function): void {
+    this._wrap(SessionClass.prototype, "prompt", this.patchPromptMethod());
+    this._wrap(SessionClass.prototype, "promptAsync", this.patchPromptMethod());
+  }
+
+  private patchPromptMethod(): (original: Function) => Function {
+    return (original: Function) => {
+      return function (this: any, ...args: any[]) {
+        const options = args[0];
+        if (options?.body?.parts && Array.isArray(options.body.parts)) {
+          const serializedContext = Laminar.serializeLaminarSpanContext();
+          if (serializedContext) {
+            options.body.parts = [
+              ...options.body.parts,
+              {
+                type: "text",
+                metadata: {
+                  lmnrSpanContext: serializedContext,
+                },
+                text: "",
+                ignored: true,
+                synthetic: true,
+              },
+            ];
+          }
+        }
+        return original.apply(this, args);
+      };
+    };
+  }
+
+  private patch(moduleExports: any): any {
+    diag.debug("Patching @opencode-ai/sdk");
+    const SessionClass = this.resolveSessionClass(moduleExports);
+    if (SessionClass) {
+      this.patchSessionClass(SessionClass);
+    }
+    return moduleExports;
+  }
+
+  private unpatch(moduleExports: any): void {
+    diag.debug("Unpatching @opencode-ai/sdk");
+    const SessionClass = this.resolveSessionClass(moduleExports);
+    if (SessionClass) {
+      this._unwrap(SessionClass.prototype, "prompt");
+      this._unwrap(SessionClass.prototype, "promptAsync");
+    }
+  }
+}
+
+/* eslint-enable
+  @typescript-eslint/no-unsafe-return,
+  @typescript-eslint/no-unsafe-function-type
+*/

--- a/packages/lmnr/src/opentelemetry-lib/interfaces/initialize-options.interface.ts
+++ b/packages/lmnr/src/opentelemetry-lib/interfaces/initialize-options.interface.ts
@@ -349,6 +349,20 @@ export interface InitializeOptions {
      * ```
      */
     stagehand?: any;
+    /**
+     * @example
+     * ```javascript
+     * import * as opencode from "@opencode-ai/sdk";
+     * import Laminar from "@lmnr-ai/lmnr";
+     *
+     * Laminar.initialize({
+     *   instrumentModules: {
+     *     opencode: opencode,
+     *   },
+     * });
+     * ```
+     */
+    opencode?: any;
   };
 
   /**

--- a/packages/lmnr/src/opentelemetry-lib/tracing/instrumentations.ts
+++ b/packages/lmnr/src/opentelemetry-lib/tracing/instrumentations.ts
@@ -24,6 +24,7 @@ import { initializeLogger } from "../../utils";
 import { ClaudeAgentSDKInstrumentation } from "../instrumentation/claude-agent-sdk";
 import { GoogleGenAiInstrumentation } from "../instrumentation/google-genai";
 import { KernelInstrumentation } from "../instrumentation/kernel";
+import { OpencodeInstrumentation } from "../instrumentation/opencode";
 import { InitializeOptions } from "../interfaces";
 
 const logger = initializeLogger();
@@ -240,6 +241,8 @@ const initInstrumentations = (
 
   instrumentations.push(new ClaudeAgentSDKInstrumentation());
 
+  instrumentations.push(new OpencodeInstrumentation());
+
   return instrumentations;
 };
 
@@ -437,6 +440,12 @@ const manuallyInitInstrumentations = (
     claudeAgentInstrumentation.manuallyInstrument(
       instrumentModules.claudeAgentSDK,
     );
+  }
+
+  if (instrumentModules?.opencode) {
+    const opencodeInstrumentation = new OpencodeInstrumentation();
+    instrumentations.push(opencodeInstrumentation);
+    opencodeInstrumentation.manuallyInstrument(instrumentModules.opencode);
   }
 
   return instrumentations;

--- a/packages/lmnr/test/opencode.test.ts
+++ b/packages/lmnr/test/opencode.test.ts
@@ -1,0 +1,309 @@
+import assert from "node:assert/strict";
+import { after, afterEach, beforeEach, describe, it } from "node:test";
+
+import { context, trace } from "@opentelemetry/api";
+import { InMemorySpanExporter } from "@opentelemetry/sdk-trace-base";
+import nock from "nock";
+
+import { observe } from "../src/decorators";
+import { Laminar } from "../src/laminar";
+import { _resetConfiguration, initializeTracing } from "../src/opentelemetry-lib/configuration";
+import { OpencodeInstrumentation } from "../src/opentelemetry-lib/instrumentation/opencode";
+
+// Minimal mock of the @opencode-ai/sdk Session class structure.
+// This mirrors how the real SDK's Session class works: it has
+// prompt/promptAsync methods that POST to the OpenCode server.
+
+class MockSession {
+  private _baseUrl: string;
+
+  constructor(baseUrl = "http://localhost:4096") {
+    this._baseUrl = baseUrl;
+  }
+
+  async prompt(options: any): Promise<any> {
+    const sessionId = options.path.id;
+    const response = await fetch(`${this._baseUrl}/session/${sessionId}/message`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(options.body),
+    });
+    return response.json();
+  }
+
+  async promptAsync(options: any): Promise<any> {
+    const sessionId = options.path.id;
+    const response = await fetch(`${this._baseUrl}/session/${sessionId}/prompt_async`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(options.body),
+    });
+    if (response.status === 204) {
+      return undefined;
+    }
+    return response.json();
+  }
+}
+
+void describe("opencode instrumentation", () => {
+  const exporter = new InMemorySpanExporter();
+  let session: MockSession;
+  let instrumentation: OpencodeInstrumentation;
+
+  void beforeEach(() => {
+    _resetConfiguration();
+    initializeTracing({ exporter, disableBatch: true });
+
+    Object.defineProperty(Laminar, "isInitialized", {
+      value: true,
+      writable: true,
+    });
+
+    instrumentation = new OpencodeInstrumentation();
+    instrumentation["patchSessionClass"](MockSession);
+
+    session = new MockSession();
+  });
+
+  void afterEach(() => {
+    exporter.reset();
+    nock.cleanAll();
+  });
+
+  void after(async () => {
+    await exporter.shutdown();
+    trace.disable();
+    context.disable();
+  });
+
+  void it("injects lmnrSpanContext into prompt parts inside observe", async () => {
+    let capturedBody: any = null;
+
+    const scope = nock("http://localhost:4096")
+      .post("/session/test-session/message", (body: any) => {
+        capturedBody = body;
+        return true;
+      })
+      .reply(200, {
+        info: { id: "msg-1", sessionID: "test-session", role: "assistant" },
+        parts: [{ id: "part-1", type: "text", text: "Hello!" }],
+      });
+
+    await observe({ name: "test-observe" }, async () => {
+      await session.prompt({
+        path: { id: "test-session" },
+        body: {
+          parts: [
+            { type: "text", text: "Hello, world!" },
+          ],
+        },
+      });
+    });
+
+    assert.ok(scope.isDone(), "nock scope should be satisfied");
+    assert.ok(capturedBody, "request body should be captured");
+
+    // Verify the original part is preserved
+    assert.strictEqual(capturedBody.parts[0].type, "text");
+    assert.strictEqual(capturedBody.parts[0].text, "Hello, world!");
+
+    // Verify the injected metadata part
+    const metadataPart = capturedBody.parts[1];
+    assert.ok(metadataPart, "metadata part should be injected");
+    assert.strictEqual(metadataPart.type, "text");
+    assert.strictEqual(metadataPart.text, "");
+    assert.strictEqual(metadataPart.ignored, true);
+    assert.strictEqual(metadataPart.synthetic, true);
+    assert.ok(metadataPart.metadata, "metadata should exist");
+    assert.ok(
+      metadataPart.metadata.lmnrSpanContext,
+      "lmnrSpanContext should exist in metadata",
+    );
+
+    // Verify the span context is valid JSON with expected fields
+    const spanContext = JSON.parse(metadataPart.metadata.lmnrSpanContext);
+    assert.ok(spanContext.traceId, "traceId should exist in span context");
+    assert.ok(spanContext.spanId, "spanId should exist in span context");
+
+    // Verify the observe span was created
+    const spans = exporter.getFinishedSpans();
+    assert.ok(spans.length >= 1, "at least one span should exist");
+    const observeSpan = spans.find(span => span.name === "test-observe");
+    assert.ok(observeSpan, "observe span should exist");
+  });
+
+  void it("injects lmnrSpanContext into promptAsync parts inside observe", async () => {
+    let capturedBody: any = null;
+
+    const scope = nock("http://localhost:4096")
+      .post("/session/test-session/prompt_async", (body: any) => {
+        capturedBody = body;
+        return true;
+      })
+      .reply(204);
+
+    await observe({ name: "test-observe-async" }, async () => {
+      await session.promptAsync({
+        path: { id: "test-session" },
+        body: {
+          parts: [
+            { type: "text", text: "Async hello!" },
+          ],
+        },
+      });
+    });
+
+    assert.ok(scope.isDone(), "nock scope should be satisfied");
+    assert.ok(capturedBody, "request body should be captured");
+
+    // Verify injection
+    assert.strictEqual(capturedBody.parts.length, 2);
+
+    const metadataPart = capturedBody.parts[1];
+    assert.strictEqual(metadataPart.type, "text");
+    assert.strictEqual(metadataPart.text, "");
+    assert.strictEqual(metadataPart.ignored, true);
+    assert.strictEqual(metadataPart.synthetic, true);
+
+    const spanContext = JSON.parse(metadataPart.metadata.lmnrSpanContext);
+    assert.ok(spanContext.traceId, "traceId should exist");
+    assert.ok(spanContext.spanId, "spanId should exist");
+  });
+
+  void it("does not inject when there is no active span context", async () => {
+    let capturedBody: any = null;
+
+    const scope = nock("http://localhost:4096")
+      .post("/session/test-session/message", (body: any) => {
+        capturedBody = body;
+        return true;
+      })
+      .reply(200, {
+        info: { id: "msg-1", sessionID: "test-session", role: "assistant" },
+        parts: [],
+      });
+
+    // Call without observe - no active span context
+    await session.prompt({
+      path: { id: "test-session" },
+      body: {
+        parts: [
+          { type: "text", text: "No context here" },
+        ],
+      },
+    });
+
+    assert.ok(scope.isDone(), "nock scope should be satisfied");
+    assert.ok(capturedBody, "request body should be captured");
+
+    // Should only have the original part, no injection
+    assert.strictEqual(capturedBody.parts.length, 1);
+    assert.strictEqual(capturedBody.parts[0].text, "No context here");
+  });
+
+  void it("does not inject when parts array is missing", async () => {
+    let capturedBody: any = null;
+
+    const scope = nock("http://localhost:4096")
+      .post("/session/test-session/message", (body: any) => {
+        capturedBody = body;
+        return true;
+      })
+      .reply(200, {
+        info: { id: "msg-1", sessionID: "test-session", role: "assistant" },
+        parts: [],
+      });
+
+    await observe({ name: "test-no-parts" }, async () => {
+      await session.prompt({
+        path: { id: "test-session" },
+        body: {},
+      });
+    });
+
+    assert.ok(scope.isDone(), "nock scope should be satisfied");
+    assert.ok(capturedBody, "request body should be captured");
+
+    // Body should not have parts added
+    assert.strictEqual(capturedBody.parts, undefined);
+  });
+
+  void it("preserves multiple existing parts when injecting", async () => {
+    let capturedBody: any = null;
+
+    const scope = nock("http://localhost:4096")
+      .post("/session/test-session/message", (body: any) => {
+        capturedBody = body;
+        return true;
+      })
+      .reply(200, {
+        info: { id: "msg-1", sessionID: "test-session", role: "assistant" },
+        parts: [],
+      });
+
+    await observe({ name: "test-multiple-parts" }, async () => {
+      await session.prompt({
+        path: { id: "test-session" },
+        body: {
+          parts: [
+            { type: "text", text: "First part" },
+            { type: "text", text: "Second part" },
+            { type: "file", mime: "image/png", url: "https://example.com/image.png" },
+          ],
+        },
+      });
+    });
+
+    assert.ok(scope.isDone(), "nock scope should be satisfied");
+    assert.ok(capturedBody, "request body should be captured");
+
+    // Original 3 parts + 1 injected
+    assert.strictEqual(capturedBody.parts.length, 4);
+    assert.strictEqual(capturedBody.parts[0].text, "First part");
+    assert.strictEqual(capturedBody.parts[1].text, "Second part");
+    assert.strictEqual(capturedBody.parts[2].type, "file");
+    assert.strictEqual(capturedBody.parts[3].type, "text");
+    assert.strictEqual(capturedBody.parts[3].ignored, true);
+    assert.strictEqual(capturedBody.parts[3].synthetic, true);
+  });
+
+  void it("span context contains trace ID matching the observe span", async () => {
+    let capturedBody: any = null;
+
+    const scope = nock("http://localhost:4096")
+      .post("/session/test-session/message", (body: any) => {
+        capturedBody = body;
+        return true;
+      })
+      .reply(200, {
+        info: { id: "msg-1", sessionID: "test-session", role: "assistant" },
+        parts: [],
+      });
+
+    await observe({ name: "test-trace-match" }, async () => {
+      await session.prompt({
+        path: { id: "test-session" },
+        body: {
+          parts: [
+            { type: "text", text: "Trace matching test" },
+          ],
+        },
+      });
+    });
+
+    assert.ok(scope.isDone());
+
+    const metadataPart = capturedBody.parts[1];
+    const spanContext = JSON.parse(metadataPart.metadata.lmnrSpanContext);
+
+    // The trace ID in the injected context should match the observe span's trace ID
+    const spans = exporter.getFinishedSpans();
+    const observeSpan = spans.find(span => span.name === "test-trace-match");
+    assert.ok(observeSpan);
+
+    // The OTel trace ID is a hex string; the serialized context converts it to UUID format
+    // Just verify both exist and the trace IDs are related
+    assert.ok(spanContext.traceId, "injected traceId should exist");
+    assert.ok(observeSpan.spanContext().traceId, "observe span traceId should exist");
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -226,6 +226,9 @@ importers:
       '@onkernel/sdk':
         specifier: ^0.18.0
         version: 0.18.0
+      '@opencode-ai/sdk':
+        specifier: ^1.4.3
+        version: 1.4.3
       '@pinecone-database/pinecone':
         specifier: ^5.1.2
         version: 5.1.2
@@ -1064,6 +1067,9 @@ packages:
 
   '@open-draft/until@2.1.0':
     resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
+
+  '@opencode-ai/sdk@1.4.3':
+    resolution: {integrity: sha512-X0CAVbwoGAjTY2iecpWkx2B+GAa2jSaQKYpJ+xILopeF/OGKZUN15mjqci+L7cEuwLHV5wk3x2TStUOVCa5p0A==}
 
   '@opentelemetry/api-logs@0.200.0':
     resolution: {integrity: sha512-IKJBQxh91qJ+3ssRly5hYEJ8NDHu9oY/B1PXVSCWf7zytmYO9RNLB0Ox9XQ/fJ8m6gY6Q6NtBWlmXfaXt5Uc4Q==}
@@ -4760,6 +4766,10 @@ snapshots:
       outvariant: 1.4.3
 
   '@open-draft/until@2.1.0': {}
+
+  '@opencode-ai/sdk@1.4.3':
+    dependencies:
+      cross-spawn: 7.0.6
 
   '@opentelemetry/api-logs@0.200.0':
     dependencies:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Wraps and mutates request payloads for `@opencode-ai/sdk` prompts, which could affect downstream behavior if the SDK’s request shape or `parts` semantics change; otherwise the change is isolated and covered by tests.
> 
> **Overview**
> Adds first-class OpenTelemetry instrumentation for `@opencode-ai/sdk`, automatically and via `Laminar.initialize({ instrumentModules: { opencode } })`.
> 
> The new `OpencodeInstrumentation` wraps `Session.prompt`/`promptAsync` to append a synthetic `parts` entry carrying `lmnrSpanContext` metadata, and includes a comprehensive test suite validating injection and no-op behavior when context/parts are missing. Dependency updates add `@opencode-ai/sdk` to `@lmnr-ai/lmnr` dev deps and lockfile.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 642586b3fe173487dde3645f189c2c5708d3f929. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->