### PR TITLE
bump to 0.8.25 for dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@lmnr-ai/lmnr-ts",
   "private": true,
-  "version": "0.8.24",
+  "version": "0.8.25",
   "description": "Laminar AI TypeScript SDK",
   "scripts": {
     "build": "pnpm -r build",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lmnr-ai/client",
-  "version": "0.8.24",
+  "version": "0.8.25",
   "description": "HTTP client for Laminar AI API",
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",

--- a/packages/lmnr/package.json
+++ b/packages/lmnr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lmnr-ai/lmnr",
-  "version": "0.8.24",
+  "version": "0.8.25",
   "description": "TypeScript SDK for Laminar AI",
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lmnr-ai/types",
-  "version": "0.8.24",
+  "version": "0.8.25",
   "description": "Shared types for Laminar AI SDK",
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Only bumps the package versions across the monorepo; no runtime code or dependency changes are included.
> 
> **Overview**
> Updates the published version from `0.8.24` to `0.8.25` across the root package and the `@lmnr-ai/client`, `@lmnr-ai/lmnr`, and `@lmnr-ai/types` packages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39a5a1277b321d396586e2a1e09f2312286eb93e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->