### PR TITLE
feat(cli): debug session set-name + trace set-note + session summary commands (LAM-1672)

### DIFF
--- a/packages/client/src/resources/rollout-sessions.ts
+++ b/packages/client/src/resources/rollout-sessions.ts
@@ -44,6 +44,33 @@ export class RolloutSessionsResource extends BaseResource {
     }
   }
 
+  /**
+   * Rename an existing debug session. Update-only: the backend returns 404 (and
+   * this throws) when the session id is unknown for the project, so a mistyped
+   * id surfaces as an error rather than silently creating a session. Creation
+   * stays the SDK's job via {@link register}.
+   */
+  public async setName({
+    sessionId,
+    name,
+  }: {
+    sessionId: string;
+    name: string;
+  }): Promise<void> {
+    const response = await fetch(
+      `${this.baseHttpUrl}/v1/rollouts/${sessionId}/name`,
+      {
+        method: "PATCH",
+        headers: this.headers(),
+        body: JSON.stringify({ name }),
+      },
+    );
+
+    if (!response.ok) {
+      await this.handleError(response);
+    }
+  }
+
   public async delete({
     sessionId,
   }: {

--- a/packages/client/src/resources/traces.ts
+++ b/packages/client/src/resources/traces.ts
@@ -30,13 +30,16 @@ export class TracesResource extends BaseResource {
    *
    * A 404 response (the trace was not found in the project — typically because
    * it has not been flushed yet) is logged as a warning and the call returns
-   * without throwing; any other non-OK status throws.
+   * without throwing, since the 404 may be expected when pushing too soon
+   * after the trace run. Pass `failOnNotFound: true` to throw instead (e.g.
+   * CLI callers that must report the failure). Any other non-OK status throws.
    *
    * @param traceId - The trace id to push metadata to. Accepts a UUID string
    *   or a 32-char OTel hex trace id.
    * @param metadata - The metadata patch. Top-level keys are merged into the
    *   trace's existing metadata. Must be non-empty (the server rejects empty
    *   patches with 400).
+   * @param options - `failOnNotFound`: throw on 404 instead of warn-and-return.
    * @example
    * ```typescript
    * import { Laminar, observe, LaminarClient } from "@lmnr-ai/lmnr";
@@ -61,6 +64,7 @@ export class TracesResource extends BaseResource {
   public async pushMetadata(
     traceId: string,
     metadata: Record<string, unknown>,
+    options?: { failOnNotFound?: boolean },
   ): Promise<void> {
     if (!metadata || Object.keys(metadata).length === 0) {
       throw new Error("metadata must be a non-empty object");
@@ -81,12 +85,15 @@ export class TracesResource extends BaseResource {
     });
 
     if (response.status === 404) {
+      const message =
+        `Trace ${formattedTraceId} not found. The trace may not have been ` +
+        "flushed yet — call await Laminar.flush() and retry.";
+      if (options?.failOnNotFound) {
+        throw new Error(message);
+      }
       // Trace not found in this project — likely not flushed yet. Don't throw,
       // but surface a warning so callers debugging an empty patch see it.
-      logger.warn(
-        `Trace ${formattedTraceId} not found. The trace may not have been ` +
-          "flushed yet — call await Laminar.flush() and retry.",
-      );
+      logger.warn(message);
       return;
     }
 

--- a/packages/client/test/traces-resource.test.ts
+++ b/packages/client/test/traces-resource.test.ts
@@ -59,6 +59,19 @@ void describe("TracesResource Client Methods", () => {
       scope.done();
     });
 
+    void it("throws on 404 when failOnNotFound is set", async () => {
+      const traceId = "12345678-1234-5678-9abc-123456789abc";
+      const scope = nock(baseUrl)
+        .post("/v1/traces/metadata")
+        .reply(404, "Trace not found");
+
+      await assert.rejects(
+        () => client.traces.pushMetadata(traceId, { k: "v" }, { failOnNotFound: true }),
+        /not found/,
+      );
+      scope.done();
+    });
+
     void it("throws on non-OK statuses other than 404", async () => {
       const traceId = "12345678-1234-5678-9abc-123456789abc";
       const scope = nock(baseUrl)

--- a/packages/lmnr-cli/src/commands/debug/index.test.ts
+++ b/packages/lmnr-cli/src/commands/debug/index.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockQuery = vi.fn();
+const mockSetName = vi.fn();
+
+vi.mock('@lmnr-ai/client', () => ({
+  LaminarClient: class {
+    sql = { query: mockQuery };
+    rolloutSessions = { setName: mockSetName };
+  },
+}));
+
+import { handleDebugSessionSummary } from './index';
+
+const baseOpts = { projectApiKey: 'fake-key', baseUrl: 'http://localhost', port: 8080 };
+const SESSION_ID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+const NOTE_KEY = 'rollout.note';
+
+const traceRow = (id: string, endTime: string, note?: string) => ({
+  id,
+  end_time: endTime,
+  metadata: JSON.stringify({
+    'rollout.session_id': SESSION_ID,
+    ...(note === undefined ? {} : { [NOTE_KEY]: note }),
+  }),
+});
+
+let logSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  vi.spyOn(process, 'exit').mockImplementation((code?) => {
+    throw new Error(`process.exit(${code})`);
+  });
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('handleDebugSessionSummary', () => {
+  it('prints note + trace tag blocks in text mode', async () => {
+    mockQuery.mockResolvedValue([
+      traceRow('trace-1', '2026-06-01T10:00:00.000Z', 'first run note'),
+      traceRow('trace-2', '2026-06-01T11:00:00.000Z', 'second run note'),
+    ]);
+
+    await handleDebugSessionSummary(SESSION_ID, baseOpts);
+
+    expect(logSpy).toHaveBeenCalledWith(
+      'first run note\n<trace id="trace-1" end-time="2026-06-01T10:00:00.000Z"/>' +
+        '\n\n' +
+        'second run note\n<trace id="trace-2" end-time="2026-06-01T11:00:00.000Z"/>',
+    );
+  });
+
+  it('prints only the trace tag when a trace has no note', async () => {
+    mockQuery.mockResolvedValue([traceRow('trace-1', '2026-06-01T10:00:00.000Z')]);
+
+    await handleDebugSessionSummary(SESSION_ID, baseOpts);
+
+    expect(logSpy).toHaveBeenCalledWith(
+      '<trace id="trace-1" end-time="2026-06-01T10:00:00.000Z"/>',
+    );
+  });
+
+  it('outputs an array of {note, traceId, endTime} in json mode', async () => {
+    mockQuery.mockResolvedValue([
+      traceRow('trace-1', '2026-06-01T10:00:00.000Z', 'a note'),
+      traceRow('trace-2', '2026-06-01T11:00:00.000Z'),
+    ]);
+
+    await handleDebugSessionSummary(SESSION_ID, { ...baseOpts, json: true });
+
+    expect(logSpy).toHaveBeenCalledWith(JSON.stringify([
+      { note: 'a note', traceId: 'trace-1', endTime: '2026-06-01T10:00:00.000Z' },
+      { note: '', traceId: 'trace-2', endTime: '2026-06-01T11:00:00.000Z' },
+    ]));
+  });
+
+  it('filters by session id and orders chronologically', async () => {
+    mockQuery.mockResolvedValue([]);
+
+    await handleDebugSessionSummary(SESSION_ID, { ...baseOpts, json: true });
+
+    const [sql, params] = mockQuery.mock.calls[0];
+    expect(sql).toContain("simpleJSONExtractString(metadata, 'rollout.session_id')");
+    expect(sql).toContain('ORDER BY start_time');
+    expect(sql).toContain('formatDateTime(end_time');
+    expect(params).toMatchObject({ session_id: SESSION_ID });
+  });
+
+  it('pages through results larger than one page', async () => {
+    const page = Array.from({ length: 1000 }, (_, i) =>
+      traceRow(`trace-${i}`, '2026-06-01T10:00:00.000Z'),
+    );
+    mockQuery
+      .mockResolvedValueOnce(page)
+      .mockResolvedValueOnce([traceRow('trace-last', '2026-06-01T11:00:00.000Z')]);
+
+    await handleDebugSessionSummary(SESSION_ID, { ...baseOpts, json: true });
+
+    expect(mockQuery).toHaveBeenCalledTimes(2);
+    expect(mockQuery.mock.calls[1][1]).toMatchObject({ offset: 1000 });
+    const output = JSON.parse(String(logSpy.mock.calls[0][0])) as unknown[];
+    expect(output).toHaveLength(1001);
+  });
+
+  it('prints a friendly message for an empty session in text mode', async () => {
+    mockQuery.mockResolvedValue([]);
+
+    await handleDebugSessionSummary(SESSION_ID, baseOpts);
+
+    expect(logSpy).toHaveBeenCalledWith(`No traces found for session ${SESSION_ID}.`);
+  });
+
+  it('outputs [] for an empty session in json mode', async () => {
+    mockQuery.mockResolvedValue([]);
+
+    await handleDebugSessionSummary(SESSION_ID, { ...baseOpts, json: true });
+
+    expect(logSpy).toHaveBeenCalledWith('[]');
+  });
+
+  it('exits 1 with a JSON error in json mode on query failure', async () => {
+    mockQuery.mockRejectedValue(new Error('boom'));
+
+    await expect(handleDebugSessionSummary(SESSION_ID, { ...baseOpts, json: true }))
+      .rejects.toThrow('process.exit(1)');
+    expect(logSpy).toHaveBeenCalledWith(JSON.stringify({ error: 'boom' }));
+  });
+});

--- a/packages/lmnr-cli/src/commands/debug/index.ts
+++ b/packages/lmnr-cli/src/commands/debug/index.ts
@@ -3,6 +3,7 @@ import { errorMessage } from "@lmnr-ai/types";
 
 import { initializeLogger } from "../../utils/logger";
 import { outputJson, outputJsonError } from "../../utils/output";
+import { readNoteFromMetadata } from "../../utils/trace-note";
 
 const logger = initializeLogger();
 
@@ -40,6 +41,81 @@ export const handleDebugSessionSetName = async (
   } catch (error) {
     if (options.json) outputJsonError(error);
     logger.error(`Failed to set session name: ${errorMessage(error)}`);
+    process.exit(1);
+  }
+};
+
+const SUMMARY_PAGE_SIZE = 1000;
+
+interface SessionTraceSummary {
+  note: string;
+  traceId: string;
+  // Trace `end_time` — the closest thing to "last updated" on a trace (it
+  // advances as spans keep arriving for the trace).
+  endTime: string;
+}
+
+/**
+ * Print a per-trace summary of a debug session: every trace whose metadata
+ * groups it to the session (`rollout.session_id`), oldest first, with the
+ * agent-authored note (`rollout.note`) attached to each.
+ */
+export const handleDebugSessionSummary = async (
+  sessionId: string,
+  options: DebugCommandOptions,
+): Promise<void> => {
+  const client = new LaminarClient({
+    projectApiKey: options.projectApiKey,
+    baseUrl: options.baseUrl,
+    port: options.port,
+  });
+
+  try {
+    const traces: SessionTraceSummary[] = [];
+    let offset = 0;
+    for (;;) {
+      // formatDateTime pins end_time to unambiguous ISO-8601 UTC — the raw
+      // column serializes as ClickHouse's space-separated local-looking format.
+      const rows = await client.sql.query(
+        "SELECT id, " +
+          "formatDateTime(end_time, '%Y-%m-%dT%H:%i:%S.%fZ') AS end_time, " +
+          "metadata FROM traces " +
+          "WHERE simpleJSONExtractString(metadata, 'rollout.session_id') " +
+          "= {session_id:String} " +
+          "ORDER BY start_time LIMIT {limit:UInt32} OFFSET {offset:UInt32}",
+        { session_id: sessionId, limit: SUMMARY_PAGE_SIZE, offset },
+      );
+      for (const row of rows) {
+        traces.push({
+          note: readNoteFromMetadata(row.metadata),
+          traceId: String(row.id ?? ""),
+          endTime: String(row.end_time ?? ""),
+        });
+      }
+      if (rows.length < SUMMARY_PAGE_SIZE) {
+        break;
+      }
+      offset += SUMMARY_PAGE_SIZE;
+    }
+
+    if (options.json) {
+      outputJson(traces);
+      return;
+    }
+
+    if (traces.length === 0) {
+      console.log(`No traces found for session ${sessionId}.`);
+      return;
+    }
+
+    const blocks = traces.map((trace) => {
+      const tag = `<trace id="${trace.traceId}" end-time="${trace.endTime}"/>`;
+      return trace.note ? `${trace.note}\n${tag}` : tag;
+    });
+    console.log(blocks.join("\n\n"));
+  } catch (error) {
+    if (options.json) outputJsonError(error);
+    logger.error(`Failed to summarize session: ${errorMessage(error)}`);
     process.exit(1);
   }
 };

--- a/packages/lmnr-cli/src/commands/debug/index.ts
+++ b/packages/lmnr-cli/src/commands/debug/index.ts
@@ -1,0 +1,45 @@
+import { LaminarClient } from "@lmnr-ai/client";
+import { errorMessage } from "@lmnr-ai/types";
+
+import { initializeLogger } from "../../utils/logger";
+import { outputJson, outputJsonError } from "../../utils/output";
+
+const logger = initializeLogger();
+
+interface DebugCommandOptions {
+  projectApiKey?: string;
+  baseUrl?: string;
+  port?: number;
+  json?: boolean;
+}
+
+/**
+ * Upsert the display name of a debug session. Update-only on the backend: a
+ * session id unknown to the project 404s rather than creating a ghost session.
+ */
+export const handleDebugSessionSetName = async (
+  sessionId: string,
+  name: string,
+  options: DebugCommandOptions,
+): Promise<void> => {
+  const client = new LaminarClient({
+    projectApiKey: options.projectApiKey,
+    baseUrl: options.baseUrl,
+    port: options.port,
+  });
+
+  try {
+    await client.rolloutSessions.setName({ sessionId, name });
+
+    if (options.json) {
+      outputJson({ sessionId, name });
+      return;
+    }
+
+    logger.info(`Set name of session ${sessionId} to "${name}".`);
+  } catch (error) {
+    if (options.json) outputJsonError(error);
+    logger.error(`Failed to set session name: ${errorMessage(error)}`);
+    process.exit(1);
+  }
+};

--- a/packages/lmnr-cli/src/commands/trace/index.test.ts
+++ b/packages/lmnr-cli/src/commands/trace/index.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockQuery = vi.fn();
+const mockPushMetadata = vi.fn();
+
+vi.mock('@lmnr-ai/client', () => ({
+  LaminarClient: class {
+    sql = { query: mockQuery };
+    traces = { pushMetadata: mockPushMetadata };
+  },
+}));
+
+import { handleTraceAppendNote } from './index';
+
+const baseOpts = { projectApiKey: 'fake-key', baseUrl: 'http://localhost', port: 8080 };
+const TRACE_ID = '01234567-89ab-cdef-0123-456789abcdef';
+const NOTE_KEY = 'rollout.note';
+
+let logSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  vi.spyOn(process, 'exit').mockImplementation((code?) => {
+    throw new Error(`process.exit(${code})`);
+  });
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('handleTraceAppendNote', () => {
+  it('sets the note as-is when the trace has no existing note', async () => {
+    mockQuery.mockResolvedValue([{ metadata: JSON.stringify({}) }]);
+
+    await handleTraceAppendNote(TRACE_ID, 'first note', baseOpts);
+
+    expect(mockPushMetadata).toHaveBeenCalledWith(TRACE_ID, { [NOTE_KEY]: 'first note' });
+  });
+
+  it('appends to an existing note with a blank-line separator', async () => {
+    mockQuery.mockResolvedValue([
+      { metadata: JSON.stringify({ [NOTE_KEY]: 'first note' }) },
+    ]);
+
+    await handleTraceAppendNote(TRACE_ID, 'second note', baseOpts);
+
+    expect(mockPushMetadata).toHaveBeenCalledWith(TRACE_ID, {
+      [NOTE_KEY]: 'first note\n\nsecond note',
+    });
+  });
+
+  it('normalizes a 32-char OTel hex trace id', async () => {
+    mockQuery.mockResolvedValue([{ metadata: '{}' }]);
+
+    await handleTraceAppendNote('0123456789abcdef0123456789abcdef', 'note', baseOpts);
+
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.stringContaining('SELECT metadata FROM traces'),
+      { trace_id: TRACE_ID },
+    );
+    expect(mockPushMetadata).toHaveBeenCalledWith(TRACE_ID, { [NOTE_KEY]: 'note' });
+  });
+
+  it('outputs the full updated note in json mode', async () => {
+    mockQuery.mockResolvedValue([
+      { metadata: JSON.stringify({ [NOTE_KEY]: 'a' }) },
+    ]);
+
+    await handleTraceAppendNote(TRACE_ID, 'b', { ...baseOpts, json: true });
+
+    expect(logSpy).toHaveBeenCalledWith(
+      JSON.stringify({ traceId: TRACE_ID, note: 'a\n\nb' }),
+    );
+  });
+
+  it('errors when the trace does not exist', async () => {
+    mockQuery.mockResolvedValue([]);
+
+    await expect(handleTraceAppendNote(TRACE_ID, 'note', baseOpts))
+      .rejects.toThrow('process.exit(1)');
+    expect(mockPushMetadata).not.toHaveBeenCalled();
+  });
+
+  it('errors on an invalid trace id without querying', async () => {
+    await expect(handleTraceAppendNote('garbage', 'note', baseOpts))
+      .rejects.toThrow('process.exit(1)');
+    expect(mockQuery).not.toHaveBeenCalled();
+    expect(mockPushMetadata).not.toHaveBeenCalled();
+  });
+});

--- a/packages/lmnr-cli/src/commands/trace/index.test.ts
+++ b/packages/lmnr-cli/src/commands/trace/index.test.ts
@@ -36,7 +36,11 @@ describe('handleTraceAppendNote', () => {
 
     await handleTraceAppendNote(TRACE_ID, 'first note', baseOpts);
 
-    expect(mockPushMetadata).toHaveBeenCalledWith(TRACE_ID, { [NOTE_KEY]: 'first note' });
+    expect(mockPushMetadata).toHaveBeenCalledWith(
+      TRACE_ID,
+      { [NOTE_KEY]: 'first note' },
+      { failOnNotFound: true },
+    );
   });
 
   it('appends to an existing note with a blank-line separator', async () => {
@@ -46,9 +50,11 @@ describe('handleTraceAppendNote', () => {
 
     await handleTraceAppendNote(TRACE_ID, 'second note', baseOpts);
 
-    expect(mockPushMetadata).toHaveBeenCalledWith(TRACE_ID, {
-      [NOTE_KEY]: 'first note\n\nsecond note',
-    });
+    expect(mockPushMetadata).toHaveBeenCalledWith(
+      TRACE_ID,
+      { [NOTE_KEY]: 'first note\n\nsecond note' },
+      { failOnNotFound: true },
+    );
   });
 
   it('normalizes a 32-char OTel hex trace id', async () => {
@@ -60,7 +66,11 @@ describe('handleTraceAppendNote', () => {
       expect.stringContaining('SELECT metadata FROM traces'),
       { trace_id: TRACE_ID },
     );
-    expect(mockPushMetadata).toHaveBeenCalledWith(TRACE_ID, { [NOTE_KEY]: 'note' });
+    expect(mockPushMetadata).toHaveBeenCalledWith(
+      TRACE_ID,
+      { [NOTE_KEY]: 'note' },
+      { failOnNotFound: true },
+    );
   });
 
   it('outputs the full updated note in json mode', async () => {

--- a/packages/lmnr-cli/src/commands/trace/index.ts
+++ b/packages/lmnr-cli/src/commands/trace/index.ts
@@ -3,13 +3,13 @@ import { errorMessage } from "@lmnr-ai/types";
 
 import { initializeLogger } from "../../utils/logger";
 import { outputJson, outputJsonError } from "../../utils/output";
+import {
+  normalizeTraceId,
+  NOTE_METADATA_KEY,
+  readNoteFromMetadata,
+} from "../../utils/trace-note";
 
 const logger = initializeLogger();
-
-// Trace-metadata key the debugger UI reads the agent's note from. Metadata
-// naming stays `rollout.*` (matching `rollout.session_id`); the value is an
-// opaque string the frontend renders as markdown.
-const NOTE_METADATA_KEY = "rollout.note";
 
 interface TraceCommandOptions {
   projectApiKey?: string;
@@ -18,12 +18,29 @@ interface TraceCommandOptions {
   json?: boolean;
 }
 
+// Separator between appended note entries. The note is rendered as markdown,
+// so a blank line keeps each appended entry its own paragraph.
+const NOTE_SEPARATOR = "\n\n";
+
 /**
- * Upsert a free-text note onto an existing trace. Stored under the
- * `rollout.note` trace-metadata key via the post-factum metadata patch endpoint
- * (last-write-wins). The note may contain markdown / span-reference links.
+ * Append a free-text note to an existing trace. Stored under the
+ * `rollout.note` trace-metadata key via the post-factum metadata patch
+ * endpoint. The patch endpoint is last-write-wins per key, so the current
+ * note is read back first (via the SQL endpoint) and the new text is pushed
+ * as `existing + "\n\n" + note`. The note may contain markdown /
+ * span-reference links.
+ *
+ * The read-modify-write is not transactional: the patch lands via the async
+ * ingestion queue, so a second append issued within ~a second of the first
+ * can read the pre-patch note and drop the first append. Fine for the
+ * intended cadence (one note per investigation step), not for concurrent
+ * writers.
+ *
+ * TODO: revisit — make the append atomic server-side (e.g. an append mode on
+ * the metadata patch endpoint that concatenates within the Postgres UPDATE,
+ * which already serializes on the trace row lock).
  */
-export const handleTraceSetNote = async (
+export const handleTraceAppendNote = async (
   traceId: string,
   note: string,
   options: TraceCommandOptions,
@@ -35,17 +52,32 @@ export const handleTraceSetNote = async (
   });
 
   try {
-    await client.traces.pushMetadata(traceId, { [NOTE_METADATA_KEY]: note });
+    const id = normalizeTraceId(traceId);
+
+    const rows = await client.sql.query(
+      "SELECT metadata FROM traces WHERE id = {trace_id:UUID} LIMIT 1",
+      { trace_id: id },
+    );
+    if (rows.length === 0) {
+      throw new Error(
+        `Trace ${id} not found. If the run just finished, the trace may not ` +
+          "be flushed yet. Retry in a few seconds.",
+      );
+    }
+
+    const existing = readNoteFromMetadata(rows[0].metadata);
+    const updated = existing ? `${existing}${NOTE_SEPARATOR}${note}` : note;
+    await client.traces.pushMetadata(id, { [NOTE_METADATA_KEY]: updated });
 
     if (options.json) {
-      outputJson({ traceId, note });
+      outputJson({ traceId: id, note: updated });
       return;
     }
 
-    logger.info(`Set note on trace ${traceId}.`);
+    logger.info(`Appended note to trace ${id}.`);
   } catch (error) {
     if (options.json) outputJsonError(error);
-    logger.error(`Failed to set trace note: ${errorMessage(error)}`);
+    logger.error(`Failed to append trace note: ${errorMessage(error)}`);
     process.exit(1);
   }
 };

--- a/packages/lmnr-cli/src/commands/trace/index.ts
+++ b/packages/lmnr-cli/src/commands/trace/index.ts
@@ -67,7 +67,13 @@ export const handleTraceAppendNote = async (
 
     const existing = readNoteFromMetadata(rows[0].metadata);
     const updated = existing ? `${existing}${NOTE_SEPARATOR}${note}` : note;
-    await client.traces.pushMetadata(id, { [NOTE_METADATA_KEY]: updated });
+    // failOnNotFound: the SQL pre-read can race a trace deletion, and a CLI
+    // exit 0 must mean the note actually landed.
+    await client.traces.pushMetadata(
+      id,
+      { [NOTE_METADATA_KEY]: updated },
+      { failOnNotFound: true },
+    );
 
     if (options.json) {
       outputJson({ traceId: id, note: updated });

--- a/packages/lmnr-cli/src/commands/trace/index.ts
+++ b/packages/lmnr-cli/src/commands/trace/index.ts
@@ -1,0 +1,51 @@
+import { LaminarClient } from "@lmnr-ai/client";
+import { errorMessage } from "@lmnr-ai/types";
+
+import { initializeLogger } from "../../utils/logger";
+import { outputJson, outputJsonError } from "../../utils/output";
+
+const logger = initializeLogger();
+
+// Trace-metadata key the debugger UI reads the agent's note from. Metadata
+// naming stays `rollout.*` (matching `rollout.session_id`); the value is an
+// opaque string the frontend renders as markdown.
+const NOTE_METADATA_KEY = "rollout.note";
+
+interface TraceCommandOptions {
+  projectApiKey?: string;
+  baseUrl?: string;
+  port?: number;
+  json?: boolean;
+}
+
+/**
+ * Upsert a free-text note onto an existing trace. Stored under the
+ * `rollout.note` trace-metadata key via the post-factum metadata patch endpoint
+ * (last-write-wins). The note may contain markdown / span-reference links.
+ */
+export const handleTraceSetNote = async (
+  traceId: string,
+  note: string,
+  options: TraceCommandOptions,
+): Promise<void> => {
+  const client = new LaminarClient({
+    projectApiKey: options.projectApiKey,
+    baseUrl: options.baseUrl,
+    port: options.port,
+  });
+
+  try {
+    await client.traces.pushMetadata(traceId, { [NOTE_METADATA_KEY]: note });
+
+    if (options.json) {
+      outputJson({ traceId, note });
+      return;
+    }
+
+    logger.info(`Set note on trace ${traceId}.`);
+  } catch (error) {
+    if (options.json) outputJsonError(error);
+    logger.error(`Failed to set trace note: ${errorMessage(error)}`);
+    process.exit(1);
+  }
+};

--- a/packages/lmnr-cli/src/index.ts
+++ b/packages/lmnr-cli/src/index.ts
@@ -10,8 +10,10 @@ import {
   handleDatasetsPull,
   handleDatasetsPush,
 } from "./commands/dataset";
+import { handleDebugSessionSetName } from "./commands/debug";
 import { handleSqlQuery } from "./commands/sql";
 import { SQL_SCHEMA_HELP } from "./commands/sql/schema";
+import { handleTraceSetNote } from "./commands/trace";
 
 async function main() {
   const program = new Command();
@@ -181,6 +183,78 @@ Examples:
       process.stdout.write(SQL_SCHEMA_HELP);
     });
 
+  const traceCmd = program
+    .command("trace")
+    .description("Operate on existing traces")
+    .option(
+      "--project-api-key <key>",
+      "Project API key. If not provided, reads from LMNR_PROJECT_API_KEY env variable",
+    )
+    .option(
+      "--base-url <url>",
+      "Base URL for the Laminar API. Defaults to https://api.lmnr.ai or LMNR_BASE_URL env variable",
+    )
+    .option(
+      "--port <port>",
+      "Port for the Laminar API. Defaults to 443",
+      (val) => parseInt(val, 10),
+    )
+    .option("--json", "Output structured JSON to stdout");
+
+  traceCmd
+    .command("set-note")
+    .description("Upsert a free-text note on a trace (stored in trace metadata)")
+    .argument("<trace-id>", "Trace ID (UUID or 32-char OTel hex trace id)")
+    .argument("<note>", "Note text (may contain markdown)")
+    .action(async (traceId: string, note: string, _options, cmd) => {
+      await handleTraceSetNote(traceId, note, cmd.optsWithGlobals());
+    })
+    .addHelpText(
+      "after",
+      `
+Examples:
+  $ lmnr-cli trace set-note <trace-id> "Reproduced the timeout on the search tool."
+`,
+    );
+
+  const debugCmd = program
+    .command("debug")
+    .description("Operate on debug sessions")
+    .option(
+      "--project-api-key <key>",
+      "Project API key. If not provided, reads from LMNR_PROJECT_API_KEY env variable",
+    )
+    .option(
+      "--base-url <url>",
+      "Base URL for the Laminar API. Defaults to https://api.lmnr.ai or LMNR_BASE_URL env variable",
+    )
+    .option(
+      "--port <port>",
+      "Port for the Laminar API. Defaults to 443",
+      (val) => parseInt(val, 10),
+    )
+    .option("--json", "Output structured JSON to stdout");
+
+  const debugSessionCmd = debugCmd
+    .command("session")
+    .description("Manage debug sessions");
+
+  debugSessionCmd
+    .command("set-name")
+    .description("Set the display name of a debug session")
+    .argument("<session-id>", "Debug session ID")
+    .argument("<name>", "Session display name")
+    .action(async (sessionId: string, name: string, _options, cmd) => {
+      await handleDebugSessionSetName(sessionId, name, cmd.optsWithGlobals());
+    })
+    .addHelpText(
+      "after",
+      `
+Examples:
+  $ lmnr-cli debug session set-name <session-id> "Fix report length + search tool"
+`,
+    );
+
   program.addHelpText(
     "after",
     `
@@ -197,6 +271,8 @@ Examples:
   lmnr-cli sql query "SELECT * FROM spans LIMIT 10" --json # Query spans
   lmnr-cli sql query "SELECT t.id, s.name FROM traces t JOIN spans s ON t.id = s.trace_id" --json
   lmnr-cli sql schema                                      # Show available tables
+  lmnr-cli trace set-note <trace-id> "note text"           # Attach a note to a trace
+  lmnr-cli debug session set-name <session-id> "title"     # Rename a debug session
 
 For more information about the Laminar platfrom:
   Documentation: https://laminar.sh/docs

--- a/packages/lmnr-cli/src/index.ts
+++ b/packages/lmnr-cli/src/index.ts
@@ -10,10 +10,10 @@ import {
   handleDatasetsPull,
   handleDatasetsPush,
 } from "./commands/dataset";
-import { handleDebugSessionSetName } from "./commands/debug";
+import { handleDebugSessionSetName, handleDebugSessionSummary } from "./commands/debug";
 import { handleSqlQuery } from "./commands/sql";
 import { SQL_SCHEMA_HELP } from "./commands/sql/schema";
-import { handleTraceSetNote } from "./commands/trace";
+import { handleTraceAppendNote } from "./commands/trace";
 
 async function main() {
   const program = new Command();
@@ -202,18 +202,21 @@ Examples:
     .option("--json", "Output structured JSON to stdout");
 
   traceCmd
-    .command("set-note")
-    .description("Upsert a free-text note on a trace (stored in trace metadata)")
+    .command("append-note")
+    .description("Append a free-text note to a trace (stored in trace metadata)")
     .argument("<trace-id>", "Trace ID (UUID or 32-char OTel hex trace id)")
     .argument("<note>", "Note text (may contain markdown)")
     .action(async (traceId: string, note: string, _options, cmd) => {
-      await handleTraceSetNote(traceId, note, cmd.optsWithGlobals());
+      await handleTraceAppendNote(traceId, note, cmd.optsWithGlobals());
     })
     .addHelpText(
       "after",
       `
+Notes accumulate: each call appends a new paragraph to the trace's existing
+note rather than overwriting it.
+
 Examples:
-  $ lmnr-cli trace set-note <trace-id> "Reproduced the timeout on the search tool."
+  $ lmnr-cli trace append-note <trace-id> "Reproduced the timeout on the search tool."
 `,
     );
 
@@ -255,6 +258,30 @@ Examples:
 `,
     );
 
+  debugSessionCmd
+    .command("summary")
+    .description("Print every trace in a debug session with its note, oldest first")
+    .argument("<session-id>", "Debug session ID")
+    .action(async (sessionId: string, _options, cmd) => {
+      await handleDebugSessionSummary(sessionId, cmd.optsWithGlobals());
+    })
+    .addHelpText(
+      "after",
+      `
+Output is one block per trace (oldest first), the trace's note followed by a
+self-closing tag carrying the trace id and end time:
+
+  {note}
+  <trace id="{trace-id}" end-time="{end-time}"/>
+
+With --json, prints an array of {"note", "traceId", "endTime"} objects.
+
+Examples:
+  $ lmnr-cli debug session summary <session-id>
+  $ lmnr-cli debug session summary <session-id> --json
+`,
+    );
+
   program.addHelpText(
     "after",
     `
@@ -271,8 +298,9 @@ Examples:
   lmnr-cli sql query "SELECT * FROM spans LIMIT 10" --json # Query spans
   lmnr-cli sql query "SELECT t.id, s.name FROM traces t JOIN spans s ON t.id = s.trace_id" --json
   lmnr-cli sql schema                                      # Show available tables
-  lmnr-cli trace set-note <trace-id> "note text"           # Attach a note to a trace
+  lmnr-cli trace append-note <trace-id> "note text"        # Append a note to a trace
   lmnr-cli debug session set-name <session-id> "title"     # Rename a debug session
+  lmnr-cli debug session summary <session-id>              # Notes for each trace in a session
 
 For more information about the Laminar platfrom:
   Documentation: https://laminar.sh/docs

--- a/packages/lmnr-cli/src/index.ts
+++ b/packages/lmnr-cli/src/index.ts
@@ -236,11 +236,23 @@ Examples:
       "Port for the Laminar API. Defaults to 443",
       (val) => parseInt(val, 10),
     )
-    .option("--json", "Output structured JSON to stdout");
+    .option("--json", "Output structured JSON to stdout")
+    .addHelpText(
+      "after",
+      `
+Learn more about debugging features at https://laminar.sh/docs/platform/debugger
+`,
+    );
 
   const debugSessionCmd = debugCmd
     .command("session")
-    .description("Manage debug sessions");
+    .description("Manage debug sessions")
+    .addHelpText(
+      "after",
+      `
+Learn more about debugging features at https://laminar.sh/docs/platform/debugger
+`,
+    );
 
   debugSessionCmd
     .command("set-name")

--- a/packages/lmnr-cli/src/utils/trace-note.test.ts
+++ b/packages/lmnr-cli/src/utils/trace-note.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+
+import { normalizeTraceId, NOTE_METADATA_KEY, readNoteFromMetadata } from './trace-note';
+
+describe('normalizeTraceId', () => {
+  it('passes a dashed UUID through', () => {
+    expect(normalizeTraceId('01234567-89ab-cdef-0123-456789abcdef'))
+      .toBe('01234567-89ab-cdef-0123-456789abcdef');
+  });
+
+  it('lowercases an uppercase UUID', () => {
+    expect(normalizeTraceId('01234567-89AB-CDEF-0123-456789ABCDEF'))
+      .toBe('01234567-89ab-cdef-0123-456789abcdef');
+  });
+
+  it('converts a 32-char OTel hex id to UUID form', () => {
+    expect(normalizeTraceId('0123456789abcdef0123456789abcdef'))
+      .toBe('01234567-89ab-cdef-0123-456789abcdef');
+  });
+
+  it('strips a 0x prefix before converting', () => {
+    expect(normalizeTraceId('0x0123456789abcdef0123456789abcdef'))
+      .toBe('01234567-89ab-cdef-0123-456789abcdef');
+  });
+
+  it('throws on anything else', () => {
+    expect(() => normalizeTraceId('not-a-trace-id')).toThrow(/Invalid trace id/);
+    expect(() => normalizeTraceId('0123')).toThrow(/Invalid trace id/);
+    expect(() => normalizeTraceId('')).toThrow(/Invalid trace id/);
+  });
+});
+
+describe('readNoteFromMetadata', () => {
+  it('reads the note from a JSON-string metadata column', () => {
+    const metadata = JSON.stringify({ [NOTE_METADATA_KEY]: 'hello', other: 'x' });
+    expect(readNoteFromMetadata(metadata)).toBe('hello');
+  });
+
+  it('reads the note from an already-parsed object', () => {
+    expect(readNoteFromMetadata({ [NOTE_METADATA_KEY]: 'hello' })).toBe('hello');
+  });
+
+  it('returns empty string when the key is absent', () => {
+    expect(readNoteFromMetadata(JSON.stringify({ other: 'x' }))).toBe('');
+  });
+
+  it('returns empty string for empty / null / malformed metadata', () => {
+    expect(readNoteFromMetadata('')).toBe('');
+    expect(readNoteFromMetadata(null)).toBe('');
+    expect(readNoteFromMetadata(undefined)).toBe('');
+    expect(readNoteFromMetadata('{not json')).toBe('');
+    expect(readNoteFromMetadata(42)).toBe('');
+  });
+
+  it('returns empty string when the note value is not a string', () => {
+    expect(readNoteFromMetadata(JSON.stringify({ [NOTE_METADATA_KEY]: 7 }))).toBe('');
+  });
+});

--- a/packages/lmnr-cli/src/utils/trace-note.ts
+++ b/packages/lmnr-cli/src/utils/trace-note.ts
@@ -1,0 +1,49 @@
+// Trace-metadata key the debugger UI reads the agent's note from. Metadata
+// naming stays `rollout.*` (matching `rollout.session_id`); the value is an
+// opaque string the frontend renders as markdown.
+export const NOTE_METADATA_KEY = "rollout.note";
+
+/**
+ * Normalize a user-supplied trace id (UUID or 32-char OTel hex, optionally
+ * 0x-prefixed) to the dashed UUID form used by the SQL endpoint. Throws on
+ * anything else so a typo fails loudly instead of querying nothing.
+ */
+export const normalizeTraceId = (traceId: string): string => {
+  const id = traceId.trim().toLowerCase().replace(/^0x/, "");
+  if (/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/.test(id)) {
+    return id;
+  }
+  if (/^[0-9a-f]{32}$/.test(id)) {
+    return id.replace(
+      /^([0-9a-f]{8})([0-9a-f]{4})([0-9a-f]{4})([0-9a-f]{4})([0-9a-f]{12})$/,
+      "$1-$2-$3-$4-$5",
+    );
+  }
+  throw new Error(
+    `Invalid trace id "${traceId}". Expected a UUID or a 32-char OTel hex trace id.`,
+  );
+};
+
+/**
+ * Extract the note from a trace's `metadata` column as returned by the SQL
+ * endpoint (a JSON string; tolerate an already-parsed object too). Missing /
+ * malformed metadata reads as "no note".
+ */
+export const readNoteFromMetadata = (metadata: unknown): string => {
+  let parsed: unknown = metadata;
+  if (typeof metadata === "string") {
+    if (metadata === "") {
+      return "";
+    }
+    try {
+      parsed = JSON.parse(metadata);
+    } catch {
+      return "";
+    }
+  }
+  if (typeof parsed !== "object" || parsed === null) {
+    return "";
+  }
+  const note = (parsed as Record<string, unknown>)[NOTE_METADATA_KEY];
+  return typeof note === "string" ? note : "";
+};


### PR DESCRIPTION
## What

Two agent-facing CLI commands for annotating debug sessions, plus the client method one needs.

- **`lmnr-cli debug session set-name <session-id> <name>`** — renames a debug session. Backed by a new `RolloutSessionsResource.setName({ sessionId, name })` that calls the **update-only** `PATCH /v1/rollouts/{id}/name` (404s on an unknown id rather than ghost-creating; creation stays the SDK's job via `register`).
- **`lmnr-cli trace set-note <trace-id> <note>`** — attaches a markdown note to a trace via the existing post-factum metadata endpoint (`traces.pushMetadata`), stored under the `rollout.note` metadata key.

Both follow the existing `<resource> <verb>` CLI convention, global auth flags (`--project-api-key` / `--base-url` / `--port` / `--json`), and output/logger patterns.

## Notes
- The backend `PATCH /v1/rollouts/{id}/name` route lives in the app-server PR (lmnr repo).
- Verified end-to-end against a local app-server: a subagent discovered `set-note` from `--help` alone and attached a markdown note; `set-name` renamed a session and correctly 404'd on an unknown id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New CLI and client HTTP helpers only; note append uses a documented non-transactional read-modify-write with no auth or ingestion pipeline changes.
> 
> **Overview**
> Adds **agent-facing CLI** commands for debug workflows, backed by small **client** extensions.
> 
> The **client** gains `rolloutSessions.setName` (`PATCH /v1/rollouts/{id}/name`, update-only / 404 on unknown sessions) and an optional `failOnNotFound` flag on `traces.pushMetadata` so CLI callers can treat a missing trace as a hard error instead of warn-and-return.
> 
> **`lmnr-cli trace append-note`** reads the current `rollout.note` via SQL, concatenates with a blank-line separator, and patches metadata (with `failOnNotFound`). **`debug session set-name`** renames a session via the new client method. **`debug session summary`** pages through traces for a `rollout.session_id`, emitting each note plus a `<trace id="…" end-time="…"/>` tag (or JSON). Shared helpers normalize trace IDs and parse notes from metadata; tests cover handlers and utilities.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 425304fb7cd31bf7fa65fd00409e2297264c23d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->