### PR TITLE
bump version to 0.8.28 for release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@lmnr-ai/lmnr-ts",
   "private": true,
-  "version": "0.8.27",
+  "version": "0.8.28",
   "description": "Laminar AI TypeScript SDK",
   "scripts": {
     "build": "pnpm -r build",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lmnr-ai/client",
-  "version": "0.8.27",
+  "version": "0.8.28",
   "description": "HTTP client for Laminar AI API",
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",

--- a/packages/lmnr/package.json
+++ b/packages/lmnr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lmnr-ai/lmnr",
-  "version": "0.8.27",
+  "version": "0.8.28",
   "description": "TypeScript SDK for Laminar AI",
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lmnr-ai/types",
-  "version": "0.8.27",
+  "version": "0.8.28",
   "description": "Shared types for Laminar AI SDK",
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Metadata-only version bumps with no runtime or API changes.
> 
> **Overview**
> Bumps the monorepo release version from **0.8.27** to **0.8.28** in all published package manifests: root `@lmnr-ai/lmnr-ts`, `@lmnr-ai/client`, `@lmnr-ai/lmnr`, and `@lmnr-ai/types`. No source or dependency changes—version fields only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7c15b0782754b375aafc84f8a0d1ea0098761eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->