### PR TITLE
feat(cli): BetterAuth device-flow auth + directory-scoped setup

### DIFF
--- a/packages/lmnr-cli/README.md
+++ b/packages/lmnr-cli/README.md
@@ -97,7 +97,7 @@ is the data API and carries **no port** — pass the port separately with `--por
 lmnr-cli sql schema --base-url http://localhost --port 8000
 ```
 
-`LMNR_FRONTEND_URL` (default `https://www.laminar.sh`), `LMNR_BASE_URL`
+`LMNR_FRONTEND_URL` (default `https://laminar.sh`), `LMNR_BASE_URL`
 (default `https://api.lmnr.ai`), and `LMNR_HTTP_PORT` (default `443`) are also
 honored, and are auto-loaded from a `.env` / `.env.local` in the working directory.
 

--- a/packages/lmnr-cli/package.json
+++ b/packages/lmnr-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lmnr-cli",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "CLI for the Laminar agent observability platform",
   "main": "dist/index.cjs",
   "bin": {

--- a/packages/lmnr-cli/src/commands/setup/index.ts
+++ b/packages/lmnr-cli/src/commands/setup/index.ts
@@ -19,7 +19,7 @@ import { installSkill } from "../../utils/install-skill";
 import { type ProjectLink, readProjectLink, writeProjectLink } from "../../utils/project-link";
 import { handleLogin } from "../login";
 
-const DEFAULT_FRONTEND_URL = "https://www.laminar.sh";
+const DEFAULT_FRONTEND_URL = "https://laminar.sh";
 const DEFAULT_BASE_URL = "https://api.lmnr.ai";
 
 // Exit codes (machine-readable contract — each distinct so automation can

--- a/packages/lmnr-cli/src/constants.ts
+++ b/packages/lmnr-cli/src/constants.ts
@@ -1,5 +1,5 @@
 // Default Laminar endpoints, shared across commands. Override per-invocation
 // via the --frontend-url / --base-url flags or the LMNR_FRONTEND_URL /
 // LMNR_BASE_URL env vars; these are the final fallback.
-export const DEFAULT_FRONTEND_URL = "https://www.laminar.sh";
+export const DEFAULT_FRONTEND_URL = "https://laminar.sh";
 export const DEFAULT_BASE_URL = "https://api.lmnr.ai";

--- a/packages/lmnr-cli/src/index.ts
+++ b/packages/lmnr-cli/src/index.ts
@@ -210,7 +210,7 @@ Examples:
     .description("Authenticate the CLI via OAuth Device Flow")
     .option(
       "--frontend-url <url>",
-      "Frontend URL (issuer). Defaults to https://www.laminar.sh or LMNR_FRONTEND_URL env variable",
+      "Frontend URL (issuer). Defaults to https://laminar.sh or LMNR_FRONTEND_URL env variable",
     )
     .option("--no-browser", "Do not open the verification URL in a browser")
     .action(async (options) => {
@@ -248,7 +248,7 @@ Examples:
     .option("--no-browser", "Do not auto-open the device-flow URL")
     .option(
       "--frontend-url <url>",
-      "Frontend URL (issuer). Defaults to LMNR_FRONTEND_URL or https://www.laminar.sh",
+      "Frontend URL (issuer). Defaults to LMNR_FRONTEND_URL or https://laminar.sh",
     )
     .option(
       "--base-url <url>",


### PR DESCRIPTION
## Summary

Reworks `lmnr-cli` to authenticate as a **user** via the BetterAuth OAuth Device Flow instead of a project API key, and adds a one-shot `setup` onboarding flow.

### Auth
- `lmnr-cli login` / `logout` — RFC 8628 device flow against the frontend's BetterAuth endpoints. Tokens stored at `~/.config/lmnr/credentials.json` (mode `0600`, XDG-aware, `%APPDATA%\lmnr` on Windows), single signed-in user, short-lived JWT auto-refreshed from the session token.
- Project commands (`sql`, `dataset`, `trace`, `debug`, `project`) run on the user session and resolve their project from `--project-id` or the nearest `.lmnr/project.json`. The legacy project-key auth path is dropped.

### setup
- `lmnr-cli setup` — logs in, resolves/creates a project (browser-driven), mints a project API key into `./.env` (for the app's SDK, not the CLI), links the dir via `.lmnr/project.json`, and installs the Laminar agent skill into `.claude/` and `.agents/`. Distinct machine-readable exit codes; `--json` mode for agents.

### Other
- `LMNR_DASHBOARD_URL` → `LMNR_FRONTEND_URL`, `--dashboard-url` → `--frontend-url`.
- Skill fetched via giget; re-fetches on branch move; install replaces (not merges) the dir.
- Default frontend URL is the apex `https://laminar.sh` (the `www` host 301-redirects, which breaks the device-flow POST).
- New `trace append-note` and `debug session set-name/summary` commands.

## Test plan
- `pnpm -r lint`, `pnpm -r test`, `pnpm build` all green.
- Device flow verified end-to-end against Laminar Cloud (apex host).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Default endpoint and docs-only help strings change; users who relied on implicit `www` still override via `LMNR_FRONTEND_URL` or `--frontend-url`.
> 
> **Overview**
> Updates the **default Laminar frontend URL** from `https://www.laminar.sh` to the apex **`https://laminar.sh`** across shared constants, `setup`, CLI help text, and the README so OAuth device flow hits the issuer directly (avoiding `www` redirects that can break the flow).
> 
> Bumps **`lmnr-cli` to `0.1.12`** for release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b32793f38453a42919bb481904c57e109c01deb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->