### PR TITLE
feat(cli): `setup` and `traces wait` commands

### DIFF
--- a/packages/lmnr-cli/README.md
+++ b/packages/lmnr-cli/README.md
@@ -128,6 +128,12 @@ Re-running setup in the same repo reuses the same project but mints a fresh API
 key each time. Old keys remain visible in the dashboard under "API keys" until
 you revoke them.
 
+Note: `workspaceCreated` reflects whether the CLI bootstrap step created the
+workspace, not whether the user is brand-new. Fresh users who create their
+first workspace inline on the OAuth approval page will see
+`workspaceCreated: false` because the workspace already exists by the time
+bootstrap runs.
+
 ### `traces wait` - Wait for trace ingestion
 
 ```bash

--- a/packages/lmnr-cli/README.md
+++ b/packages/lmnr-cli/README.md
@@ -12,6 +12,36 @@ npx lmnr-cli@latest <command>
 npm install -g lmnr-cli
 ```
 
+## Quick start
+
+One command takes you from a fresh install to a working API key in `./.env`:
+
+```bash
+lmnr-cli setup --json
+```
+
+Approve the device-flow URL in your browser, and `setup` will:
+
+1. Log in (if you are not already)
+2. Create or reuse a workspace + project (idempotent on re-runs in the same repo)
+3. Mint a fresh API key and write `LMNR_PROJECT_API_KEY=...` to `./.env`
+4. Print a dashboard URL and the revoke link
+
+```bash
+# Verify your instrumentation runs end-to-end:
+lmnr-cli traces wait --since 60s --count 1
+```
+
+`setup` is designed to be invoked by coding agents. Exit codes:
+
+- `0` success
+- `1` generic error
+- `6` login failed or aborted
+- `7` ambiguous workspace (multiple workspaces, no `--workspace`, non-interactive)
+- `8` `.env` write failed (API key is surfaced on stderr so the agent can rescue it)
+
+See `lmnr-cli setup --help` and `lmnr-cli traces wait --help` for all flags.
+
 ## Authentication
 
 The CLI supports three authentication modes, evaluated in this precedence order:
@@ -83,6 +113,30 @@ lmnr-cli dataset push data.jsonl -n my-dataset --json    # Push data to a datase
 lmnr-cli dataset pull output.jsonl -n my-dataset --json  # Pull data from a dataset
 lmnr-cli dataset create my-dataset data.jsonl -o out.jsonl
 ```
+
+### `setup` - One-shot onboarding
+
+```bash
+lmnr-cli setup                              # Human-readable summary
+lmnr-cli setup --json                       # Machine-readable single-line JSON
+lmnr-cli setup --workspace <uuid>           # Target a specific workspace
+lmnr-cli setup --project-name my-app        # Use an explicit project name
+lmnr-cli setup --no-write-env               # Skip writing ./.env
+```
+
+Re-running setup in the same repo reuses the same project but mints a fresh API
+key each time. Old keys remain visible in the dashboard under "API keys" until
+you revoke them.
+
+### `traces wait` - Wait for trace ingestion
+
+```bash
+lmnr-cli traces wait --since 60s --count 1 --timeout 120s
+lmnr-cli traces wait --since 2m --count 5 --json
+```
+
+Polls the server every 2 seconds. Useful for coding agents that need to confirm
+their instrumentation actually emits traces before declaring "done".
 
 ### `login` / `logout` / `status` - Authentication
 

--- a/packages/lmnr-cli/src/commands/setup/index.ts
+++ b/packages/lmnr-cli/src/commands/setup/index.ts
@@ -1,0 +1,338 @@
+import { resolve as resolvePath } from "node:path";
+import { createInterface } from "node:readline";
+
+import { readCredentials, type StoredCredentials, writeCredentials } from "../../auth/credentials";
+import { refreshIfNeeded } from "../../auth/resolve";
+import { writeEnvFile } from "../../utils/env-file";
+import { deriveProjectName, deriveWorkspaceName } from "../../utils/project-name";
+import { handleLogin } from "../login";
+
+const DEFAULT_DASHBOARD_URL = "https://www.laminar.sh";
+const DEFAULT_BASE_URL = "https://api.lmnr.ai";
+
+export interface SetupOptions {
+  workspace?: string;
+  projectName?: string;
+  writeEnv?: boolean;
+  json?: boolean;
+  noBrowser?: boolean;
+  dashboardUrl?: string;
+  baseUrl?: string;
+}
+
+export interface SetupResult {
+  projectId: string;
+  projectName: string;
+  workspaceId: string;
+  workspaceName: string;
+  workspaceCreated: boolean;
+  projectCreated: boolean;
+  apiKey: string;
+  apiKeyName: string;
+  envFileUpdated: string | null;
+  dashboardUrl: string;
+  userEmail: string | null;
+}
+
+interface CallerContext {
+  bearer: string;
+  issuer: string;
+  baseUrl: string;
+  userEmail: string | null;
+}
+
+/**
+ * One-shot onboarding: login (if needed) → bootstrap workspace + project →
+ * mint API key → write `.env` → print summary. Exits with non-zero on
+ * recoverable failures so coding agents can branch on $?.
+ */
+export async function handleSetup(options: SetupOptions): Promise<void> {
+  const writeEnv = options.writeEnv !== false;
+  const dashboardUrl = pick(
+    options.dashboardUrl,
+    process.env.LMNR_DASHBOARD_URL,
+    DEFAULT_DASHBOARD_URL,
+  );
+  const baseUrl = pick(options.baseUrl, process.env.LMNR_BASE_URL, DEFAULT_BASE_URL);
+  const isJson = options.json === true;
+
+  // Step 1 — login if needed.
+  let creds: StoredCredentials | null;
+  try {
+    creds = await readCredentials();
+    if (creds) {
+      creds = await refreshIfNeeded(creds);
+    }
+  } catch (err) {
+    if (!isJson) {
+      process.stderr.write(`Refresh failed (${describeError(err)}); re-running login...\n`);
+    }
+    creds = null;
+  }
+  if (!creds) {
+    try {
+      await handleLogin({
+        dashboardUrl,
+        baseUrl,
+        noBrowser: options.noBrowser,
+        projectId: undefined,
+      });
+    } catch (err) {
+      emitError(isJson, "login_failed", describeError(err));
+      process.exit(6);
+    }
+    creds = await readCredentials();
+    if (!creds) {
+      emitError(isJson, "login_failed", "credentials missing after login");
+      process.exit(6);
+    }
+  }
+
+  const caller: CallerContext = {
+    bearer: creds.accessToken,
+    issuer: creds.issuer || dashboardUrl,
+    baseUrl: creds.baseUrl || baseUrl,
+    userEmail: creds.userEmail ?? null,
+  };
+
+  if (!isJson) {
+    process.stderr.write(`✓ Logged in as ${caller.userEmail ?? "<unknown>"}\n`);
+  }
+
+  // Step 2/3 — derive names.
+  const projectName = deriveProjectName({ explicit: options.projectName });
+  const workspaceName = deriveWorkspaceName();
+
+  // Step 4 — bootstrap.
+  let bootstrap = await postBootstrap(caller, {
+    workspaceId: options.workspace,
+    workspaceName,
+    projectName,
+  });
+
+  if (
+    bootstrap.status === 400 &&
+    bootstrap.body?.error === "workspace_ambiguous" &&
+    !options.workspace
+  ) {
+    const candidates = (bootstrap.body.workspaces ?? []) as { id: string; name: string }[];
+    if (isJson || !process.stdin.isTTY) {
+      process.stdout.write(
+        JSON.stringify({
+          error: "workspace_ambiguous",
+          workspaces: candidates,
+        }) + "\n",
+      );
+      process.exit(7);
+    }
+    const chosenId = await pickWorkspace(candidates);
+    if (!chosenId) {
+      emitError(false, "workspace_pick_aborted", "Selection aborted.");
+      process.exit(7);
+    }
+    bootstrap = await postBootstrap(caller, {
+      workspaceId: chosenId,
+      workspaceName,
+      projectName,
+    });
+  }
+
+  if (bootstrap.status !== 200 || !bootstrap.body) {
+    emitError(isJson, bootstrap.body?.error ?? "bootstrap_failed", JSON.stringify(bootstrap.body));
+    process.exit(1);
+  }
+
+  const {
+    workspaceId,
+    workspaceName: resolvedWorkspaceName,
+    workspaceCreated,
+    projectId,
+    projectName: resolvedProjectName,
+    projectCreated,
+  } = bootstrap.body as {
+    workspaceId: string;
+    workspaceName: string;
+    workspaceCreated: boolean;
+    projectId: string;
+    projectName: string;
+    projectCreated: boolean;
+  };
+
+  if (!isJson) {
+    process.stderr.write(
+      `✓ Workspace: ${resolvedWorkspaceName} (${workspaceCreated ? "created" : "existing"})\n`,
+    );
+    process.stderr.write(
+      `✓ Project: ${resolvedProjectName} (${projectCreated ? "created" : "existing"})\n`,
+    );
+  }
+
+  // Step 5 — mint API key.
+  const apiKeyName = `cli-setup-${resolvedProjectName}-${utcDate()}`;
+  const mint = await postApiKey(caller, projectId, apiKeyName);
+  if (mint.status !== 200 || !mint.body) {
+    emitError(isJson, mint.body?.error ?? "api_key_failed", JSON.stringify(mint.body));
+    process.exit(1);
+  }
+  const apiKey = (mint.body as { value: string }).value;
+  if (!isJson) {
+    process.stderr.write(`✓ API key: ${apiKeyName}\n`);
+  }
+
+  // Persist project id in credentials so subsequent `traces wait` etc. work.
+  await writeCredentials({
+    ...creds,
+    projectId,
+    projectName: resolvedProjectName,
+    workspaceId,
+    workspaceName: resolvedWorkspaceName,
+  });
+
+  // Step 6 — write .env.
+  let envPath: string | null = null;
+  if (writeEnv) {
+    const target = resolvePath(process.cwd(), ".env");
+    try {
+      const result = await writeEnvFile(target, apiKey);
+      envPath = result.path;
+      if (!isJson) {
+        const verb = result.created
+          ? "Created"
+          : result.replaced
+            ? "Replaced LMNR_PROJECT_API_KEY in"
+            : "Appended LMNR_PROJECT_API_KEY to";
+        process.stderr.write(`✓ ${verb} ${result.path}\n`);
+      }
+    } catch (err) {
+      // Surface key on stderr so the agent can rescue it.
+      process.stderr.write(
+        `\nERROR: failed to write ${target}: ${describeError(err)}\n` +
+          `Your API key (set it manually):\n  LMNR_PROJECT_API_KEY=${apiKey}\n\n`,
+      );
+      if (isJson) {
+        const payload = {
+          error: "env_write_failed",
+          apiKey,
+          projectId,
+          message: describeError(err),
+        };
+        process.stdout.write(JSON.stringify(payload) + "\n");
+      }
+      process.exit(8);
+    }
+  }
+
+  // Step 7 — summary.
+  const dashboardLink = `${caller.issuer.replace(/\/+$/, "")}/project/${projectId}/traces`;
+  const revokeLink = `${caller.issuer.replace(/\/+$/, "")}/project/${projectId}/settings/api-keys`;
+
+  const result: SetupResult = {
+    projectId,
+    projectName: resolvedProjectName,
+    workspaceId,
+    workspaceName: resolvedWorkspaceName,
+    workspaceCreated,
+    projectCreated,
+    apiKey,
+    apiKeyName,
+    envFileUpdated: envPath,
+    dashboardUrl: dashboardLink,
+    userEmail: caller.userEmail,
+  };
+
+  if (isJson) {
+    process.stdout.write(JSON.stringify(result) + "\n");
+  } else {
+    process.stdout.write(
+      `\nDashboard:    ${dashboardLink}\n` +
+        `Revoke key:   ${revokeLink}\n`,
+    );
+  }
+}
+
+async function postBootstrap(
+  caller: CallerContext,
+  body: { workspaceId?: string; workspaceName: string; projectName: string },
+): Promise<{ status: number; body: Record<string, unknown> | null }> {
+  return jsonFetch(caller, "POST", "/api/cli/bootstrap", body);
+}
+
+async function postApiKey(
+  caller: CallerContext,
+  projectId: string,
+  name: string,
+): Promise<{ status: number; body: Record<string, unknown> | null }> {
+  return jsonFetch(caller, "POST", `/api/cli/projects/${projectId}/api-keys`, {
+    name,
+    isIngestOnly: false,
+  });
+}
+
+async function jsonFetch(
+  caller: CallerContext,
+  method: "GET" | "POST",
+  path: string,
+  body?: unknown,
+): Promise<{ status: number; body: Record<string, unknown> | null }> {
+  const url = `${caller.issuer.replace(/\/+$/, "")}${path}`;
+  const res = await fetch(url, {
+    method,
+    headers: {
+      authorization: `Bearer ${caller.bearer}`,
+      "content-type": "application/json",
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  let parsed: Record<string, unknown> | null;
+  try {
+    parsed = (await res.json()) as Record<string, unknown>;
+  } catch {
+    parsed = null;
+  }
+  return { status: res.status, body: parsed };
+}
+
+async function pickWorkspace(candidates: { id: string; name: string }[]): Promise<string | null> {
+  if (candidates.length === 0) return null;
+  process.stderr.write("\nMultiple workspaces. Pick one:\n");
+  candidates.forEach((w, i) => {
+    process.stderr.write(`  ${i + 1}. ${w.name} (${w.id})\n`);
+  });
+  const rl = createInterface({ input: process.stdin, output: process.stderr });
+  try {
+    const answer = await new Promise<string>((resolveP) => {
+      rl.question(`Enter 1-${candidates.length}: `, (a) => resolveP(a));
+    });
+    const idx = Number(answer.trim());
+    if (!Number.isFinite(idx) || idx < 1 || idx > candidates.length) {
+      return null;
+    }
+    return candidates[idx - 1].id;
+  } finally {
+    rl.close();
+  }
+}
+
+function utcDate(): string {
+  return new Date().toISOString().slice(0, 10).replace(/-/g, "");
+}
+
+function pick(...candidates: (string | undefined)[]): string {
+  for (const c of candidates) {
+    if (c && c.length > 0) return c;
+  }
+  return "";
+}
+
+function describeError(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  return String(err);
+}
+
+function emitError(json: boolean, code: string, detail: string): void {
+  if (json) {
+    process.stdout.write(JSON.stringify({ error: code, detail }) + "\n");
+  } else {
+    process.stderr.write(`\nERROR (${code}): ${detail}\n`);
+  }
+}

--- a/packages/lmnr-cli/src/commands/traces/index.ts
+++ b/packages/lmnr-cli/src/commands/traces/index.ts
@@ -1,0 +1,155 @@
+import { readCredentials } from "../../auth/credentials";
+import { refreshIfNeeded } from "../../auth/resolve";
+import { parseDuration } from "../../utils/duration";
+
+export interface TracesWaitOptions {
+  since?: string;
+  count?: string;
+  timeout?: string;
+  project?: string;
+  json?: boolean;
+  baseUrl?: string;
+}
+
+const POLL_INTERVAL_MS = 2000;
+
+/**
+ * Poll the app-server until at least `--count` spans appear in the last
+ * `--since` window, or until `--timeout` elapses. Designed to be invoked by
+ * a coding agent after running an instrumented script — exit 0 = "tracing
+ * works"; exit 1 = timed out; exit 6 = no credentials and no API key.
+ */
+export async function handleTracesWait(options: TracesWaitOptions): Promise<void> {
+  const isJson = options.json === true;
+  const sinceSeconds = parseDuration(options.since) ?? 60;
+  const targetCount = Number(options.count ?? "1");
+  const timeoutSeconds = parseDuration(options.timeout) ?? 120;
+  if (!Number.isFinite(targetCount) || targetCount <= 0) {
+    emitError(isJson, "bad_count", "Invalid --count");
+    process.exit(1);
+  }
+
+  // Resolve project id + bearer. Use OAuth credentials first; API-key callers
+  // must pass --project because the key doesn't carry a project id over the
+  // wire on the CLI side.
+  const creds = await readCredentials();
+  let bearer: string;
+  let issuer: string;
+  let projectId: string;
+
+  if (creds) {
+    const refreshed = await refreshIfNeeded(creds);
+    bearer = refreshed.accessToken;
+    issuer = refreshed.issuer;
+    projectId = options.project ?? refreshed.projectId ?? "";
+    if (!projectId) {
+      emitError(
+        isJson,
+        "no_project",
+        "No project id in credentials. Pass --project <uuid>.",
+      );
+      process.exit(1);
+    }
+  } else {
+    const envKey = process.env.LMNR_PROJECT_API_KEY;
+    if (!envKey) {
+      emitError(
+        isJson,
+        "not_authenticated",
+        "Run `lmnr-cli login` or set LMNR_PROJECT_API_KEY.",
+      );
+      process.exit(6);
+    }
+    if (!options.project) {
+      emitError(
+        isJson,
+        "no_project",
+        "API key auth requires --project <uuid>.",
+      );
+      process.exit(6);
+    }
+    bearer = envKey;
+    issuer = process.env.LMNR_DASHBOARD_URL ?? "https://www.laminar.sh";
+    projectId = options.project;
+  }
+
+  if (!isJson) {
+    process.stderr.write(
+      `Waiting for traces (last ${sinceSeconds}s, need ${targetCount})...\n`,
+    );
+  }
+
+  const start = Date.now();
+  const trimmedIssuer = issuer.replace(/\/+$/, "");
+  const url =
+    `${trimmedIssuer}/api/cli/projects/${projectId}/traces/recent?since=${sinceSeconds}s`;
+
+  for (;;) {
+    let res: Response;
+    try {
+      res = await fetch(url, { headers: { authorization: `Bearer ${bearer}` } });
+    } catch (err) {
+      process.stderr.write(`(network error: ${describeError(err)})\n`);
+      // continue polling
+      if (Date.now() - start >= timeoutSeconds * 1000) break;
+      await sleep(POLL_INTERVAL_MS);
+      continue;
+    }
+
+    if (res.status === 401 || res.status === 403) {
+      emitError(isJson, "unauthorized", `Server returned ${res.status}`);
+      process.exit(6);
+    }
+    if (!res.ok) {
+      process.stderr.write(`(server returned ${res.status})\n`);
+    } else {
+      const body = (await res.json().catch(() => null)) as { count?: number } | null;
+      const count = body?.count ?? 0;
+      if (count >= targetCount) {
+        const elapsedMs = Date.now() - start;
+        if (isJson) {
+          process.stdout.write(
+            JSON.stringify({ found: count, projectId, elapsedMs, timedOut: false }) + "\n",
+          );
+        } else {
+          const noun = count === 1 ? "trace" : "traces";
+          const secs = (elapsedMs / 1000).toFixed(1);
+          process.stdout.write(`✓ Found ${count} ${noun} in ${secs}s\n`);
+        }
+        return;
+      }
+    }
+
+    if (Date.now() - start >= timeoutSeconds * 1000) break;
+    await sleep(POLL_INTERVAL_MS);
+  }
+
+  const elapsedMs = Date.now() - start;
+  if (isJson) {
+    process.stdout.write(
+      JSON.stringify({ found: 0, projectId, elapsedMs, timedOut: true }) + "\n",
+    );
+  } else {
+    process.stdout.write(
+      `✗ Timed out after ${(elapsedMs / 1000).toFixed(1)}s (0 traces in last ${sinceSeconds}s)\n`,
+    );
+  }
+  process.exit(1);
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolveP) => setTimeout(resolveP, ms));
+}
+
+function describeError(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  return String(err);
+}
+
+function emitError(json: boolean, code: string, detail: string): void {
+  if (json) {
+    process.stdout.write(JSON.stringify({ error: code, detail }) + "\n");
+  } else {
+    process.stderr.write(`\nERROR (${code}): ${detail}\n`);
+  }
+}

--- a/packages/lmnr-cli/src/index.ts
+++ b/packages/lmnr-cli/src/index.ts
@@ -13,6 +13,7 @@ import {
 import { runDev } from "./commands/dev";
 import { handleLogin } from "./commands/login";
 import { handleLogout } from "./commands/logout";
+import { handleSetup } from "./commands/setup";
 import { handleSqlQuery } from "./commands/sql";
 import { SQL_SCHEMA_HELP } from "./commands/sql/schema";
 import { handleStatus } from "./commands/status";
@@ -305,6 +306,33 @@ Examples:
       await handleStatus();
     });
 
+  program
+    .command("setup")
+    .description("One-shot onboarding: login + workspace/project + write LMNR_PROJECT_API_KEY")
+    .option(
+      "--workspace <id>",
+      "Target workspace UUID (skips picker on multi-workspace accounts)",
+    )
+    .option(
+      "--project-name <name>",
+      "Project name (default: derive from git remote / cwd)",
+    )
+    .option("--write-env", "Write LMNR_PROJECT_API_KEY to ./.env (default)", true)
+    .option("--no-write-env", "Do not write to ./.env")
+    .option("--json", "Emit a machine-readable JSON line on stdout")
+    .option("--no-browser", "Do not auto-open the device-flow URL")
+    .option(
+      "--dashboard-url <url>",
+      "Dashboard URL (issuer). Defaults to LMNR_DASHBOARD_URL or https://www.laminar.sh",
+    )
+    .option(
+      "--base-url <url>",
+      "Base URL for the Laminar API. Defaults to LMNR_BASE_URL or https://api.lmnr.ai",
+    )
+    .action(async (options) => {
+      await handleSetup(options);
+    });
+
   program.addHelpText(
     "after",
     `
@@ -316,6 +344,9 @@ Authentication (precedence: highest first):
   or run "lmnr-cli login" to authenticate via your browser.
 
 Examples:
+  lmnr-cli setup --json                                    # One-shot onboarding (login + .env)
+  lmnr-cli setup --workspace <uuid> --project-name my-app  # Into a specific workspace
+  lmnr-cli traces wait --since 60s --count 1               # Wait for traces (verifies)
   lmnr-cli dev agent.ts                                    # Debugger TypeScript entrypoint
   lmnr-cli dev agent.py                                    # Debugger Python script mode
   lmnr-cli dev -m src.agent                                # Debugger Python module mode

--- a/packages/lmnr-cli/src/index.ts
+++ b/packages/lmnr-cli/src/index.ts
@@ -17,6 +17,7 @@ import { handleSetup } from "./commands/setup";
 import { handleSqlQuery } from "./commands/sql";
 import { SQL_SCHEMA_HELP } from "./commands/sql/schema";
 import { handleStatus } from "./commands/status";
+import { handleTracesWait } from "./commands/traces";
 
 async function main() {
   const program = new Command();
@@ -304,6 +305,23 @@ Examples:
     .description("Show the current OAuth login state and token expiry")
     .action(async () => {
       await handleStatus();
+    });
+
+  const traces = program
+    .command("traces")
+    .description("Inspect traces in a project");
+
+  traces
+    .command("wait")
+    .description("Poll the server until N spans appear in the last <since> window")
+    .option("--since <duration>", "Look-back window (e.g. 60s, 2m, 1h)", "60s")
+    .option("--count <n>", "Minimum span count", "1")
+    .option("--timeout <duration>", "Give up after this duration", "120s")
+    .option("--project <id>", "Project UUID (defaults to credentials)")
+    .option("--json", "Emit a machine-readable JSON line on stdout")
+    .option("--base-url <url>", "Base URL for the Laminar API")
+    .action(async (options) => {
+      await handleTracesWait(options);
     });
 
   program

--- a/packages/lmnr-cli/src/utils/duration.test.ts
+++ b/packages/lmnr-cli/src/utils/duration.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+
+import { parseDuration } from "./duration";
+
+describe("parseDuration", () => {
+  it("parses seconds (default unit)", () => {
+    expect(parseDuration("60")).toBe(60);
+    expect(parseDuration("60s")).toBe(60);
+  });
+  it("parses minutes and hours", () => {
+    expect(parseDuration("2m")).toBe(120);
+    expect(parseDuration("1h")).toBe(3600);
+  });
+  it("trims whitespace", () => {
+    expect(parseDuration("  120s  ")).toBe(120);
+  });
+  it("rejects bad input", () => {
+    expect(parseDuration("")).toBe(null);
+    expect(parseDuration("abc")).toBe(null);
+    expect(parseDuration("-1s")).toBe(null);
+    expect(parseDuration("0")).toBe(null);
+    expect(parseDuration(null)).toBe(null);
+    expect(parseDuration(undefined)).toBe(null);
+  });
+  it("caps at 24h", () => {
+    expect(parseDuration("48h")).toBe(24 * 60 * 60);
+  });
+});

--- a/packages/lmnr-cli/src/utils/duration.ts
+++ b/packages/lmnr-cli/src/utils/duration.ts
@@ -1,0 +1,23 @@
+const MAX_SECONDS = 24 * 60 * 60;
+
+/**
+ * Parse a duration string like `60s`, `2m`, `1h`. Returns seconds, capped at
+ * 24h. Returns null on malformed input (caller decides the fallback).
+ *
+ * Accepts: positive integers with optional unit suffix `s` (default), `m`, `h`.
+ * Whitespace is trimmed. Negative or zero values reject. Values are capped at
+ * MAX_SECONDS rather than rejecting so users can pass `99h` without surprise.
+ */
+export function parseDuration(raw: string | undefined | null): number | null {
+  if (raw === undefined || raw === null) return null;
+  const trimmed = raw.trim().toLowerCase();
+  const match = trimmed.match(/^(\d+)\s*(s|m|h)?$/);
+  if (!match) return null;
+  const n = Number(match[1]);
+  if (!Number.isFinite(n) || n <= 0) return null;
+  const unit = match[2] ?? "s";
+  let seconds = n;
+  if (unit === "m") seconds = n * 60;
+  if (unit === "h") seconds = n * 3600;
+  return Math.min(seconds, MAX_SECONDS);
+}

--- a/packages/lmnr-cli/src/utils/env-file.test.ts
+++ b/packages/lmnr-cli/src/utils/env-file.test.ts
@@ -1,0 +1,100 @@
+import { mkdtempSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { writeEnvFile } from "./env-file";
+
+const isWin = process.platform === "win32";
+
+let scratch: string;
+
+beforeEach(() => {
+  scratch = mkdtempSync(join(tmpdir(), "lmnr-cli-envfile-"));
+});
+
+afterEach(async () => {
+  await rm(scratch, { recursive: true, force: true });
+});
+
+describe("writeEnvFile", () => {
+  it("creates a new .env with mode 0o600 when the file does not exist", async () => {
+    const path = join(scratch, ".env");
+    const result = await writeEnvFile(path, "lmnr_proj_abc");
+    expect(result).toEqual({ path, created: true, replaced: false });
+    expect(readFileSync(path, "utf-8")).toBe("LMNR_PROJECT_API_KEY=lmnr_proj_abc\n");
+    if (!isWin) {
+      const mode = statSync(path).mode & 0o777;
+      expect(mode).toBe(0o600);
+    }
+  });
+
+  it("replaces an existing LMNR_PROJECT_API_KEY= line in place", async () => {
+    const path = join(scratch, ".env");
+    writeFileSync(
+      path,
+      ["# header", "FOO=bar", "LMNR_PROJECT_API_KEY=old_key", "BAR=baz", ""].join("\n"),
+    );
+    const result = await writeEnvFile(path, "new_key");
+    expect(result.created).toBe(false);
+    expect(result.replaced).toBe(true);
+    const after = readFileSync(path, "utf-8");
+    expect(after).toContain("LMNR_PROJECT_API_KEY=new_key");
+    expect(after).toContain("FOO=bar");
+    expect(after).toContain("BAR=baz");
+    expect(after).toContain("# header");
+    // No duplicate line was appended.
+    expect(after.match(/LMNR_PROJECT_API_KEY=/g)?.length).toBe(1);
+  });
+
+  it("appends to existing file without the key and adds trailing newline if needed", async () => {
+    const path = join(scratch, ".env");
+    // No trailing newline.
+    writeFileSync(path, "FOO=bar\nBAZ=qux");
+    const result = await writeEnvFile(path, "k");
+    expect(result.replaced).toBe(false);
+    expect(result.created).toBe(false);
+    const after = readFileSync(path, "utf-8");
+    expect(after).toBe("FOO=bar\nBAZ=qux\nLMNR_PROJECT_API_KEY=k\n");
+  });
+
+  it("does not touch mode on existing files", async () => {
+    if (isWin) return;
+    const path = join(scratch, ".env");
+    writeFileSync(path, "FOO=bar\n", { mode: 0o644 });
+    await writeEnvFile(path, "k");
+    expect(statSync(path).mode & 0o777).toBe(0o644);
+  });
+
+  it("supports a custom var name", async () => {
+    const path = join(scratch, ".env");
+    await writeEnvFile(path, "v", "CUSTOM_KEY");
+    expect(readFileSync(path, "utf-8")).toBe("CUSTOM_KEY=v\n");
+  });
+
+  it("handles a mid-file key with comments and ordering preserved", async () => {
+    const path = join(scratch, ".env");
+    const before = [
+      "# comment 1",
+      "A=1",
+      "LMNR_PROJECT_API_KEY=stale",
+      "# midline comment",
+      "B=2",
+      "",
+    ].join("\n");
+    writeFileSync(path, before);
+    await writeEnvFile(path, "fresh");
+    const after = readFileSync(path, "utf-8");
+    const expected = [
+      "# comment 1",
+      "A=1",
+      "LMNR_PROJECT_API_KEY=fresh",
+      "# midline comment",
+      "B=2",
+      "",
+    ].join("\n");
+    expect(after).toBe(expected);
+  });
+});

--- a/packages/lmnr-cli/src/utils/env-file.test.ts
+++ b/packages/lmnr-cli/src/utils/env-file.test.ts
@@ -68,6 +68,30 @@ describe("writeEnvFile", () => {
     expect(statSync(path).mode & 0o777).toBe(0o644);
   });
 
+  it("preserves a tighter-than-umask mode on existing files (0o640)", async () => {
+    if (isWin) return;
+    const path = join(scratch, ".env");
+    writeFileSync(path, "FOO=bar\n", { mode: 0o640 });
+    // chmod explicitly because writeFileSync's mode option is masked by umask
+    // on some systems, and we need the on-disk mode to be exactly 0o640 first.
+    const { chmodSync } = await import("node:fs");
+    chmodSync(path, 0o640);
+    expect(statSync(path).mode & 0o777).toBe(0o640);
+    await writeEnvFile(path, "k");
+    expect(statSync(path).mode & 0o777).toBe(0o640);
+  });
+
+  it("preserves 0o600 mode across idempotent re-runs", async () => {
+    if (isWin) return;
+    const path = join(scratch, ".env");
+    // First write: no file → created with 0o600.
+    await writeEnvFile(path, "first");
+    expect(statSync(path).mode & 0o777).toBe(0o600);
+    // Idempotent rerun: must NOT widen to 0o644.
+    await writeEnvFile(path, "second");
+    expect(statSync(path).mode & 0o777).toBe(0o600);
+  });
+
   it("supports a custom var name", async () => {
     const path = join(scratch, ".env");
     await writeEnvFile(path, "v", "CUSTOM_KEY");

--- a/packages/lmnr-cli/src/utils/env-file.ts
+++ b/packages/lmnr-cli/src/utils/env-file.ts
@@ -2,9 +2,9 @@ import {
   access,
   readFile,
   rename,
+  stat,
   writeFile,
 } from "node:fs/promises";
-import { dirname } from "node:path";
 
 const DEFAULT_VAR_NAME = "LMNR_PROJECT_API_KEY";
 
@@ -56,7 +56,11 @@ export async function writeEnvFile(
     const prefix = original.endsWith("\n") || original.length === 0 ? original : `${original}\n`;
     next = `${prefix}${varName}=${value}\n`;
   }
-  await atomicWrite(envPath, next, undefined);
+  // Capture existing mode so the tmp inherits dest's perms — POSIX `rename`
+  // adopts the source inode's permissions, so without this an existing 0o600
+  // .env would silently widen to the umask default (0o644) on every rerun.
+  const existingMode = (await stat(envPath)).mode & 0o777;
+  await atomicWrite(envPath, next, existingMode);
   return { path: envPath, created: false, replaced };
 }
 
@@ -77,8 +81,6 @@ async function atomicWrite(
   const tmp = `${path}.tmp`;
   await writeFile(tmp, contents, mode === undefined ? undefined : { mode });
   await rename(tmp, path);
-  // Touch the parent dir variable so Windows doesn't complain — no-op on POSIX.
-  void dirname(path);
 }
 
 function escapeRegex(raw: string): string {

--- a/packages/lmnr-cli/src/utils/env-file.ts
+++ b/packages/lmnr-cli/src/utils/env-file.ts
@@ -1,0 +1,86 @@
+import {
+  access,
+  readFile,
+  rename,
+  writeFile,
+} from "node:fs/promises";
+import { dirname } from "node:path";
+
+const DEFAULT_VAR_NAME = "LMNR_PROJECT_API_KEY";
+
+export interface WriteEnvResult {
+  /** Absolute path of the .env file. */
+  path: string;
+  /** True when the file did not exist before this call. */
+  created: boolean;
+  /** True when an existing `<varName>=` line was overwritten. */
+  replaced: boolean;
+}
+
+/**
+ * Write/replace `<varName>=<value>` in the .env file at `envPath`.
+ *
+ * Semantics:
+ * - If the file does not exist: create it with mode 0o600 and a single line.
+ * - If the file exists:
+ *   - Replace an existing `^<varName>\s*=.*` line in place (preserves comments,
+ *     ordering, and other keys).
+ *   - Otherwise append the line (with a leading newline if the file does not
+ *     end in one).
+ *   - DO NOT change the file mode on existing files — the user may have set
+ *     a deliberate mode and changing it surprises them.
+ * - Writes are atomic: write to `<envPath>.tmp`, then rename.
+ */
+export async function writeEnvFile(
+  envPath: string,
+  value: string,
+  varName: string = DEFAULT_VAR_NAME,
+): Promise<WriteEnvResult> {
+  const exists = await fileExists(envPath);
+
+  if (!exists) {
+    const contents = `${varName}=${value}\n`;
+    await atomicWrite(envPath, contents, 0o600);
+    return { path: envPath, created: true, replaced: false };
+  }
+
+  const original = await readFile(envPath, "utf-8");
+  // ^ at line start, m flag so . doesn't match newlines.
+  const regex = new RegExp(`^${escapeRegex(varName)}\\s*=.*$`, "m");
+  let next: string;
+  let replaced = false;
+  if (regex.test(original)) {
+    next = original.replace(regex, `${varName}=${value}`);
+    replaced = true;
+  } else {
+    const prefix = original.endsWith("\n") || original.length === 0 ? original : `${original}\n`;
+    next = `${prefix}${varName}=${value}\n`;
+  }
+  await atomicWrite(envPath, next, undefined);
+  return { path: envPath, created: false, replaced };
+}
+
+async function fileExists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function atomicWrite(
+  path: string,
+  contents: string,
+  mode: number | undefined,
+): Promise<void> {
+  const tmp = `${path}.tmp`;
+  await writeFile(tmp, contents, mode === undefined ? undefined : { mode });
+  await rename(tmp, path);
+  // Touch the parent dir variable so Windows doesn't complain — no-op on POSIX.
+  void dirname(path);
+}
+
+function escapeRegex(raw: string): string {
+  return raw.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/packages/lmnr-cli/src/utils/project-name.test.ts
+++ b/packages/lmnr-cli/src/utils/project-name.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import { deriveProjectName, parseRepoNameFromUrl } from "./project-name";
+
+describe("parseRepoNameFromUrl", () => {
+  it("strips .git from https URLs", () => {
+    expect(parseRepoNameFromUrl("https://github.com/owner/repo.git")).toBe("repo");
+  });
+  it("strips trailing slashes", () => {
+    expect(parseRepoNameFromUrl("https://github.com/owner/repo/")).toBe("repo");
+  });
+  it("handles ssh-style URLs (colon as separator)", () => {
+    expect(parseRepoNameFromUrl("git@github.com:owner/repo.git")).toBe("repo");
+  });
+  it("returns undefined for empty or no-separator inputs", () => {
+    expect(parseRepoNameFromUrl("")).toBeUndefined();
+    expect(parseRepoNameFromUrl("nonsense")).toBeUndefined();
+  });
+});
+
+describe("deriveProjectName", () => {
+  it("uses explicit name when provided (normalised)", () => {
+    expect(deriveProjectName({ explicit: "My Cool Repo" })).toBe("my-cool-repo");
+  });
+  it("normalises capital letters and special chars", () => {
+    expect(deriveProjectName({ explicit: "ABC_123 Foo!" })).toBe("abc-123-foo");
+  });
+  it("collapses repeated dashes", () => {
+    expect(deriveProjectName({ explicit: "foo---bar" })).toBe("foo-bar");
+  });
+  it("caps at 64 chars", () => {
+    const longName = "a".repeat(100);
+    const out = deriveProjectName({ explicit: longName });
+    expect(out.length).toBeLessThanOrEqual(64);
+  });
+  it("falls back to 'default' when explicit is whitespace and cwd basename is empty", () => {
+    // Whitespace only normalises to empty → "default".
+    expect(deriveProjectName({ explicit: "   " })).not.toBe("");
+  });
+  it("falls back to cwd basename when no explicit provided", () => {
+    const out = deriveProjectName({ cwd: "/tmp/my-project" });
+    expect(out).toBe("my-project");
+  });
+});

--- a/packages/lmnr-cli/src/utils/project-name.ts
+++ b/packages/lmnr-cli/src/utils/project-name.ts
@@ -1,0 +1,100 @@
+import { execSync } from "node:child_process";
+import { basename } from "node:path";
+
+const GIT_TIMEOUT_MS = 1500;
+
+export interface DeriveOptions {
+  explicit?: string;
+  cwd?: string;
+}
+
+/**
+ * Derive a project name. First non-empty wins:
+ *   1. `opts.explicit`
+ *   2. git remote URL (last path segment, `.git` stripped)
+ *   3. cwd basename
+ *   4. literal `"default"`
+ *
+ * Then normalize: trim → lowercase → replace `[^a-z0-9-]` with `-` →
+ * collapse repeated dashes → trim leading/trailing dashes → cap at 64 chars.
+ * Empty after normalization falls back to `"default"`.
+ */
+export function deriveProjectName(opts: DeriveOptions = {}): string {
+  const raw =
+    firstNonEmpty(
+      opts.explicit,
+      tryGitRemoteName(opts.cwd ?? process.cwd()),
+      basename(opts.cwd ?? process.cwd()),
+    ) ?? "default";
+  return normalize(raw);
+}
+
+/**
+ * Derive a workspace name. Same fallback order, but NO normalization —
+ * workspace names are human-readable. Default `"My Workspace"`.
+ */
+export function deriveWorkspaceName(opts: DeriveOptions = {}): string {
+  return (
+    firstNonEmpty(
+      opts.explicit?.trim(),
+      tryGitRemoteName(opts.cwd ?? process.cwd())?.trim(),
+      basename(opts.cwd ?? process.cwd()).trim(),
+    ) ?? "My Workspace"
+  );
+}
+
+function firstNonEmpty(...candidates: (string | undefined | null)[]): string | undefined {
+  for (const c of candidates) {
+    if (typeof c === "string" && c.length > 0) return c;
+  }
+  return undefined;
+}
+
+function tryGitRemoteName(cwd: string): string | undefined {
+  try {
+    const out = execSync("git remote -v", {
+      cwd,
+      timeout: GIT_TIMEOUT_MS,
+      stdio: ["ignore", "pipe", "ignore"],
+    })
+      .toString("utf-8")
+      .split("\n")
+      .find((line) => line.length > 0);
+    if (!out) return undefined;
+    // line shape: "origin\tgit@github.com:foo/bar.git (fetch)" or "origin\thttps://github.com/foo/bar.git (fetch)"
+    const parts = out.split(/\s+/);
+    const url = parts[1];
+    if (!url) return undefined;
+    return parseRepoNameFromUrl(url);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * `git@github.com:owner/repo.git` → `repo`
+ * `https://github.com/owner/repo.git` → `repo`
+ * `https://github.com/owner/repo` → `repo`
+ */
+export function parseRepoNameFromUrl(url: string): string | undefined {
+  // Strip trailing `.git` and trailing slash.
+  let s = url.trim();
+  if (s.endsWith("/")) s = s.slice(0, -1);
+  if (s.endsWith(".git")) s = s.slice(0, -4);
+  // The last `:` or `/` separator marks the start of the path; we want the
+  // segment after it.
+  const sepIdx = Math.max(s.lastIndexOf("/"), s.lastIndexOf(":"));
+  if (sepIdx < 0) return undefined;
+  const tail = s.slice(sepIdx + 1);
+  return tail.length > 0 ? tail : undefined;
+}
+
+function normalize(raw: string): string {
+  let s = raw.trim().toLowerCase();
+  s = s.replace(/[^a-z0-9-]+/g, "-");
+  s = s.replace(/-+/g, "-");
+  s = s.replace(/^-+|-+$/g, "");
+  if (s.length === 0) return "default";
+  if (s.length > 64) s = s.slice(0, 64).replace(/-+$/, "");
+  return s;
+}


### PR DESCRIPTION
## Summary
- New `lmnr-cli setup` command — one-shot onboarding for coding agents. Login → bootstrap (workspace + project) → mint API key → write `LMNR_PROJECT_API_KEY` to `./.env`.
- New `lmnr-cli traces wait` command — verification primitive. Polls until N spans appear in the last <since> seconds. Exits 0 on success, 1 on timeout.
- Companion server PR: lmnr-ai/lmnr#TBD (adds `/api/cli/bootstrap`, `/api/cli/workspaces`, `/api/cli/projects/:id/api-keys`, `/api/cli/projects/:id/traces/recent`).

> **Note on PR base.** Stacked on `feat/cli-oauth-device-flow` (lmnr-ts#237). When that merges, this rebases to `main`.

## The flow this enables

```bash
# Pasted into a coding agent: "Set up Laminar tracing for this project"
npm install -g @lmnr-ai/lmnr-cli
lmnr-cli setup --write-env --json > /tmp/lmnr-setup.json
# Agent instruments code, runs the app
open "$(jq -r .dashboardUrl /tmp/lmnr-setup.json)"
lmnr-cli traces wait --since 120s --count 1 --timeout 180s
```

One human click (the OAuth approval) in the entire flow.

## What's in this PR

**New commands**:
- `src/commands/setup/index.ts` — orchestrates login (Device Flow if needed) → bootstrap → API-key mint → `.env` write. Hand-rolled 25-line readline picker for N-workspace TTY case.
- `src/commands/traces/index.ts` — `wait` subcommand, 2-second polling, `--since` / `--count` / `--timeout` / `--project` / `--json`.

**Utilities** (all unit-tested):
- `src/utils/env-file.ts` — atomic write + in-place `LMNR_PROJECT_API_KEY=` replacement preserving other keys, comments, ordering. Preserves existing file mode (iteration-01 fix).
- `src/utils/project-name.ts` — derive from `--project-name` → git remote → cwd basename → "default", with normalization.
- `src/utils/duration.ts` — parse `60s` / `2m` / `1h` durations, capped at 24h.

**Exit codes**: 0 success, 1 generic error, 6 login required, 7 ambiguous workspace (JSON or non-TTY), 8 .env write failed (API key still printed to stderr).

**Output**: human-readable by default; `--json` emits a single line to stdout with `projectId`, `projectName`, `workspaceId`, `workspaceName`, `workspaceCreated`, `projectCreated`, `apiKey`, `apiKeyName`, `envFileUpdated`, `dashboardUrl`, `userEmail`.

**Idempotency**: re-running setup in the same repo reuses the project (same name + workspace) but always mints a fresh API key. The dashboard is the user's path to revoke accumulated keys.

**Docs**: README quick-start + per-command sections covering all flags, exit codes, JSON shape.

## Test plan
- [ ] `pnpm --filter @lmnr-ai/lmnr-cli build` clean
- [ ] `pnpm --filter @lmnr-ai/lmnr-cli test` green (158 tests)
- [ ] `pnpm --filter @lmnr-ai/lmnr-cli lint` clean
- [ ] End-to-end against companion server PR on localhost:
  - Brand-new account: setup → workspace + project + key created, `.env` populated, key works against app-server
  - Existing single-workspace account: workspace reused, fresh project + key
  - Existing N-workspace account, `--json`: exit 7 with candidates; `--workspace <id>`: exit 0
  - Idempotency: same `projectId`, different `apiKey` across runs
  - `traces wait`: returns 0 within seconds after a span lands; returns 1 on timeout with no ingest
  - `.env` semantics: existing file's other keys + comments + ordering preserved; mode (0o640) preserved on existing files; mode 0o600 on new files; exit 8 with key on stderr when cwd is read-only

## Known follow-ups
- `workspaceCreated` reflects the bootstrap call, not the user's overall state. Documented in README + the worktree CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)