### PR TITLE
extend support to aisdk v7 / provider v4

### DIFF
--- a/packages/lmnr/package.json
+++ b/packages/lmnr/package.json
@@ -88,6 +88,7 @@
     "@ai-sdk/openai": "^3.0.1",
     "@ai-sdk/provider": "^3.0.0",
     "@ai-sdk/provider-v2": "npm:@ai-sdk/provider@2.0.0",
+    "@ai-sdk/provider-v4-canary": "npm:@ai-sdk/provider@4.0.0-canary.17",
     "@aws-sdk/client-bedrock-runtime": "^3.1057.0",
     "@azure/openai": "^2.0.0",
     "@google/genai": "^2.0.0",

--- a/packages/lmnr/src/opentelemetry-lib/instrumentation/aisdk/base-language-model.ts
+++ b/packages/lmnr/src/opentelemetry-lib/instrumentation/aisdk/base-language-model.ts
@@ -20,10 +20,25 @@ import {
   type SharedV2Headers,
   type SharedV2ProviderMetadata,
 } from "@ai-sdk/provider-v2";
+import {
+  type LanguageModelV4,
+  type LanguageModelV4CallOptions,
+  type LanguageModelV4Content,
+  type LanguageModelV4FinishReason,
+  type LanguageModelV4ResponseMetadata,
+  type LanguageModelV4Usage,
+  type SharedV4Headers,
+  type SharedV4ProviderMetadata,
+  type SharedV4Warning,
+} from "@ai-sdk/provider-v4-canary";
 import { CachedSpan } from "@lmnr-ai/types";
 
 import { awaitCacheReady } from "../../../debug/index";
-import { cachedPayloadFor, markSpanCached, replayEnabled } from "../../../debug/replay";
+import {
+  cachedPayloadFor,
+  markSpanCached,
+  replayEnabled,
+} from "../../../debug/replay";
 import { Laminar } from "../../../laminar";
 
 /**
@@ -32,12 +47,19 @@ import { Laminar } from "../../../laminar";
  * Uses method overloads for type safety across versions.
  */
 export abstract class BaseLaminarLanguageModel {
-  protected readonly innerLanguageModel: LanguageModelV2 | LanguageModelV3;
+  protected readonly innerLanguageModel:
+    | LanguageModelV2
+    | LanguageModelV3
+    | LanguageModelV4;
   readonly provider: string;
   readonly modelId: string;
-  readonly supportedUrls: PromiseLike<Record<string, RegExp[]>> | Record<string, RegExp[]>;
+  readonly supportedUrls:
+    | PromiseLike<Record<string, RegExp[]>>
+    | Record<string, RegExp[]>;
 
-  constructor(languageModel: LanguageModelV2 | LanguageModelV3) {
+  constructor(
+    languageModel: LanguageModelV2 | LanguageModelV3 | LanguageModelV4,
+  ) {
     this.innerLanguageModel = languageModel;
     this.provider = languageModel.provider;
     this.modelId = languageModel.modelId;
@@ -48,16 +70,24 @@ export abstract class BaseLaminarLanguageModel {
    * Creates a version-specific usage object.
    * V2 and V3 have different usage structures, so this must be implemented by subclasses.
    */
-  protected abstract createUsageObject(): LanguageModelV2Usage | LanguageModelV3Usage;
+  protected abstract createUsageObject():
+    | LanguageModelV2Usage
+    | LanguageModelV3Usage
+    | LanguageModelV4Usage;
 
   /**
    * Creates a version-specific stream from cached response data.
    * V2 and V3 have different stream part types, so this must be implemented by subclasses.
    */
   protected abstract createStreamFromCachedResponse(
-    content: Array<LanguageModelV2Content | LanguageModelV3Content>,
-    finishReason: LanguageModelV2FinishReason | LanguageModelV3FinishReason,
-    usage: LanguageModelV2Usage | LanguageModelV3Usage
+    content: Array<
+      LanguageModelV2Content | LanguageModelV3Content | LanguageModelV4Content
+    >,
+    finishReason:
+      | LanguageModelV2FinishReason
+      | LanguageModelV3FinishReason
+      | LanguageModelV4FinishReason,
+    usage: LanguageModelV2Usage | LanguageModelV3Usage | LanguageModelV4Usage,
   ): ReadableStream<any>;
 
   /**
@@ -71,16 +101,22 @@ export abstract class BaseLaminarLanguageModel {
       usage: LanguageModelV2Usage;
       providerMetadata?: SharedV2ProviderMetadata;
       request?: { body?: unknown };
-      response?: LanguageModelV2ResponseMetadata & { headers?: SharedV2Headers; body?: unknown };
+      response?: LanguageModelV2ResponseMetadata & {
+        headers?: SharedV2Headers;
+        body?: unknown;
+      };
       warnings: Array<LanguageModelV2CallWarning>;
-    }>
+    }>,
   ): PromiseLike<{
     content: Array<LanguageModelV2Content>;
     finishReason: LanguageModelV2FinishReason;
     usage: LanguageModelV2Usage;
     providerMetadata?: SharedV2ProviderMetadata;
     request?: { body?: unknown };
-    response?: LanguageModelV2ResponseMetadata & { headers?: SharedV2Headers; body?: unknown };
+    response?: LanguageModelV2ResponseMetadata & {
+      headers?: SharedV2Headers;
+      body?: unknown;
+    };
     warnings: Array<LanguageModelV2CallWarning>;
   }>;
 
@@ -95,17 +131,53 @@ export abstract class BaseLaminarLanguageModel {
       usage: LanguageModelV3Usage;
       providerMetadata?: SharedV3ProviderMetadata;
       request?: { body?: unknown };
-      response?: LanguageModelV3ResponseMetadata & { headers?: SharedV3Headers; body?: unknown };
+      response?: LanguageModelV3ResponseMetadata & {
+        headers?: SharedV3Headers;
+        body?: unknown;
+      };
       warnings: Array<SharedV3Warning>;
-    }>
+    }>,
   ): PromiseLike<{
     content: Array<LanguageModelV3Content>;
     finishReason: LanguageModelV3FinishReason;
     usage: LanguageModelV3Usage;
     providerMetadata?: SharedV3ProviderMetadata;
     request?: { body?: unknown };
-    response?: LanguageModelV3ResponseMetadata & { headers?: SharedV3Headers; body?: unknown };
+    response?: LanguageModelV3ResponseMetadata & {
+      headers?: SharedV3Headers;
+      body?: unknown;
+    };
     warnings: Array<SharedV3Warning>;
+  }>;
+
+  /**
+   * Main generation method with caching support for V4
+   */
+  protected doGenerateWithCaching(
+    options: LanguageModelV4CallOptions,
+    doGenerateFn: (opts: LanguageModelV4CallOptions) => PromiseLike<{
+      content: Array<LanguageModelV4Content>;
+      finishReason: LanguageModelV4FinishReason;
+      usage: LanguageModelV4Usage;
+      providerMetadata?: SharedV4ProviderMetadata;
+      request?: { body?: unknown };
+      response?: LanguageModelV4ResponseMetadata & {
+        headers?: SharedV4Headers;
+        body?: unknown;
+      };
+      warnings: Array<SharedV4Warning>;
+    }>,
+  ): PromiseLike<{
+    content: Array<LanguageModelV4Content>;
+    finishReason: LanguageModelV4FinishReason;
+    usage: LanguageModelV4Usage;
+    providerMetadata?: SharedV4ProviderMetadata;
+    request?: { body?: unknown };
+    response?: LanguageModelV4ResponseMetadata & {
+      headers?: SharedV4Headers;
+      body?: unknown;
+    };
+    warnings: Array<SharedV4Warning>;
   }>;
 
   /**
@@ -113,13 +185,14 @@ export abstract class BaseLaminarLanguageModel {
    * Consults the in-process replay cache (§G); falls through to the live call.
    */
   protected doGenerateWithCaching(
-    options: LanguageModelV2CallOptions | LanguageModelV3CallOptions,
+    options:
+      | LanguageModelV2CallOptions
+      | LanguageModelV3CallOptions
+      | LanguageModelV4CallOptions,
     doGenerateFn: (opts: any) => PromiseLike<any>,
   ): PromiseLike<any> {
-    return this.doGenerateOrStreamWithCaching(
-      options,
-      doGenerateFn,
-      (cached) => this.cachedDoGenerate(cached),
+    return this.doGenerateOrStreamWithCaching(options, doGenerateFn, (cached) =>
+      this.cachedDoGenerate(cached),
     );
   }
 
@@ -132,7 +205,7 @@ export abstract class BaseLaminarLanguageModel {
       stream: ReadableStream<any>;
       request?: { body?: unknown };
       response?: { headers?: SharedV2Headers };
-    }>
+    }>,
   ): PromiseLike<{
     stream: ReadableStream<any>;
     request?: { body?: unknown };
@@ -148,7 +221,7 @@ export abstract class BaseLaminarLanguageModel {
       stream: ReadableStream<any>;
       request?: { body?: unknown };
       response?: { headers?: SharedV3Headers };
-    }>
+    }>,
   ): PromiseLike<{
     stream: ReadableStream<any>;
     request?: { body?: unknown };
@@ -156,17 +229,34 @@ export abstract class BaseLaminarLanguageModel {
   }>;
 
   /**
+   * Main streaming method with caching support for V4
+   */
+  protected doStreamWithCaching(
+    options: LanguageModelV4CallOptions,
+    doStreamFn: (opts: LanguageModelV4CallOptions) => PromiseLike<{
+      stream: ReadableStream<any>;
+      request?: { body?: unknown };
+      response?: { headers?: SharedV4Headers };
+    }>,
+  ): PromiseLike<{
+    stream: ReadableStream<any>;
+    request?: { body?: unknown };
+    response?: { headers?: SharedV4Headers };
+  }>;
+
+  /**
    * Implementation of doStreamWithCaching
    * Consults the in-process replay cache (§H); falls through to the live call.
    */
   protected doStreamWithCaching(
-    options: LanguageModelV2CallOptions | LanguageModelV3CallOptions,
+    options:
+      | LanguageModelV2CallOptions
+      | LanguageModelV3CallOptions
+      | LanguageModelV4CallOptions,
     doStreamFn: (opts: any) => PromiseLike<any>,
   ): PromiseLike<any> {
-    return this.doGenerateOrStreamWithCaching(
-      options,
-      doStreamFn,
-      (cached) => this.cachedDoStream(cached),
+    return this.doGenerateOrStreamWithCaching(options, doStreamFn, (cached) =>
+      this.cachedDoStream(cached),
     );
   }
 
@@ -179,7 +269,10 @@ export abstract class BaseLaminarLanguageModel {
    * through to the live provider call.
    */
   private async doGenerateOrStreamWithCaching(
-    options: LanguageModelV2CallOptions | LanguageModelV3CallOptions,
+    options:
+      | LanguageModelV2CallOptions
+      | LanguageModelV3CallOptions
+      | LanguageModelV4CallOptions,
     originalFn: (opts: any) => PromiseLike<any>,
     buildFromCached: (cached: CachedSpan) => any,
   ): Promise<any> {
@@ -193,7 +286,8 @@ export abstract class BaseLaminarLanguageModel {
     await awaitCacheReady();
 
     const span = Laminar.getCurrentSpan();
-    const spanPath = Laminar.getLaminarSpanContext()?.spanPath?.join('.') ?? null;
+    const spanPath =
+      Laminar.getLaminarSpanContext()?.spanPath?.join(".") ?? null;
     const cached = cachedPayloadFor(spanPath);
     if (!cached) {
       return originalFn(options);
@@ -204,10 +298,17 @@ export abstract class BaseLaminarLanguageModel {
   }
 
   private cachedDoGenerate(cached: CachedSpan): {
-    content: Array<LanguageModelV2Content | LanguageModelV3Content>;
-    finishReason: LanguageModelV2FinishReason | LanguageModelV3FinishReason;
-    usage: LanguageModelV2Usage | LanguageModelV3Usage;
-    warnings: Array<LanguageModelV2CallWarning | SharedV3Warning>;
+    content: Array<
+      LanguageModelV2Content | LanguageModelV3Content | LanguageModelV4Content
+    >;
+    finishReason:
+      | LanguageModelV2FinishReason
+      | LanguageModelV3FinishReason
+      | LanguageModelV4FinishReason;
+    usage: LanguageModelV2Usage | LanguageModelV3Usage | LanguageModelV4Usage;
+    warnings: Array<
+      LanguageModelV2CallWarning | SharedV3Warning | SharedV4Warning
+    >;
   } {
     return {
       ...this.parseCachedSpan(cached),
@@ -229,9 +330,14 @@ export abstract class BaseLaminarLanguageModel {
    * Reconstructs content blocks, usage, and finish reason from a cached span.
    */
   private parseCachedSpan(cached: CachedSpan): {
-    content: Array<LanguageModelV2Content | LanguageModelV3Content>;
-    finishReason: LanguageModelV2FinishReason | LanguageModelV3FinishReason;
-    usage: LanguageModelV2Usage | LanguageModelV3Usage;
+    content: Array<
+      LanguageModelV2Content | LanguageModelV3Content | LanguageModelV4Content
+    >;
+    finishReason:
+      | LanguageModelV2FinishReason
+      | LanguageModelV3FinishReason
+      | LanguageModelV4FinishReason;
+    usage: LanguageModelV2Usage | LanguageModelV3Usage | LanguageModelV4Usage;
   } {
     let parsedOutput: string | Record<string, any>[] = cached.output;
     try {
@@ -242,62 +348,79 @@ export abstract class BaseLaminarLanguageModel {
 
     const content = this.convertToContentBlocks(parsedOutput);
     const usage = this.createUsageObject();
-    const finishReason = cached.attributes['ai.response.finishReason'] ?? 'stop';
+    const finishReason =
+      cached.attributes["ai.response.finishReason"] ?? "stop";
 
     return { content, usage, finishReason };
   }
 
   /**
-  * Converts output from span to content blocks compatible with both V2 and V3
-  */
+   * Converts output from span to content blocks compatible with both V2 and V3
+   */
   private convertToContentBlocks(
     output: string | Record<string, any>[],
-  ): Array<LanguageModelV3Content | LanguageModelV2Content> {
-    if (typeof output === 'string') {
-      return [{
-        type: 'text',
-        text: output,
-      }];
+  ): Array<
+    LanguageModelV4Content | LanguageModelV3Content | LanguageModelV2Content
+  > {
+    if (typeof output === "string") {
+      return [
+        {
+          type: "text",
+          text: output,
+        },
+      ];
     }
 
-    const handleItem = (item: Record<string, any>): LanguageModelV3Content[] => {
-      if (item.type === 'text') {
-        return [{
-          type: 'text',
-          text: item.text ?? '',
-        }];
+    const handleItem = (
+      item: Record<string, any>,
+    ): LanguageModelV3Content[] => {
+      if (item.type === "text") {
+        return [
+          {
+            type: "text",
+            text: item.text ?? "",
+          },
+        ];
       }
-      if (['tool-call', 'tool_call'].includes(item.type)) {
-        return [{
-          type: 'tool-call',
-          toolCallId: item.toolCallId ?? item.id,
-          toolName: item.toolName ?? item.name,
-          input: JSON.stringify(item.input ?? item.arguments),
-        }];
+      if (["tool-call", "tool_call"].includes(item.type)) {
+        return [
+          {
+            type: "tool-call",
+            toolCallId: item.toolCallId ?? item.id,
+            toolName: item.toolName ?? item.name,
+            input: JSON.stringify(item.input ?? item.arguments),
+          },
+        ];
       }
-      if (item.type === 'reasoning') {
-        return [{
-          type: 'reasoning',
-          text: item.text ?? '',
-        }];
+      if (item.type === "reasoning") {
+        return [
+          {
+            type: "reasoning",
+            text: item.text ?? "",
+          },
+        ];
       }
-      return [{
-        type: 'text',
-        text: JSON.stringify(item),
-      }];
+      return [
+        {
+          type: "text",
+          text: JSON.stringify(item),
+        },
+      ];
     };
 
-    return output.flatMap(item => {
+    return output.flatMap((item) => {
       if (item.role && item.content) {
         let parsedContent: Record<string, any>[] = item.content;
         try {
           parsedContent = JSON.parse(item.content);
         } catch {
-          if (typeof item === 'string') {
-            return [{
-              type: 'text',
-              text: item,
-            }];
+          if (typeof item === "string") {
+            return [
+              {
+                type: "text",
+                text: item,
+              },
+            ];
           }
         }
         return parsedContent.flatMap(handleItem);

--- a/packages/lmnr/src/opentelemetry-lib/instrumentation/aisdk/index.ts
+++ b/packages/lmnr/src/opentelemetry-lib/instrumentation/aisdk/index.ts
@@ -1,10 +1,12 @@
 import { type LanguageModelV3 } from "@ai-sdk/provider";
 import { type LanguageModelV2 } from "@ai-sdk/provider-v2";
+import { type LanguageModelV4 } from "@ai-sdk/provider-v4-canary";
 import type * as AI from "ai";
 
 import { getTracer } from "../../tracing";
 import { LaminarLanguageModelV2 } from "./v2";
 import { LaminarLanguageModelV3 } from "./v3";
+import { LaminarLanguageModelV4 } from "./v4";
 import { aiSdkTelemetry } from "./v7-integration/index";
 
 const AI_FUNCTIONS = [
@@ -80,14 +82,20 @@ export const wrapAISDK = (ai: typeof AI): typeof AI => {
 };
 
 export function wrapLanguageModel(
+  languageModel: LanguageModelV4,
+): LanguageModelV4;
+export function wrapLanguageModel(
   languageModel: LanguageModelV3,
 ): LanguageModelV3;
 export function wrapLanguageModel(
   languageModel: LanguageModelV2,
 ): LanguageModelV2;
 export function wrapLanguageModel(
-  languageModel: LanguageModelV2 | LanguageModelV3,
-): LanguageModelV2 | LanguageModelV3 {
+  languageModel: LanguageModelV2 | LanguageModelV3 | LanguageModelV4,
+): LanguageModelV2 | LanguageModelV3 | LanguageModelV4 {
+  if (languageModel.specificationVersion === "v4") {
+    return new LaminarLanguageModelV4(languageModel);
+  }
   if (languageModel.specificationVersion === "v3") {
     return new LaminarLanguageModelV3(languageModel);
   }

--- a/packages/lmnr/src/opentelemetry-lib/instrumentation/aisdk/v4.ts
+++ b/packages/lmnr/src/opentelemetry-lib/instrumentation/aisdk/v4.ts
@@ -1,0 +1,139 @@
+import {
+  type LanguageModelV4,
+  type LanguageModelV4CallOptions,
+  type LanguageModelV4Content,
+  type LanguageModelV4FinishReason,
+  type LanguageModelV4ResponseMetadata,
+  type LanguageModelV4StreamPart,
+  type LanguageModelV4Usage,
+  type SharedV4Headers,
+  type SharedV4ProviderMetadata,
+  type SharedV4Warning,
+} from "@ai-sdk/provider-v4-canary";
+
+import { BaseLaminarLanguageModel } from "./base-language-model";
+
+export class LaminarLanguageModelV4
+  extends BaseLaminarLanguageModel
+  implements LanguageModelV4
+{
+  readonly specificationVersion = "v4";
+
+  protected readonly innerLanguageModel: LanguageModelV4;
+
+  constructor(languageModel: LanguageModelV4) {
+    super(languageModel);
+    this.innerLanguageModel = languageModel;
+  }
+
+  protected createUsageObject(): LanguageModelV4Usage {
+    return {
+      inputTokens: {
+        total: 0,
+        noCache: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+      },
+      outputTokens: {
+        total: 0,
+        text: 0,
+        reasoning: 0,
+      },
+    };
+  }
+
+  doGenerate(options: LanguageModelV4CallOptions): PromiseLike<{
+    content: Array<LanguageModelV4Content>;
+    finishReason: LanguageModelV4FinishReason;
+    usage: LanguageModelV4Usage;
+    providerMetadata?: SharedV4ProviderMetadata;
+    request?: {
+      body?: unknown;
+    };
+    response?: LanguageModelV4ResponseMetadata & {
+      headers?: SharedV4Headers;
+      body?: unknown;
+    };
+    warnings: Array<SharedV4Warning>;
+  }> {
+    return this.doGenerateWithCaching(options, (opts) =>
+      this.innerLanguageModel.doGenerate(opts),
+    );
+  }
+
+  doStream(options: LanguageModelV4CallOptions): PromiseLike<{
+    stream: ReadableStream<LanguageModelV4StreamPart>;
+    request?: {
+      body?: unknown;
+    };
+    response?: {
+      headers?: SharedV4Headers;
+    };
+  }> {
+    return this.doStreamWithCaching(options, (opts) =>
+      this.innerLanguageModel.doStream(opts),
+    );
+  }
+
+  protected createStreamFromCachedResponse(
+    content: Array<LanguageModelV4Content>,
+    finishReason: LanguageModelV4FinishReason,
+    usage: LanguageModelV4Usage,
+  ): ReadableStream<LanguageModelV4StreamPart> {
+    const parts: LanguageModelV4StreamPart[] = [];
+
+    // Stream start
+    parts.push({ type: "stream-start", warnings: [] });
+
+    // Process each content block
+    let textIndex = 0;
+    let toolIndex = 0;
+    let reasoningIndex = 0;
+
+    for (const block of content) {
+      if (block.type === "text") {
+        const id = `text-${textIndex++}`;
+        parts.push({ type: "text-start", id });
+        parts.push({ type: "text-delta", id, delta: block.text });
+        parts.push({ type: "text-end", id });
+      } else if (block.type === "tool-call") {
+        const id = `tool-${toolIndex++}`;
+        parts.push({
+          type: "tool-input-start",
+          id,
+          toolName: block.toolName,
+        });
+        parts.push({
+          type: "tool-input-delta",
+          id,
+          delta: block.input,
+        });
+        parts.push({ type: "tool-input-end", id });
+        parts.push({
+          type: "tool-call",
+          toolCallId: block.toolCallId,
+          toolName: block.toolName,
+          input: block.input,
+        });
+      } else if (block.type === "reasoning") {
+        const id = `reasoning-${reasoningIndex++}`;
+        parts.push({ type: "reasoning-start", id });
+        parts.push({ type: "reasoning-delta", id, delta: block.text });
+        parts.push({ type: "reasoning-end", id });
+      }
+    }
+
+    // Finish event
+    parts.push({ type: "finish", usage, finishReason });
+
+    // Create readable stream from the parts array
+    return new ReadableStream({
+      start(controller) {
+        for (const part of parts) {
+          controller.enqueue(part);
+        }
+        controller.close();
+      },
+    });
+  }
+}

--- a/packages/lmnr/src/opentelemetry-lib/instrumentation/aisdk/v7-integration/index.ts
+++ b/packages/lmnr/src/opentelemetry-lib/instrumentation/aisdk/v7-integration/index.ts
@@ -52,7 +52,10 @@ import {
   type ToolState,
 } from "./types";
 import {
-  applyUsage,
+  applyFinishReason,
+  applyPromptMessages,
+  applyRequestModelAttributes,
+  applyUsageToSpan,
   compareHrTime,
   extractReasoningFromContent,
   extractTextFromContent,
@@ -60,7 +63,6 @@ import {
   normalizeToolCalls,
   readSpanEndTime,
   serializeJSON,
-  standardizedPromptToMessages,
 } from "./utils";
 
 /* eslint-disable @typescript-eslint/no-unsafe-argument */
@@ -159,12 +161,7 @@ export class LaminarAiSdkTelemetry {
       // generate/stream variants carry StandardizedPrompt (system + messages);
       // embed carries `value`; rerank carries `documents` + `query`.
       if (Array.isArray(event.messages) || event.system !== undefined) {
-        const msgs = standardizedPromptToMessages(event);
-        if (msgs.length > 0) {
-          const serialized = serializeJSON(msgs);
-          span.setAttribute("ai.prompt.messages", serialized);
-          span.setAttribute(SPAN_INPUT, serialized);
-        }
+        applyPromptMessages(span, event);
       } else if (event.value !== undefined) {
         span.setAttribute(SPAN_INPUT, serializeJSON(event.value));
       } else if (event.query !== undefined || event.documents !== undefined) {
@@ -201,12 +198,7 @@ export class LaminarAiSdkTelemetry {
     span.setAttribute("ai.step.number", stepNumber);
 
     if (this.recordInputs) {
-      const msgs = standardizedPromptToMessages(event);
-      if (msgs.length > 0) {
-        const serialized = serializeJSON(msgs);
-        span.setAttribute("ai.prompt.messages", serialized);
-        span.setAttribute(SPAN_INPUT, serialized);
-      }
+      applyPromptMessages(span, event);
     }
 
     this.stepByKey.set(stepKey(callId, stepNumber), {
@@ -235,22 +227,9 @@ export class LaminarAiSdkTelemetry {
       parentCtx,
     );
     span.setAttribute(SPAN_TYPE, "LLM");
-    if (typeof event.provider === "string") {
-      const provider = normalizeProvider(event.provider);
-      if (provider) span.setAttribute(LaminarAttributes.PROVIDER, provider);
-      span.setAttribute("ai.model.provider", event.provider);
-    }
-    if (typeof event.modelId === "string") {
-      span.setAttribute(LaminarAttributes.REQUEST_MODEL, event.modelId);
-      span.setAttribute("ai.model.id", event.modelId);
-    }
+    applyRequestModelAttributes(span, event);
     if (this.recordInputs) {
-      const msgs = standardizedPromptToMessages(event);
-      if (msgs.length > 0) {
-        const serialized = serializeJSON(msgs);
-        span.setAttribute("ai.prompt.messages", serialized);
-        span.setAttribute(SPAN_INPUT, serialized);
-      }
+      applyPromptMessages(span, event);
     }
 
     this.llmByKey.set(stepKey(callId, stepNumber), {
@@ -276,17 +255,12 @@ export class LaminarAiSdkTelemetry {
       span.setAttribute(LaminarAttributes.RESPONSE_MODEL, event.modelId);
     }
     if (typeof event.finishReason === "string") {
-      span.setAttribute("gen_ai.response.finish_reason", event.finishReason);
-      span.setAttribute("ai.response.finishReason", event.finishReason);
+      applyFinishReason(span, event.finishReason);
     }
     if (typeof event.responseId === "string") {
       span.setAttribute("gen_ai.response.id", event.responseId);
     }
-    const usageAttrs: Record<string, any> = {};
-    applyUsage(usageAttrs, event.usage);
-    for (const [k, v] of Object.entries(usageAttrs)) {
-      if (v !== undefined) span.setAttribute(k, v);
-    }
+    applyUsageToSpan(span, event.usage);
 
     if (this.recordOutputs) {
       const content: any[] | undefined = Array.isArray(event.content)
@@ -428,17 +402,9 @@ export class LaminarAiSdkTelemetry {
 
     // Emit per-step usage + finish reason on the step span too, so a step
     // that was interrupted mid-stream still reports correct totals.
-    const attrs: Record<string, any> = {};
-    applyUsage(attrs, event.usage);
-    for (const [k, v] of Object.entries(attrs)) {
-      if (v !== undefined) step.span.setAttribute(k, v);
-    }
+    applyUsageToSpan(step.span, event.usage);
     if (typeof event.finishReason === "string") {
-      step.span.setAttribute(
-        "gen_ai.response.finish_reason",
-        event.finishReason,
-      );
-      step.span.setAttribute("ai.response.finishReason", event.finishReason);
+      applyFinishReason(step.span, event.finishReason);
     }
     if (this.recordOutputs) {
       const outputPayload: Record<string, unknown> = {};
@@ -489,15 +455,7 @@ export class LaminarAiSdkTelemetry {
       op.ctx,
     );
     span.setAttribute(SPAN_TYPE, "LLM");
-    if (typeof event.provider === "string") {
-      const provider = normalizeProvider(event.provider);
-      if (provider) span.setAttribute(LaminarAttributes.PROVIDER, provider);
-      span.setAttribute("ai.model.provider", event.provider);
-    }
-    if (typeof event.modelId === "string") {
-      span.setAttribute(LaminarAttributes.REQUEST_MODEL, event.modelId);
-      span.setAttribute("ai.model.id", event.modelId);
-    }
+    applyRequestModelAttributes(span, event);
     this.llmByKey.set(stepKey(callId, 0), { span, textDeltas: [] });
   };
 
@@ -507,11 +465,7 @@ export class LaminarAiSdkTelemetry {
     const llm = this.llmByKey.get(stepKey(callId, 0));
     if (!llm) return;
     if (typeof event.finishReason === "string") {
-      llm.span.setAttribute(
-        "gen_ai.response.finish_reason",
-        event.finishReason,
-      );
-      llm.span.setAttribute("ai.response.finishReason", event.finishReason);
+      applyFinishReason(llm.span, event.finishReason);
     }
     // GenerateObjectStepEndEvent.response carries { id, modelId, ... } — mirror
     // onLanguageModelCallEnd by emitting gen_ai.response.model +
@@ -529,11 +483,7 @@ export class LaminarAiSdkTelemetry {
         llm.span.setAttribute("gen_ai.response.id", response.id);
       }
     }
-    const attrs: Record<string, any> = {};
-    applyUsage(attrs, event.usage);
-    for (const [k, v] of Object.entries(attrs)) {
-      if (v !== undefined) llm.span.setAttribute(k, v);
-    }
+    applyUsageToSpan(llm.span, event.usage);
     if (this.recordOutputs && typeof event.objectText === "string") {
       llm.span.setAttribute("ai.response.text", event.objectText);
       llm.span.setAttribute(SPAN_OUTPUT, event.objectText);
@@ -664,16 +614,12 @@ export class LaminarAiSdkTelemetry {
     }
   };
 
-  onEmbedFinish = (event: any): void => {
+  onEmbedEnd = (event: any): void => {
     const callId: string | undefined = event?.callId;
     if (!callId) return;
     const op = this.operationByCallId.get(callId);
     if (!op) return;
-    const attrs: Record<string, any> = {};
-    applyUsage(attrs, event.usage);
-    for (const [k, v] of Object.entries(attrs)) {
-      if (v !== undefined) op.span.setAttribute(k, v);
-    }
+    applyUsageToSpan(op.span, event.usage);
   };
 
   onRerankStart = (): void => {
@@ -681,7 +627,7 @@ export class LaminarAiSdkTelemetry {
     // documents/query are already recorded.
   };
 
-  onRerankFinish = (): void => {
+  onRerankEnd = (): void => {
     // End-of-rerank data lands via onFinish which carries the full event.
   };
 
@@ -689,7 +635,7 @@ export class LaminarAiSdkTelemetry {
   // operation finish / error
   // ------------------------------------------------------------------
 
-  onFinish = (event: any): void => {
+  onEnd = (event: any): void => {
     const callId: string | undefined = event?.callId;
     if (!callId) return;
     const op = this.operationByCallId.get(callId);
@@ -699,15 +645,9 @@ export class LaminarAiSdkTelemetry {
     // of recordOutputs — it's not user-content and is what analytics / cost
     // dashboards read off the top-level span.
     if (typeof event.finishReason === "string") {
-      op.span.setAttribute("gen_ai.response.finish_reason", event.finishReason);
-      op.span.setAttribute("ai.response.finishReason", event.finishReason);
+      applyFinishReason(op.span, event.finishReason);
     }
-    const totalUsage = event.totalUsage ?? event.usage;
-    const usageAttrs: Record<string, any> = {};
-    applyUsage(usageAttrs, totalUsage);
-    for (const [k, v] of Object.entries(usageAttrs)) {
-      if (v !== undefined) op.span.setAttribute(k, v);
-    }
+    applyUsageToSpan(op.span, event.totalUsage ?? event.usage);
 
     // Write final output content onto the operation span.
     if (this.recordOutputs) {
@@ -754,10 +694,7 @@ export class LaminarAiSdkTelemetry {
       op.span.setStatus({ code: SpanStatusCode.OK });
     }
 
-    const latestChildEnd = this.endOrphanChildSpansForCallId(callId);
-    op.span.end(latestChildEnd);
-    this.operationByCallId.delete(callId);
-    this.activeStreamStepByCallId.delete(callId);
+    this.closeOperation(callId, op);
   };
 
   onError = (event: any): void => {
@@ -809,15 +746,56 @@ export class LaminarAiSdkTelemetry {
     // leak if `onError` is terminal (no subsequent `onFinish`). If `onFinish`
     // does fire afterwards, its `operationByCallId.get(callId)` returns
     // undefined and it early-returns.
-    const latestChildEnd = this.endOrphanChildSpansForCallId(targetCallId);
-    targetOp.span.end(latestChildEnd);
-    this.operationByCallId.delete(targetCallId);
-    this.activeStreamStepByCallId.delete(targetCallId);
+    this.closeOperation(targetCallId, targetOp);
+  };
+
+  onAbort = (event: any): void => {
+    // Fired when a streaming text generation is aborted (its AbortSignal
+    // fired) before it could finish — so onEnd never arrives and the
+    // operation + child spans would otherwise leak. An abort is a deliberate
+    // cancellation, NOT a failure: the event carries `{ callId, steps,
+    // reason? }` with no error/finishReason, so we leave span status UNSET
+    // (neither OK nor ERROR) and just record an abort marker.
+    const callId: string | undefined = event?.callId;
+    if (!callId) return;
+    const op = this.operationByCallId.get(callId);
+    if (!op) return;
+
+    op.span.setAttribute("ai.response.aborted", true);
+    op.span.addEvent("abort");
+    // The AbortSignal reason is free-form (often a DOMException or string).
+    // Record it as an attribute when present so the cancellation cause is
+    // visible without implying an error status.
+    if (event?.reason !== undefined) {
+      const reason = event.reason;
+      const reasonStr =
+        reason instanceof Error
+          ? reason.message
+          : typeof reason === "string"
+            ? reason
+            : serializeJSON(reason);
+      if (reasonStr.length > 0) {
+        op.span.setAttribute("ai.response.abortReason", reasonStr);
+      }
+    }
+
+    // Close orphan child spans (llm / step / tool — flushing any buffered
+    // stream deltas) BEFORE the operation span so children never end after
+    // their parent, then clamp the op endTime to the latest child endTime.
+    this.closeOperation(callId, op);
   };
 
   // ------------------------------------------------------------------
   // helpers
   // ------------------------------------------------------------------
+
+  /** End child spans, end the operation span, and clean up both maps. */
+  private closeOperation(callId: string, op: OperationState): void {
+    const latestChildEnd = this.endOrphanChildSpansForCallId(callId);
+    op.span.end(latestChildEnd);
+    this.operationByCallId.delete(callId);
+    this.activeStreamStepByCallId.delete(callId);
+  }
 
   /** Latest (highest-stepNumber) open step for a given callId. */
   private findLatestStep(callId: string): StepState | undefined {
@@ -858,6 +836,16 @@ export class LaminarAiSdkTelemetry {
     };
     for (const [key, llm] of this.llmByKey) {
       if (key.startsWith(prefix)) {
+        // Flush any buffered stream deltas as the text output before force-
+        // closing. This is the only place the buffered-deltas fallback is
+        // consumed for aborted / errored streams where onLanguageModelCallEnd
+        // never fired (see onChunk). Mirror onStepFinish's attribute writes
+        // (ai.response.text + SPAN_OUTPUT) so partial output still renders.
+        if (this.recordOutputs && llm.textDeltas.length > 0) {
+          const bufferedText = llm.textDeltas.join("");
+          llm.span.setAttribute("ai.response.text", bufferedText);
+          llm.span.setAttribute(SPAN_OUTPUT, bufferedText);
+        }
         llm.span.end();
         bump(readSpanEndTime(llm.span));
       }

--- a/packages/lmnr/src/opentelemetry-lib/instrumentation/aisdk/v7-integration/utils.ts
+++ b/packages/lmnr/src/opentelemetry-lib/instrumentation/aisdk/v7-integration/utils.ts
@@ -1,6 +1,6 @@
 import type { HrTime, Span } from "@opentelemetry/api";
 
-import { LaminarAttributes } from "../../../tracing/attributes";
+import { LaminarAttributes, SPAN_INPUT } from "../../../tracing/attributes";
 
 export const serializeJSON = (value: unknown): string => {
   if (typeof value === "string") return value;
@@ -110,6 +110,45 @@ export const extractReasoningFromContent = (
     .filter((p) => p && p.type === "reasoning" && typeof p.text === "string")
     .map((p) => p.text as string)
     .join("");
+};
+
+// Apply `applyUsage` output directly onto a span, skipping undefined values.
+export const applyUsageToSpan = (span: Span, usage: any): void => {
+  const attrs: Record<string, any> = {};
+  applyUsage(attrs, usage);
+  for (const [k, v] of Object.entries(attrs)) {
+    if (v !== undefined) span.setAttribute(k, v);
+  }
+};
+
+// Set the dual finish-reason attributes used by both ai.* and gen_ai.* parsers.
+export const applyFinishReason = (span: Span, finishReason: string): void => {
+  span.setAttribute("gen_ai.response.finish_reason", finishReason);
+  span.setAttribute("ai.response.finishReason", finishReason);
+};
+
+// Set provider + request-model attributes on an LLM span.
+export const applyRequestModelAttributes = (span: Span, event: any): void => {
+  if (typeof event.provider === "string") {
+    const provider = normalizeProvider(event.provider);
+    if (provider) span.setAttribute(LaminarAttributes.PROVIDER, provider);
+    span.setAttribute("ai.model.provider", event.provider);
+  }
+  if (typeof event.modelId === "string") {
+    span.setAttribute(LaminarAttributes.REQUEST_MODEL, event.modelId);
+    span.setAttribute("ai.model.id", event.modelId);
+  }
+};
+
+// Serialize prompt messages from a StandardizedPrompt-shaped event and set
+// `ai.prompt.messages` + `SPAN_INPUT` on the span. No-ops when the event
+// carries no messages.
+export const applyPromptMessages = (span: Span, event: any): void => {
+  const msgs = standardizedPromptToMessages(event);
+  if (msgs.length === 0) return;
+  const serialized = serializeJSON(msgs);
+  span.setAttribute("ai.prompt.messages", serialized);
+  span.setAttribute(SPAN_INPUT, serialized);
 };
 
 export const compareHrTime = (a: HrTime, b: HrTime): number => {

--- a/packages/lmnr/test/aisdk-v7-telemetry.test.ts
+++ b/packages/lmnr/test/aisdk-v7-telemetry.test.ts
@@ -167,7 +167,7 @@ void describe("AI SDK v7 LaminarTelemetry integration", () => {
     tel.onLanguageModelCallStart(mkLlmCallStart(callId));
     tel.onLanguageModelCallEnd(mkLlmCallEnd(callId));
     tel.onStepFinish(mkStepEnd(callId, 0));
-    tel.onFinish(mkFinish(callId));
+    tel.onEnd(mkFinish(callId));
 
     const spans = exporter.getFinishedSpans();
     const byName = new Map(spans.map((s) => [s.name, s]));
@@ -279,7 +279,7 @@ void describe("AI SDK v7 LaminarTelemetry integration", () => {
     tel.onLanguageModelCallStart(mkLlmCallStart(callId));
     tel.onLanguageModelCallEnd(mkLlmCallEnd(callId));
     tel.onStepFinish(mkStepEnd(callId, 1));
-    tel.onFinish(mkFinish(callId, { stepNumber: 1 }));
+    tel.onEnd(mkFinish(callId, { stepNumber: 1 }));
 
     const spans = exporter.getFinishedSpans();
 
@@ -350,7 +350,7 @@ void describe("AI SDK v7 LaminarTelemetry integration", () => {
         tel.onLanguageModelCallStart(mkLlmCallStart(innerCallId));
         tel.onLanguageModelCallEnd(mkLlmCallEnd(innerCallId));
         tel.onStepFinish(mkStepEnd(innerCallId, 0));
-        tel.onFinish(mkFinish(innerCallId));
+        tel.onEnd(mkFinish(innerCallId));
         return Promise.resolve("ok");
       },
     });
@@ -370,7 +370,7 @@ void describe("AI SDK v7 LaminarTelemetry integration", () => {
         finishReason: "tool-calls",
       }),
     );
-    tel.onFinish(mkFinish(outerCallId));
+    tel.onEnd(mkFinish(outerCallId));
 
     const spans = exporter.getFinishedSpans();
     // The outer operation span's span id is shared — the inner operation
@@ -410,7 +410,7 @@ void describe("AI SDK v7 LaminarTelemetry integration", () => {
       toolOutput: { type: "tool-error", error: new Error("boom") },
     });
     tel.onStepFinish(mkStepEnd(callId, 0));
-    tel.onFinish(mkFinish(callId));
+    tel.onEnd(mkFinish(callId));
 
     const spans = exporter.getFinishedSpans();
     const tool = spans.find((s) => s.name === "ai.tool broken");
@@ -433,7 +433,7 @@ void describe("AI SDK v7 LaminarTelemetry integration", () => {
       headers: undefined,
       providerOptions: undefined,
     });
-    tel.onFinish({
+    tel.onEnd({
       callId,
       operationId: "ai.embed",
       provider: "openai",
@@ -471,7 +471,7 @@ void describe("AI SDK v7 LaminarTelemetry integration", () => {
       }),
     );
     tel.onStepFinish(mkStepEnd(callId, 0, { text: "42" }));
-    tel.onFinish(mkFinish(callId, { text: "42" }));
+    tel.onEnd(mkFinish(callId, { text: "42" }));
 
     const spans = exporter.getFinishedSpans();
     const llm = spans.find((s) => s.name.startsWith("ai.llm "));
@@ -549,7 +549,7 @@ void describe("AI SDK v7 LaminarTelemetry integration", () => {
     assert.equal(spans[0].status.message, "A broke");
 
     // call-B must still be open and unaffected — onFinish will close it.
-    tel.onFinish(mkFinish("call-B"));
+    tel.onEnd(mkFinish("call-B"));
     const after = exporter.getFinishedSpans();
     const b = after.find(
       (s) =>
@@ -568,8 +568,8 @@ void describe("AI SDK v7 LaminarTelemetry integration", () => {
     // No spans should have ended yet — we refused to guess which op failed.
     assert.equal(exporter.getFinishedSpans().length, 0);
 
-    tel.onFinish(mkFinish("call-X"));
-    tel.onFinish(mkFinish("call-Y"));
+    tel.onEnd(mkFinish("call-X"));
+    tel.onEnd(mkFinish("call-Y"));
     const ended = exporter.getFinishedSpans();
     for (const s of ended) {
       assert.notEqual(s.status.code, 2, "no op should be marked errored");
@@ -615,7 +615,7 @@ void describe("AI SDK v7 LaminarTelemetry integration", () => {
     });
     // Provider never emits onToolExecutionEnd — onFinish must still close
     // the tool span so it doesn't leak in the tracing backend or the map.
-    tel.onFinish(mkFinish(callId));
+    tel.onEnd(mkFinish(callId));
 
     const spans = exporter.getFinishedSpans();
     const names = spans.map((s) => s.name).sort();
@@ -637,7 +637,7 @@ void describe("AI SDK v7 LaminarTelemetry integration", () => {
     });
     // Provider skipped every per-child end callback. onFinish must end
     // children BEFORE the parent so the parent's endTime is the latest.
-    tel.onFinish(mkFinish(callId));
+    tel.onEnd(mkFinish(callId));
 
     const spans = exporter.getFinishedSpans();
     const op = spans.find((s) => s.name === "ai.generateText");
@@ -691,7 +691,7 @@ void describe("AI SDK v7 LaminarTelemetry integration", () => {
     const tel = new LaminarAiSdkTelemetry();
     const callId = "call-tool-only";
     tel.onStart(mkStartEvent(callId));
-    tel.onFinish(
+    tel.onEnd(
       mkFinish(callId, {
         text: "",
         content: [],
@@ -720,7 +720,7 @@ void describe("AI SDK v7 LaminarTelemetry integration", () => {
     const tel = new LaminarAiSdkTelemetry();
     const callId = "call-finish-error";
     tel.onStart(mkStartEvent(callId));
-    tel.onFinish(mkFinish(callId, { finishReason: "error" }));
+    tel.onEnd(mkFinish(callId, { finishReason: "error" }));
 
     const spans = exporter.getFinishedSpans();
     const op = spans.find((s) => s.name === "ai.generateText");
@@ -755,7 +755,7 @@ void describe("AI SDK v7 LaminarTelemetry integration", () => {
       }),
     );
     tel.onStepFinish(mkStepEnd(callId, 0));
-    tel.onFinish(mkFinish(callId));
+    tel.onEnd(mkFinish(callId));
 
     const spans = exporter.getFinishedSpans();
     const llm = spans.find((s) => s.name.startsWith("ai.llm "));
@@ -796,7 +796,7 @@ void describe("AI SDK v7 LaminarTelemetry integration", () => {
         text: "",
       }),
     );
-    tel.onFinish(mkFinish(callId));
+    tel.onEnd(mkFinish(callId));
 
     const spans = exporter.getFinishedSpans();
     const llm = spans.find((s) => s.name.startsWith("ai.llm "));
@@ -819,7 +819,7 @@ void describe("AI SDK v7 LaminarTelemetry integration", () => {
     tel.onChunk({ chunk: { type: "text-delta", id: "d1", text: "ghost" } });
     tel.onLanguageModelCallEnd(mkLlmCallEnd(callId));
     tel.onStepFinish(mkStepEnd(callId, 0));
-    tel.onFinish(mkFinish(callId));
+    tel.onEnd(mkFinish(callId));
 
     const spans = exporter.getFinishedSpans();
     const llm = spans.find((s) => s.name.startsWith("ai.llm "));
@@ -873,8 +873,8 @@ void describe("AI SDK v7 LaminarTelemetry integration", () => {
     // Close out via onStepFinish fallback so buffered deltas get flushed.
     tel.onStepFinish(mkStepEnd(callA, 0, { content: [], text: "" }));
     tel.onStepFinish(mkStepEnd(callB, 0, { content: [], text: "" }));
-    tel.onFinish(mkFinish(callA));
-    tel.onFinish(mkFinish(callB));
+    tel.onEnd(mkFinish(callA));
+    tel.onEnd(mkFinish(callB));
 
     const spans = exporter.getFinishedSpans();
     const llmSpans = spans.filter((s) => s.name.startsWith("ai.llm "));
@@ -934,7 +934,7 @@ void describe("AI SDK v7 LaminarTelemetry integration", () => {
       },
       providerMetadata: undefined,
     });
-    tel.onFinish(mkFinish(callId));
+    tel.onEnd(mkFinish(callId));
 
     const spans = exporter.getFinishedSpans();
     const llm = spans.find((s) => s.name.startsWith("ai.llm "));

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -196,6 +196,9 @@ importers:
       '@ai-sdk/provider-v2':
         specifier: npm:@ai-sdk/provider@2.0.0
         version: '@ai-sdk/provider@2.0.0'
+      '@ai-sdk/provider-v4-canary':
+        specifier: npm:@ai-sdk/provider@4.0.0-canary.17
+        version: '@ai-sdk/provider@4.0.0-canary.17'
       '@aws-sdk/client-bedrock-runtime':
         specifier: ^3.1057.0
         version: 3.1057.0
@@ -345,6 +348,10 @@ packages:
   '@ai-sdk/provider@3.0.10':
     resolution: {integrity: sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==}
     engines: {node: '>=18'}
+
+  '@ai-sdk/provider@4.0.0-canary.17':
+    resolution: {integrity: sha512-m/rtalImeIt7deuQGkEHehqlIPOM8Sjb0cF1b1SJ3B6Re+WYgbUkOK9gY2SSro1YO8jYBRgTMPz2qYzPtIzAxQ==}
+    engines: {node: '>=22'}
 
   '@aws-crypto/crc32@5.2.0':
     resolution: {integrity: sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==}
@@ -3428,6 +3435,10 @@ snapshots:
       json-schema: 0.4.0
 
   '@ai-sdk/provider@3.0.10':
+    dependencies:
+      json-schema: 0.4.0
+
+  '@ai-sdk/provider@4.0.0-canary.17':
     dependencies:
       json-schema: 0.4.0
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes affect OpenTelemetry span lifecycle and attribute mapping for AI SDK calls; incorrect abort or orphan cleanup could leak spans or mislabel outputs, though behavior is largely additive and covered by existing v7 tests renamed to onEnd.
> 
> **Overview**
> Adds **AI SDK language model v4** support via a new `LaminarLanguageModelV4` wrapper and extends shared replay-cache plumbing in `BaseLaminarLanguageModel` and `wrapLanguageModel` for `specificationVersion === "v4"` (canary `@ai-sdk/provider` types).
> 
> Updates the **v7 telemetry integration** to match renamed SDK lifecycle hooks (`onEnd`, `onEmbedEnd`, `onRerankEnd`), centralizes span attribute helpers, and adds **`onAbort`** plus shared **`closeOperation`** so aborted streams close spans without marking errors while still flushing partial streamed text on orphan cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f2d1470115db7247c6e6ed21cc13729f02600c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->