### PR TITLE
Clearer names and split the file into smaller bits

### DIFF
--- a/packages/lmnr/src/index.ts
+++ b/packages/lmnr/src/index.ts
@@ -20,12 +20,12 @@ export {
 } from "./opentelemetry-lib/instrumentation/aisdk";
 export {
   AI_SDK_TELEMETRY_DIAGNOSTIC_CHANNEL,
-  enableLaminarTelemetryDebug,
-  LaminarTelemetry,
-  laminarTelemetry,
-  type LaminarTelemetryOptions,
-  registerLaminarTelemetry,
-} from "./opentelemetry-lib/instrumentation/aisdk/v7-integration";
+  aiSdkTelemetry,
+  enableAiSdkTelemetryDebug,
+  LaminarAiSdkTelemetry,
+  type LaminarAiSdkTelemetryOptions,
+  registerAiSdkTelemetry,
+} from "./opentelemetry-lib/instrumentation/aisdk/v7-integration/index";
 export { instrumentClaudeAgentQuery } from "./opentelemetry-lib/instrumentation/claude-agent-sdk";
 export {
   MastraExporter,

--- a/packages/lmnr/src/opentelemetry-lib/instrumentation/aisdk/index.ts
+++ b/packages/lmnr/src/opentelemetry-lib/instrumentation/aisdk/index.ts
@@ -5,7 +5,7 @@ import type * as AI from "ai";
 import { getTracer } from "../../tracing";
 import { LaminarLanguageModelV2 } from "./v2";
 import { LaminarLanguageModelV3 } from "./v3";
-import { laminarTelemetry } from "./v7-integration";
+import { aiSdkTelemetry } from "./v7-integration/index";
 
 const AI_FUNCTIONS = [
   "generateText",
@@ -30,7 +30,7 @@ export const wrapAISDK = (ai: typeof AI): typeof AI => {
   const v7 = isAISDKv7(ai);
   // Create one integration per wrap() call so registrations are stable
   // across calls within the same process but distinct across test runs.
-  const v7Integration = v7 ? laminarTelemetry() : undefined;
+  const v7Integration = v7 ? aiSdkTelemetry() : undefined;
 
   Object.entries(ai).forEach(([key, value]) => {
     if (typeof value === "function" && AI_FUNCTIONS.includes(key)) {

--- a/packages/lmnr/src/opentelemetry-lib/instrumentation/aisdk/v7-integration/index.ts
+++ b/packages/lmnr/src/opentelemetry-lib/instrumentation/aisdk/v7-integration/index.ts
@@ -29,23 +29,39 @@
 import * as diagnosticsChannel from "node:diagnostics_channel";
 
 import {
-  type Context,
   context as contextApi,
   type HrTime,
-  type Span,
   SpanKind,
   SpanStatusCode,
   trace,
 } from "@opentelemetry/api";
 
-import { getTracer } from "../../tracing";
+import { getTracer } from "../../../tracing";
 import {
   LaminarAttributes,
   SPAN_INPUT,
   SPAN_OUTPUT,
   SPAN_TYPE,
-} from "../../tracing/attributes";
-import { LaminarContextManager } from "../../tracing/context";
+} from "../../../tracing/attributes";
+import { LaminarContextManager } from "../../../tracing/context";
+import {
+  type LlmState,
+  type OperationState,
+  stepKey,
+  type StepState,
+  type ToolState,
+} from "./types";
+import {
+  applyUsage,
+  compareHrTime,
+  extractReasoningFromContent,
+  extractTextFromContent,
+  normalizeProvider,
+  normalizeToolCalls,
+  readSpanEndTime,
+  serializeJSON,
+  standardizedPromptToMessages,
+} from "./utils";
 
 /* eslint-disable @typescript-eslint/no-unsafe-argument */
 
@@ -55,140 +71,7 @@ import { LaminarContextManager } from "../../tracing/context";
  */
 export const AI_SDK_TELEMETRY_DIAGNOSTIC_CHANNEL = "aisdk:telemetry";
 
-interface OperationState {
-  span: Span;
-  ctx: Context;
-  operationId?: string;
-  provider?: string;
-  modelId?: string;
-}
-
-interface StepState {
-  span: Span;
-  ctx: Context;
-  stepNumber: number;
-}
-
-interface LlmState {
-  span: Span;
-  textDeltas: string[];
-}
-
-interface ToolState {
-  span: Span;
-  ctx: Context;
-  callId: string;
-}
-
-const stepKey = (callId: string, stepNumber: number) =>
-  `${callId}:${stepNumber}`;
-
-const serializeJSON = (value: unknown): string => {
-  if (typeof value === "string") return value;
-  try {
-    return JSON.stringify(value);
-  } catch {
-    return "[unserializable]";
-  }
-};
-
-const normalizeProvider = (
-  provider: string | undefined,
-): string | undefined => {
-  if (!provider) return undefined;
-  const head = provider.split(".").shift();
-  return (
-    head?.toLowerCase().trim() || provider.toLowerCase().trim() || undefined
-  );
-};
-
-const applyUsage = (attributes: Record<string, any>, usage: any): void => {
-  if (!usage || typeof usage !== "object") return;
-  if (typeof usage.inputTokens === "number") {
-    attributes[LaminarAttributes.INPUT_TOKEN_COUNT] = usage.inputTokens;
-  }
-  if (typeof usage.outputTokens === "number") {
-    attributes[LaminarAttributes.OUTPUT_TOKEN_COUNT] = usage.outputTokens;
-  }
-  if (typeof usage.totalTokens === "number") {
-    attributes[LaminarAttributes.TOTAL_TOKEN_COUNT] = usage.totalTokens;
-  } else if (
-    typeof usage.inputTokens === "number" ||
-    typeof usage.outputTokens === "number"
-  ) {
-    attributes[LaminarAttributes.TOTAL_TOKEN_COUNT] =
-      (usage.inputTokens ?? 0) + (usage.outputTokens ?? 0);
-  }
-  if (typeof usage.reasoningTokens === "number") {
-    attributes["gen_ai.usage.reasoning_tokens"] = usage.reasoningTokens;
-  } else if (typeof usage.outputTokenDetails?.reasoningTokens === "number") {
-    attributes["gen_ai.usage.reasoning_tokens"] =
-      usage.outputTokenDetails.reasoningTokens;
-  }
-  if (typeof usage.cachedInputTokens === "number") {
-    attributes["gen_ai.usage.cache_read_input_tokens"] =
-      usage.cachedInputTokens;
-  } else if (typeof usage.inputTokenDetails?.cacheReadTokens === "number") {
-    attributes["gen_ai.usage.cache_read_input_tokens"] =
-      usage.inputTokenDetails.cacheReadTokens;
-  }
-  if (typeof usage.inputTokenDetails?.cacheWriteTokens === "number") {
-    attributes["gen_ai.usage.cache_creation_input_tokens"] =
-      usage.inputTokenDetails.cacheWriteTokens;
-  }
-};
-
-// Convert a StandardizedPrompt-shaped object (`system` + `messages`) to an
-// array of `ModelMessage`-like entries. Laminar's backend parses
-// `ai.prompt.messages` as an array of AI SDK messages.
-const standardizedPromptToMessages = (event: {
-  system?: any;
-  messages?: any[];
-}): any[] => {
-  const messages: any[] = [];
-  const sys = event.system;
-  if (typeof sys === "string" && sys.length > 0) {
-    messages.push({ role: "system", content: sys });
-  } else if (Array.isArray(sys)) {
-    for (const m of sys) messages.push(m);
-  } else if (sys && typeof sys === "object") {
-    messages.push(sys);
-  }
-  if (Array.isArray(event.messages)) {
-    for (const m of event.messages) messages.push(m);
-  }
-  return messages;
-};
-
-// Build a concise `ai.response.toolCalls`-shaped array from v7 `toolCalls`.
-const normalizeToolCalls = (toolCalls: any[] | undefined): any[] => {
-  if (!Array.isArray(toolCalls)) return [];
-  return toolCalls.map((tc) => ({
-    toolCallType: "function",
-    toolCallId: tc?.toolCallId,
-    toolName: tc?.toolName,
-    args:
-      typeof tc?.input === "string" ? tc.input : serializeJSON(tc?.input ?? {}),
-  }));
-};
-
-const extractTextFromContent = (content: any[] | undefined): string => {
-  if (!Array.isArray(content)) return "";
-  return content
-    .filter((p) => p && p.type === "text" && typeof p.text === "string")
-    .map((p) => p.text as string)
-    .join("");
-};
-
-const extractReasoningFromContent = (content: any[] | undefined): string => {
-  if (!Array.isArray(content)) return "";
-  return content
-    .filter((p) => p && p.type === "reasoning" && typeof p.text === "string")
-    .map((p) => p.text as string)
-    .join("");
-};
-
-export interface LaminarTelemetryOptions {
+export interface LaminarAiSdkTelemetryOptions {
   /**
    * When true, record prompt messages and response content on spans.
    * Defaults to true.
@@ -205,7 +88,7 @@ export interface LaminarTelemetryOptions {
  * `Telemetry` interface from `ai` so users can pick up the integration even
  * when they are on a narrower `ai` version that doesn't export it yet.
  */
-export class LaminarTelemetry {
+export class LaminarAiSdkTelemetry {
   private readonly recordInputs: boolean;
   private readonly recordOutputs: boolean;
 
@@ -225,7 +108,7 @@ export class LaminarTelemetry {
   // stepNumber themselves.
   private readonly activeStreamStepByCallId = new Map<string, number>();
 
-  constructor(options: LaminarTelemetryOptions = {}) {
+  constructor(options: LaminarAiSdkTelemetryOptions = {}) {
     this.recordInputs = options.recordInputs ?? true;
     this.recordOutputs = options.recordOutputs ?? true;
   }
@@ -414,25 +297,28 @@ export class LaminarTelemetry {
       const toolCallsRaw = content
         ? content.filter((p: any) => p && p.type === "tool-call")
         : [];
-      const normalizedToolCalls = normalizeToolCalls(toolCallsRaw);
+      const normalizedToolCallsList = normalizeToolCalls(toolCallsRaw);
 
       if (text.length > 0) {
         span.setAttribute("ai.response.text", text);
         span.setAttribute(SPAN_OUTPUT, text);
       }
-      if (normalizedToolCalls.length > 0) {
+      if (normalizedToolCallsList.length > 0) {
         span.setAttribute(
           "ai.response.toolCalls",
-          serializeJSON(normalizedToolCalls),
+          serializeJSON(normalizedToolCallsList),
         );
         if (text.length === 0) {
-          span.setAttribute(SPAN_OUTPUT, serializeJSON(normalizedToolCalls));
+          span.setAttribute(
+            SPAN_OUTPUT,
+            serializeJSON(normalizedToolCallsList),
+          );
         }
       }
 
       // OTel GenAI semconv `gen_ai.output.messages` — rendered by the Laminar
       // UI with a Thinking label when `type: "thinking"` is present.
-      if (reasoningText.length > 0 || normalizedToolCalls.length > 0) {
+      if (reasoningText.length > 0 || normalizedToolCallsList.length > 0) {
         const parts: any[] = [];
         if (reasoningText.length > 0) {
           parts.push({ type: "thinking", content: reasoningText });
@@ -440,7 +326,7 @@ export class LaminarTelemetry {
         if (text.length > 0) {
           parts.push({ type: "text", content: text });
         }
-        for (const tc of normalizedToolCalls) {
+        for (const tc of normalizedToolCallsList) {
           let argsObj: unknown = tc.args;
           if (typeof argsObj === "string") {
             try {
@@ -560,12 +446,12 @@ export class LaminarTelemetry {
         outputPayload.text = event.text;
         step.span.setAttribute("ai.response.text", event.text);
       }
-      const normalizedToolCalls = normalizeToolCalls(event.toolCalls);
-      if (normalizedToolCalls.length > 0) {
-        outputPayload.toolCalls = normalizedToolCalls;
+      const normalizedToolCallsList = normalizeToolCalls(event.toolCalls);
+      if (normalizedToolCallsList.length > 0) {
+        outputPayload.toolCalls = normalizedToolCallsList;
         step.span.setAttribute(
           "ai.response.toolCalls",
-          serializeJSON(normalizedToolCalls),
+          serializeJSON(normalizedToolCallsList),
         );
       }
       if (Object.keys(outputPayload).length > 0) {
@@ -831,9 +717,9 @@ export class LaminarTelemetry {
         op.span.setAttribute("ai.response.text", event.text);
         op.span.setAttribute(SPAN_OUTPUT, event.text);
       }
-      const normalizedToolCalls = normalizeToolCalls(event.toolCalls);
-      if (normalizedToolCalls.length > 0) {
-        const serialized = serializeJSON(normalizedToolCalls);
+      const normalizedToolCallsList = normalizeToolCalls(event.toolCalls);
+      if (normalizedToolCallsList.length > 0) {
+        const serialized = serializeJSON(normalizedToolCallsList);
         op.span.setAttribute("ai.response.toolCalls", serialized);
         // Fall back to serialized tool calls for SPAN_OUTPUT when text is
         // empty — mirrors `onLanguageModelCallEnd` so tool-call-only
@@ -1008,25 +894,6 @@ export class LaminarTelemetry {
   }
 }
 
-const compareHrTime = (a: HrTime, b: HrTime): number => {
-  if (a[0] !== b[0]) return a[0] - b[0];
-  return a[1] - b[1];
-};
-
-// LaminarSpan wraps an SDK Span and copies `endTime` in its constructor (before
-// `end()` was called), so reading it from the wrapper yields the stale
-// `[0, 0]` snapshot. The underlying `_span` (an SDK span) mutates its own
-// `endTime` on `end()`, which is what we need. Probe both fields defensively
-// so exotic Span implementations still degrade gracefully.
-const readSpanEndTime = (span: Span): HrTime | undefined => {
-  const inner = (span as unknown as { _span?: { endTime?: HrTime } })._span;
-  const innerEnd = inner?.endTime;
-  if (innerEnd && (innerEnd[0] !== 0 || innerEnd[1] !== 0)) return innerEnd;
-  const outerEnd = (span as unknown as { endTime?: HrTime }).endTime;
-  if (outerEnd && (outerEnd[0] !== 0 || outerEnd[1] !== 0)) return outerEnd;
-  return undefined;
-};
-
 /**
  * Returns a Laminar `Telemetry` integration instance. Pass it to
  * `experimental_telemetry.integrations` on any AI SDK v7 generate/stream/
@@ -1047,9 +914,9 @@ const readSpanEndTime = (span: Span): HrTime | undefined => {
  * });
  * ```
  */
-export const laminarTelemetry = (
-  options?: LaminarTelemetryOptions,
-): LaminarTelemetry => new LaminarTelemetry(options);
+export const aiSdkTelemetry = (
+  options?: LaminarAiSdkTelemetryOptions,
+): LaminarAiSdkTelemetry => new LaminarAiSdkTelemetry(options);
 
 /**
  * Registers a Laminar `Telemetry` integration as a global receiver for every
@@ -1060,10 +927,10 @@ export const laminarTelemetry = (
  * of `ai` — callers often want to register telemetry before the first
  * provider call and must not pay the cost of eagerly loading the AI SDK.
  */
-export const registerLaminarTelemetry = (
-  options?: LaminarTelemetryOptions,
-): LaminarTelemetry => {
-  const integration = new LaminarTelemetry(options);
+export const registerAiSdkTelemetry = (
+  options?: LaminarAiSdkTelemetryOptions,
+): LaminarAiSdkTelemetry => {
+  const integration = new LaminarAiSdkTelemetry(options);
   const g = globalThis as unknown as {
     AI_SDK_TELEMETRY_INTEGRATIONS?: unknown[];
   };
@@ -1081,7 +948,7 @@ export const registerLaminarTelemetry = (
  *
  * Returns an unsubscribe function.
  */
-export const enableLaminarTelemetryDebug = (
+export const enableAiSdkTelemetryDebug = (
   log: (entry: { type: string; event: unknown }) => void = (e) =>
     console.log("[aisdk:telemetry]", e.type, e.event),
 ): (() => void) => {

--- a/packages/lmnr/src/opentelemetry-lib/instrumentation/aisdk/v7-integration/types.ts
+++ b/packages/lmnr/src/opentelemetry-lib/instrumentation/aisdk/v7-integration/types.ts
@@ -1,0 +1,29 @@
+import type { Context, Span } from "@opentelemetry/api";
+
+export interface OperationState {
+  span: Span;
+  ctx: Context;
+  operationId?: string;
+  provider?: string;
+  modelId?: string;
+}
+
+export interface StepState {
+  span: Span;
+  ctx: Context;
+  stepNumber: number;
+}
+
+export interface LlmState {
+  span: Span;
+  textDeltas: string[];
+}
+
+export interface ToolState {
+  span: Span;
+  ctx: Context;
+  callId: string;
+}
+
+export const stepKey = (callId: string, stepNumber: number): string =>
+  `${callId}:${stepNumber}`;

--- a/packages/lmnr/src/opentelemetry-lib/instrumentation/aisdk/v7-integration/utils.ts
+++ b/packages/lmnr/src/opentelemetry-lib/instrumentation/aisdk/v7-integration/utils.ts
@@ -1,0 +1,132 @@
+import type { HrTime, Span } from "@opentelemetry/api";
+
+import { LaminarAttributes } from "../../../tracing/attributes";
+
+export const serializeJSON = (value: unknown): string => {
+  if (typeof value === "string") return value;
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return "[unserializable]";
+  }
+};
+
+export const normalizeProvider = (
+  provider: string | undefined,
+): string | undefined => {
+  if (!provider) return undefined;
+  const head = provider.split(".").shift();
+  return (
+    head?.toLowerCase().trim() || provider.toLowerCase().trim() || undefined
+  );
+};
+
+export const applyUsage = (
+  attributes: Record<string, any>,
+  usage: any,
+): void => {
+  if (!usage || typeof usage !== "object") return;
+  if (typeof usage.inputTokens === "number") {
+    attributes[LaminarAttributes.INPUT_TOKEN_COUNT] = usage.inputTokens;
+  }
+  if (typeof usage.outputTokens === "number") {
+    attributes[LaminarAttributes.OUTPUT_TOKEN_COUNT] = usage.outputTokens;
+  }
+  if (typeof usage.totalTokens === "number") {
+    attributes[LaminarAttributes.TOTAL_TOKEN_COUNT] = usage.totalTokens;
+  } else if (
+    typeof usage.inputTokens === "number" ||
+    typeof usage.outputTokens === "number"
+  ) {
+    attributes[LaminarAttributes.TOTAL_TOKEN_COUNT] =
+      (usage.inputTokens ?? 0) + (usage.outputTokens ?? 0);
+  }
+  if (typeof usage.reasoningTokens === "number") {
+    attributes["gen_ai.usage.reasoning_tokens"] = usage.reasoningTokens;
+  } else if (typeof usage.outputTokenDetails?.reasoningTokens === "number") {
+    attributes["gen_ai.usage.reasoning_tokens"] =
+      usage.outputTokenDetails.reasoningTokens;
+  }
+  if (typeof usage.cachedInputTokens === "number") {
+    attributes["gen_ai.usage.cache_read_input_tokens"] =
+      usage.cachedInputTokens;
+  } else if (typeof usage.inputTokenDetails?.cacheReadTokens === "number") {
+    attributes["gen_ai.usage.cache_read_input_tokens"] =
+      usage.inputTokenDetails.cacheReadTokens;
+  }
+  if (typeof usage.inputTokenDetails?.cacheWriteTokens === "number") {
+    attributes["gen_ai.usage.cache_creation_input_tokens"] =
+      usage.inputTokenDetails.cacheWriteTokens;
+  }
+};
+
+// Convert a StandardizedPrompt-shaped object (`system` + `messages`) to an
+// array of `ModelMessage`-like entries. Laminar's backend parses
+// `ai.prompt.messages` as an array of AI SDK messages.
+export const standardizedPromptToMessages = (event: {
+  system?: any;
+  messages?: any[];
+}): any[] => {
+  const messages: any[] = [];
+  const sys = event.system;
+  if (typeof sys === "string" && sys.length > 0) {
+    messages.push({ role: "system", content: sys });
+  } else if (Array.isArray(sys)) {
+    for (const m of sys) messages.push(m);
+  } else if (sys && typeof sys === "object") {
+    messages.push(sys);
+  }
+  if (Array.isArray(event.messages)) {
+    for (const m of event.messages) messages.push(m);
+  }
+  return messages;
+};
+
+// Build a concise `ai.response.toolCalls`-shaped array from v7 `toolCalls`.
+export const normalizeToolCalls = (toolCalls: any[] | undefined): any[] => {
+  if (!Array.isArray(toolCalls)) return [];
+  return toolCalls.map((tc) => ({
+    toolCallType: "function",
+    toolCallId: tc?.toolCallId,
+    toolName: tc?.toolName,
+    args:
+      typeof tc?.input === "string" ? tc.input : serializeJSON(tc?.input ?? {}),
+  }));
+};
+
+export const extractTextFromContent = (content: any[] | undefined): string => {
+  if (!Array.isArray(content)) return "";
+  return content
+    .filter((p) => p && p.type === "text" && typeof p.text === "string")
+    .map((p) => p.text as string)
+    .join("");
+};
+
+export const extractReasoningFromContent = (
+  content: any[] | undefined,
+): string => {
+  if (!Array.isArray(content)) return "";
+  return content
+    .filter((p) => p && p.type === "reasoning" && typeof p.text === "string")
+    .map((p) => p.text as string)
+    .join("");
+};
+
+export const compareHrTime = (a: HrTime, b: HrTime): number => {
+  if (a[0] !== b[0]) return a[0] - b[0];
+  return a[1] - b[1];
+};
+
+// LaminarSpan wraps an SDK Span and copies `endTime` in its constructor (before
+// `end()` was called), so reading it from the wrapper yields the stale
+// `[0, 0]` snapshot. The underlying `_span` (an SDK span) mutates its own
+// `endTime` on `end()`, which is what we need. Probe both fields defensively
+// so exotic Span implementations still degrade gracefully.
+export const readSpanEndTime = (span: Span): HrTime | undefined => {
+  const inner = (span as unknown as { _span?: { endTime?: HrTime } })._span;
+  const innerEnd = inner?.endTime;
+  if (innerEnd && (innerEnd[0] !== 0 || innerEnd[1] !== 0)) return innerEnd;
+  const outerEnd = (span as unknown as { endTime?: HrTime }).endTime;
+  if (outerEnd && (outerEnd[0] !== 0 || outerEnd[1] !== 0)) return outerEnd;
+  return undefined;
+};

--- a/packages/lmnr/test/aisdk-v7-telemetry.test.ts
+++ b/packages/lmnr/test/aisdk-v7-telemetry.test.ts
@@ -11,9 +11,9 @@ import {
 } from "../src/opentelemetry-lib/configuration";
 import { wrapAISDK } from "../src/opentelemetry-lib/instrumentation/aisdk";
 import {
-  LaminarTelemetry,
-  laminarTelemetry,
-  registerLaminarTelemetry,
+  aiSdkTelemetry,
+  LaminarAiSdkTelemetry,
+  registerAiSdkTelemetry,
 } from "../src/opentelemetry-lib/instrumentation/aisdk/v7-integration";
 import {
   SPAN_INPUT,
@@ -159,7 +159,7 @@ void describe("AI SDK v7 LaminarTelemetry integration", () => {
   });
 
   void it("creates operation → step → llm span tree for generateText", () => {
-    const tel = new LaminarTelemetry();
+    const tel = new LaminarAiSdkTelemetry();
     const callId = "call-1";
 
     tel.onStart(mkStartEvent(callId));
@@ -213,7 +213,7 @@ void describe("AI SDK v7 LaminarTelemetry integration", () => {
   });
 
   void it("makes tool spans flat siblings of llm under the step", () => {
-    const tel = new LaminarTelemetry();
+    const tel = new LaminarAiSdkTelemetry();
     const callId = "call-2";
 
     tel.onStart(mkStartEvent(callId));
@@ -311,7 +311,7 @@ void describe("AI SDK v7 LaminarTelemetry integration", () => {
   });
 
   void it("propagates tool span as parent for nested generateText (sub-agent)", async () => {
-    const tel = new LaminarTelemetry();
+    const tel = new LaminarAiSdkTelemetry();
     const outerCallId = "outer-1";
     const innerCallId = "inner-1";
 
@@ -390,7 +390,7 @@ void describe("AI SDK v7 LaminarTelemetry integration", () => {
   });
 
   void it("records tool-error status when toolOutput is tool-error", () => {
-    const tel = new LaminarTelemetry();
+    const tel = new LaminarAiSdkTelemetry();
     const callId = "call-err";
 
     tel.onStart(mkStartEvent(callId));
@@ -420,7 +420,7 @@ void describe("AI SDK v7 LaminarTelemetry integration", () => {
   });
 
   void it("creates a single LLM span for embed", () => {
-    const tel = new LaminarTelemetry();
+    const tel = new LaminarAiSdkTelemetry();
     const callId = "embed-1";
 
     tel.onStart({
@@ -456,7 +456,7 @@ void describe("AI SDK v7 LaminarTelemetry integration", () => {
   });
 
   void it("records reasoning text via gen_ai.output.messages", () => {
-    const tel = new LaminarTelemetry();
+    const tel = new LaminarAiSdkTelemetry();
     const callId = "call-think";
 
     tel.onStart(mkStartEvent(callId));
@@ -487,16 +487,16 @@ void describe("AI SDK v7 LaminarTelemetry integration", () => {
   });
 
   void it("factory helpers create independent integrations", () => {
-    const a = laminarTelemetry();
-    const b = laminarTelemetry();
+    const a = aiSdkTelemetry();
+    const b = aiSdkTelemetry();
     assert.notEqual(a, b);
-    assert.ok(a instanceof LaminarTelemetry);
+    assert.ok(a instanceof LaminarAiSdkTelemetry);
   });
 
   void it("registerLaminarTelemetry appends to globalThis.AI_SDK_TELEMETRY_INTEGRATIONS", () => {
     const g = globalThis as { AI_SDK_TELEMETRY_INTEGRATIONS?: unknown[] };
     const before = g.AI_SDK_TELEMETRY_INTEGRATIONS?.length ?? 0;
-    const integration = registerLaminarTelemetry();
+    const integration = registerAiSdkTelemetry();
     assert.ok(Array.isArray(g.AI_SDK_TELEMETRY_INTEGRATIONS));
     assert.equal(g.AI_SDK_TELEMETRY_INTEGRATIONS.length, before + 1);
     assert.ok(g.AI_SDK_TELEMETRY_INTEGRATIONS.includes(integration));
@@ -529,14 +529,14 @@ void describe("AI SDK v7 LaminarTelemetry integration", () => {
       assert.ok(Array.isArray(firstCall.telemetry.integrations));
       assert.ok(
         firstCall.telemetry.integrations.some(
-          (i) => i instanceof LaminarTelemetry,
+          (i) => i instanceof LaminarAiSdkTelemetry,
         ),
       );
     },
   );
 
   void it("onError scopes error to the callId on the event", () => {
-    const tel = new LaminarTelemetry();
+    const tel = new LaminarAiSdkTelemetry();
     tel.onStart(mkStartEvent("call-A"));
     tel.onStart(mkStartEvent("call-B"));
 
@@ -559,7 +559,7 @@ void describe("AI SDK v7 LaminarTelemetry integration", () => {
   });
 
   void it("onError doesn't flag other ops when no callId and multiple in-flight", () => {
-    const tel = new LaminarTelemetry();
+    const tel = new LaminarAiSdkTelemetry();
     tel.onStart(mkStartEvent("call-X"));
     tel.onStart(mkStartEvent("call-Y"));
 
@@ -577,7 +577,7 @@ void describe("AI SDK v7 LaminarTelemetry integration", () => {
   });
 
   void it("onError closes step/llm/tool child spans for the errored callId", () => {
-    const tel = new LaminarTelemetry();
+    const tel = new LaminarAiSdkTelemetry();
     const callId = "call-leaky";
     tel.onStart(mkStartEvent(callId));
     tel.onStepStart(mkStepStartEvent(callId, 0));
@@ -603,7 +603,7 @@ void describe("AI SDK v7 LaminarTelemetry integration", () => {
   });
 
   void it("onFinish closes orphaned tool spans for the callId", () => {
-    const tel = new LaminarTelemetry();
+    const tel = new LaminarAiSdkTelemetry();
     const callId = "call-tool-orphan";
     tel.onStart(mkStartEvent(callId));
     tel.onStepStart(mkStepStartEvent(callId, 0));
@@ -624,7 +624,7 @@ void describe("AI SDK v7 LaminarTelemetry integration", () => {
   });
 
   void it("onFinish ends orphan children before the parent operation span", () => {
-    const tel = new LaminarTelemetry();
+    const tel = new LaminarAiSdkTelemetry();
     const callId = "call-order";
     tel.onStart(mkStartEvent(callId));
     tel.onStepStart(mkStepStartEvent(callId, 0));
@@ -662,7 +662,7 @@ void describe("AI SDK v7 LaminarTelemetry integration", () => {
   });
 
   void it("onError ends orphan tool spans before their parent step span", () => {
-    const tel = new LaminarTelemetry();
+    const tel = new LaminarAiSdkTelemetry();
     const callId = "call-error-order";
     tel.onStart(mkStartEvent(callId));
     tel.onStepStart(mkStepStartEvent(callId, 0));
@@ -688,7 +688,7 @@ void describe("AI SDK v7 LaminarTelemetry integration", () => {
   });
 
   void it("onFinish falls back SPAN_OUTPUT to tool calls when text is empty", () => {
-    const tel = new LaminarTelemetry();
+    const tel = new LaminarAiSdkTelemetry();
     const callId = "call-tool-only";
     tel.onStart(mkStartEvent(callId));
     tel.onFinish(
@@ -717,7 +717,7 @@ void describe("AI SDK v7 LaminarTelemetry integration", () => {
   });
 
   void it("onFinish honors finishReason === 'error' and marks the op ERROR", () => {
-    const tel = new LaminarTelemetry();
+    const tel = new LaminarAiSdkTelemetry();
     const callId = "call-finish-error";
     tel.onStart(mkStartEvent(callId));
     tel.onFinish(mkFinish(callId, { finishReason: "error" }));
@@ -730,7 +730,7 @@ void describe("AI SDK v7 LaminarTelemetry integration", () => {
   });
 
   void it("applies cache write and read tokens from v6+ inputTokenDetails", () => {
-    const tel = new LaminarTelemetry();
+    const tel = new LaminarAiSdkTelemetry();
     const callId = "call-cache";
 
     tel.onStart(mkStartEvent(callId));
@@ -769,7 +769,7 @@ void describe("AI SDK v7 LaminarTelemetry integration", () => {
   });
 
   void it("accumulates streaming text-delta chunks via firstChunk/finish lifecycle markers", () => {
-    const tel = new LaminarTelemetry();
+    const tel = new LaminarAiSdkTelemetry();
     const callId = "call-stream";
 
     tel.onStart(mkStartEvent(callId, { operationId: "ai.streamText" }));
@@ -808,7 +808,7 @@ void describe("AI SDK v7 LaminarTelemetry integration", () => {
   });
 
   void it("drops text-delta chunks that arrive without a preceding firstChunk marker", () => {
-    const tel = new LaminarTelemetry();
+    const tel = new LaminarAiSdkTelemetry();
     const callId = "call-stream-no-marker";
 
     tel.onStart(mkStartEvent(callId, { operationId: "ai.streamText" }));
@@ -834,7 +834,7 @@ void describe("AI SDK v7 LaminarTelemetry integration", () => {
     // fires while A is still active, a naive LIFO pick would push A's
     // subsequent deltas into B's buffer. The integration must instead
     // decline to attribute deltas while the owner is ambiguous.
-    const tel = new LaminarTelemetry();
+    const tel = new LaminarAiSdkTelemetry();
     const callA = "call-concurrent-a";
     const callB = "call-concurrent-b";
 
@@ -902,7 +902,7 @@ void describe("AI SDK v7 LaminarTelemetry integration", () => {
     // gen_ai.request.model (REQUEST_MODEL) + gen_ai.response.model
     // (RESPONSE_MODEL) for model-routing and cost analytics; object-gen
     // spans must carry both, matching onLanguageModelCallEnd parity.
-    const tel = new LaminarTelemetry();
+    const tel = new LaminarAiSdkTelemetry();
     const callId = "call-object";
 
     tel.onStart(mkStartEvent(callId, { operationId: "ai.generateObject" }));


### PR DESCRIPTION
The renames are not-critical, because there has not been a release since last merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk due to public API renames/relocated exports for the AI SDK v7 telemetry integration, which can break downstream imports despite mostly refactor-only logic changes.
> 
> **Overview**
> Renames and re-exports the AI SDK v7 telemetry integration under clearer names: `LaminarTelemetry`/`laminarTelemetry`/`registerLaminarTelemetry`/`enableLaminarTelemetryDebug` become `LaminarAiSdkTelemetry`/`aiSdkTelemetry`/`registerAiSdkTelemetry`/`enableAiSdkTelemetryDebug`, and `wrapAISDK` now injects `aiSdkTelemetry()`.
> 
> Splits the previously monolithic v7 integration implementation by extracting shared helpers into new `v7-integration/utils.ts` and state types into `v7-integration/types.ts`, and updates tests to match the new names and import paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8afa927436a7551ad4dff5878cfa527045b99c9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->