### PR TITLE
Fix/auto initialize in aisdk telemetry

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@lmnr-ai/lmnr-ts",
   "private": true,
-  "version": "0.8.31",
+  "version": "0.8.32",
   "description": "Laminar AI TypeScript SDK",
   "scripts": {
     "build": "pnpm -r build",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lmnr-ai/client",
-  "version": "0.8.31",
+  "version": "0.8.32",
   "description": "HTTP client for Laminar AI API",
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",

--- a/packages/lmnr/package.json
+++ b/packages/lmnr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lmnr-ai/lmnr",
-  "version": "0.8.31",
+  "version": "0.8.32",
   "description": "TypeScript SDK for Laminar AI",
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",
@@ -96,8 +96,8 @@
   "devDependencies": {
     "@ai-sdk/openai": "^3.0.1",
     "@ai-sdk/provider": "^3.0.0",
-    "@ai-sdk/provider-v2": "npm:@ai-sdk/provider@2.0.0",
-    "@ai-sdk/provider-v4-canary": "npm:@ai-sdk/provider@4.0.0-canary.17",
+    "@ai-sdk/provider-v2": "npm:@ai-sdk/provider@ai-v5",
+    "@ai-sdk/provider-v4-canary": "npm:@ai-sdk/provider@4.0.0-canary.18",
     "@aws-sdk/client-bedrock-runtime": "^3.1057.0",
     "@azure/openai": "^2.0.0",
     "@google/genai": "^2.0.0",
@@ -114,7 +114,7 @@
     "@types/node": "^24.12.0",
     "@types/semver": "^7.7.0",
     "ai": "^6.0.3",
-    "ai-v5": "npm:ai@5.0.116",
+    "ai-v5": "npm:ai@ai-v5",
     "chromadb": "^3.0.10",
     "nock": "^14.0.8",
     "openai": "^6.33.0",

--- a/packages/lmnr/src/index.ts
+++ b/packages/lmnr/src/index.ts
@@ -12,7 +12,7 @@ export {
   type EvaluatorFunctionReturn,
   HumanEvaluator,
 } from "./evaluations";
-export { Laminar } from "./laminar";
+export { Laminar, type LaminarInitializeProps } from "./laminar";
 export { LaminarSpanProcessor } from "./opentelemetry-lib/";
 export {
   wrapAISDK,

--- a/packages/lmnr/src/laminar.ts
+++ b/packages/lmnr/src/laminar.ts
@@ -71,7 +71,7 @@ loadEnv();
 
 const logger = initializeLogger();
 
-interface LaminarInitializeProps {
+export interface LaminarInitializeProps {
   projectApiKey?: string;
   baseUrl?: string;
   baseHttpUrl?: string;

--- a/packages/lmnr/src/opentelemetry-lib/instrumentation/aisdk/index.ts
+++ b/packages/lmnr/src/opentelemetry-lib/instrumentation/aisdk/index.ts
@@ -3,11 +3,11 @@ import { type LanguageModelV2 } from "@ai-sdk/provider-v2";
 import { type LanguageModelV4 } from "@ai-sdk/provider-v4-canary";
 import type * as AI from "ai";
 
+import { initializeLogger } from "../../../utils";
 import { getTracer } from "../../tracing";
 import { LaminarLanguageModelV2 } from "./v2";
 import { LaminarLanguageModelV3 } from "./v3";
 import { LaminarLanguageModelV4 } from "./v4";
-import { aiSdkTelemetry } from "./v7-integration/index";
 
 const AI_FUNCTIONS = [
   "generateText",
@@ -27,49 +27,43 @@ const AI_FUNCTIONS = [
 const isAISDKv7 = (ai: typeof AI): boolean =>
   typeof (ai as any).registerTelemetry === "function";
 
+const logger = initializeLogger();
+let wrapAISDKv7WarnedOnce = false;
+
 export const wrapAISDK = (ai: typeof AI): typeof AI => {
   const wrapped: Record<string, any> = {};
   const v7 = isAISDKv7(ai);
-  // Create one integration per wrap() call so registrations are stable
-  // across calls within the same process but distinct across test runs.
-  const v7Integration = v7 ? aiSdkTelemetry() : undefined;
+
+  if (v7) {
+    if (!wrapAISDKv7WarnedOnce) {
+      wrapAISDKv7WarnedOnce = true;
+      logger.warn(
+        "wrapAISDK() is not supported for AI SDK v7. " +
+          "Use registerAiSdkTelemetry() instead:\n" +
+          "  import { LaminarAiSdkTelemetry } from '@lmnr-ai/lmnr';\n" +
+          "  import { registerTelemetry } from 'ai';\n" +
+          "  registerTelemetry(new LaminarAiSdkTelemetry());",
+      );
+    }
+    return ai;
+  }
 
   Object.entries(ai).forEach(([key, value]) => {
     if (typeof value === "function" && AI_FUNCTIONS.includes(key)) {
       const originalFn = value as (...args: any[]) => any;
       wrapped[key] = (...args: any[]) => {
         if (args[0] && typeof args[0] === "object") {
-          if (v7) {
-            const userTelemetry =
-              args[0].telemetry ?? args[0].experimental_telemetry ?? {};
-            const mergedIntegrations: any[] = [v7Integration];
-            const userIntegrations = userTelemetry.integrations;
-            if (Array.isArray(userIntegrations)) {
-              mergedIntegrations.push(...userIntegrations);
-            } else if (userIntegrations) {
-              mergedIntegrations.push(userIntegrations);
-            }
-            args[0] = {
-              ...args[0],
-              telemetry: {
-                isEnabled: true,
-                ...userTelemetry,
-                integrations: mergedIntegrations,
-              },
-            };
-          } else {
-            const defaultTelemetry = {
-              isEnabled: true,
-              tracer: getTracer(),
-            };
-            args[0] = {
-              ...args[0],
-              experimental_telemetry: {
-                ...defaultTelemetry,
-                ...args[0].experimental_telemetry,
-              },
-            };
-          }
+          const defaultTelemetry = {
+            isEnabled: true,
+            tracer: getTracer(),
+          };
+          args[0] = {
+            ...args[0],
+            experimental_telemetry: {
+              ...defaultTelemetry,
+              ...args[0].experimental_telemetry,
+            },
+          };
         }
         // eslint-disable-next-line @typescript-eslint/no-unsafe-return
         return originalFn(...args);

--- a/packages/lmnr/src/opentelemetry-lib/instrumentation/aisdk/index.ts
+++ b/packages/lmnr/src/opentelemetry-lib/instrumentation/aisdk/index.ts
@@ -39,7 +39,7 @@ export const wrapAISDK = (ai: typeof AI): typeof AI => {
       wrapAISDKv7WarnedOnce = true;
       logger.warn(
         "wrapAISDK() is not supported for AI SDK v7. " +
-          "Use registerAiSdkTelemetry() instead:\n" +
+          "Use LaminarAiSdkTelemetry instead:\n" +
           "  import { LaminarAiSdkTelemetry } from '@lmnr-ai/lmnr';\n" +
           "  import { registerTelemetry } from 'ai';\n" +
           "  registerTelemetry(new LaminarAiSdkTelemetry());",

--- a/packages/lmnr/src/opentelemetry-lib/instrumentation/aisdk/v7-integration/index.ts
+++ b/packages/lmnr/src/opentelemetry-lib/instrumentation/aisdk/v7-integration/index.ts
@@ -36,6 +36,7 @@ import {
   trace,
 } from "@opentelemetry/api";
 
+import { Laminar, type LaminarInitializeProps } from "../../../../laminar";
 import { getTracer } from "../../../tracing";
 import {
   LaminarAttributes,
@@ -87,6 +88,12 @@ export interface LaminarAiSdkTelemetryOptions {
    * generation. Defaults to false.
    */
   createStepSpan?: boolean;
+  /**
+   * Options to pass to {@link Laminar.initialize}. If Laminar is already
+   * initialized, this is ignored. Allows all-in-one setup without a separate
+   * `Laminar.initialize()` call.
+   */
+  laminarOptions?: LaminarInitializeProps;
 }
 
 /**
@@ -122,6 +129,9 @@ export class LaminarAiSdkTelemetry {
     this.recordInputs = options.recordInputs ?? true;
     this.recordOutputs = options.recordOutputs ?? true;
     this.createStepSpan = options.createStepSpan ?? false;
+    if (!Laminar.initialized()) {
+      Laminar.initialize(options.laminarOptions ?? {});
+    }
   }
 
   // ------------------------------------------------------------------

--- a/packages/lmnr/src/opentelemetry-lib/instrumentation/aisdk/v7-integration/index.ts
+++ b/packages/lmnr/src/opentelemetry-lib/instrumentation/aisdk/v7-integration/index.ts
@@ -212,11 +212,7 @@ export class LaminarAiSdkTelemetry {
     const op = this.operationByCallId.get(callId);
     if (!op) return;
     const tracer = getTracer();
-    const span = tracer.startSpan(
-      `ai.step ${stepNumber}`,
-      { kind: SpanKind.CLIENT },
-      op.ctx,
-    );
+    const span = tracer.startSpan(`ai.step`, { kind: SpanKind.CLIENT }, op.ctx);
     const spanCtx = trace.setSpan(op.ctx, span);
     span.setAttribute(SPAN_TYPE, "DEFAULT");
     span.setAttribute("ai.step.number", stepNumber);

--- a/packages/lmnr/test/aisdk-v7-telemetry.test.ts
+++ b/packages/lmnr/test/aisdk-v7-telemetry.test.ts
@@ -181,7 +181,7 @@ void describe("AI SDK v7 LaminarTelemetry integration", () => {
     assert.equal(op.attributes["ai.response.text"], "hello");
     assert.equal(op.attributes["ai.response.finishReason"], "stop");
 
-    const step = spans.find((s) => s.name === "ai.step 0");
+    const step = spans.find((s) => s.name === "ai.step");
     assert.ok(step, "step span missing");
     assert.equal(step.attributes[SPAN_TYPE], "DEFAULT");
     assert.equal(step.attributes["ai.step.number"], 0);
@@ -212,7 +212,7 @@ void describe("AI SDK v7 LaminarTelemetry integration", () => {
 
     // All three span kinds present.
     assert.ok(byName.has("ai.generateText"));
-    assert.ok(byName.has("ai.step 0"));
+    assert.ok(byName.has("ai.step"));
   });
 
   void it("makes tool spans flat siblings of llm under the step", () => {
@@ -640,7 +640,7 @@ void describe("AI SDK v7 LaminarTelemetry integration", () => {
 
     const spans = exporter.getFinishedSpans();
     const op = spans.find((s) => s.name === "ai.generateText");
-    const step = spans.find((s) => s.name === "ai.step 0");
+    const step = spans.find((s) => s.name === "ai.step");
     const llm = spans.find((s) => s.name.startsWith("ai.llm "));
     const tool = spans.find((s) => s.name === "ai.tool lookup");
     assert.ok(op && step && llm && tool);
@@ -675,7 +675,7 @@ void describe("AI SDK v7 LaminarTelemetry integration", () => {
     tel.onError({ callId, error: new Error("boom") });
 
     const spans = exporter.getFinishedSpans();
-    const step = spans.find((s) => s.name === "ai.step 0");
+    const step = spans.find((s) => s.name === "ai.step");
     const tool = spans.find((s) => s.name === "ai.tool lookup");
     assert.ok(step && tool);
 

--- a/packages/lmnr/test/aisdk-v7-telemetry.test.ts
+++ b/packages/lmnr/test/aisdk-v7-telemetry.test.ts
@@ -9,7 +9,6 @@ import {
   _resetConfiguration,
   initializeTracing,
 } from "../src/opentelemetry-lib/configuration";
-import { wrapAISDK } from "../src/opentelemetry-lib/instrumentation/aisdk";
 import {
   aiSdkTelemetry,
   LaminarAiSdkTelemetry,
@@ -505,35 +504,6 @@ void describe("AI SDK v7 LaminarTelemetry integration", () => {
       (x) => x !== integration,
     );
   });
-
-  void it(
-    "wrapAISDK injects the v7 integration into call args when " +
-      "registerTelemetry is present",
-    async () => {
-      const observed: unknown[] = [];
-      const fakeAI = {
-        registerTelemetry: () => {},
-        generateText: (opts: unknown) => {
-          observed.push(opts);
-          return Promise.resolve({ text: "ok" });
-        },
-      } as unknown as Parameters<typeof wrapAISDK>[0];
-      const wrapped = wrapAISDK(fakeAI);
-      await (
-        wrapped as unknown as { generateText: (o: unknown) => Promise<unknown> }
-      ).generateText({ prompt: "hi" });
-      const firstCall = observed[0] as {
-        telemetry?: { integrations?: unknown[] };
-      };
-      assert.ok(firstCall.telemetry);
-      assert.ok(Array.isArray(firstCall.telemetry.integrations));
-      assert.ok(
-        firstCall.telemetry.integrations.some(
-          (i) => i instanceof LaminarAiSdkTelemetry,
-        ),
-      );
-    },
-  );
 
   void it("onError scopes error to the callId on the event", () => {
     const tel = new LaminarAiSdkTelemetry();

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lmnr-ai/types",
-  "version": "0.8.31",
+  "version": "0.8.32",
   "description": "Shared types for Laminar AI SDK",
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -197,11 +197,11 @@ importers:
         specifier: ^3.0.0
         version: 3.0.10
       '@ai-sdk/provider-v2':
-        specifier: npm:@ai-sdk/provider@2.0.0
-        version: '@ai-sdk/provider@2.0.0'
+        specifier: npm:@ai-sdk/provider@ai-v5
+        version: '@ai-sdk/provider@2.0.3'
       '@ai-sdk/provider-v4-canary':
-        specifier: npm:@ai-sdk/provider@4.0.0-canary.17
-        version: '@ai-sdk/provider@4.0.0-canary.17'
+        specifier: npm:@ai-sdk/provider@4.0.0-canary.18
+        version: '@ai-sdk/provider@4.0.0-canary.18'
       '@aws-sdk/client-bedrock-runtime':
         specifier: ^3.1057.0
         version: 3.1057.0
@@ -249,10 +249,10 @@ importers:
         version: 7.7.1
       ai:
         specifier: ^6.0.3
-        version: 6.0.178(zod@4.4.3)
+        version: 6.0.205(zod@4.4.3)
       ai-v5:
-        specifier: npm:ai@5.0.116
-        version: ai@5.0.116(zod@4.4.3)
+        specifier: npm:ai@ai-v5
+        version: ai@5.0.202(zod@4.4.3)
       chromadb:
         specifier: ^3.0.10
         version: 3.4.3
@@ -326,14 +326,14 @@ importers:
 
 packages:
 
-  '@ai-sdk/gateway@2.0.23':
-    resolution: {integrity: sha512-qmX7afPRszUqG5hryHF3UN8ITPIRSGmDW6VYCmByzjoUkgm3MekzSx2hMV1wr0P+llDeuXb378SjqUfpvWJulg==}
+  '@ai-sdk/gateway@2.0.101':
+    resolution: {integrity: sha512-I6bqpMWUfJ3RbXyvrfNMudFoV9Iln/4DD5nWpklueyde5e1+FQUv4hXxOoBCfv3nj1cXycRH+R2OdsyJ0KVpxw==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/gateway@3.0.112':
-    resolution: {integrity: sha512-jiBao9pR4owWyjo0BnuNc7WSQBGOD0thysE4AFgZXaG+zMFbISQXUkJr7ePw/phBvePy7jE5FSA2Lf7lwqUiiQ==}
+  '@ai-sdk/gateway@3.0.131':
+    resolution: {integrity: sha512-CnjOZdywQaUnCyZ0N5wVNm7Sm63+NeHDVZQJKFX2IDq+t03SLwiiuoi3ILTLPlM+YSOhkQ/pvIDoR4qa98Zp5A==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -344,8 +344,8 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/provider-utils@3.0.19':
-    resolution: {integrity: sha512-W41Wc9/jbUVXVwCN/7bWa4IKe8MtxO3EyA0Hfhx6grnmiYlCvpI8neSYWFE0zScXJkgA/YK3BRybzgyiXuu6JA==}
+  '@ai-sdk/provider-utils@3.0.26':
+    resolution: {integrity: sha512-dNciNI4knep6z3cqDNng7yORCcBnEDBHZYj8rJLcLn9pLzEtNVkf6WLg9HR6AnVDDRxHsUeGAEqyF8M+FAtRgg==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -356,16 +356,22 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/provider@2.0.0':
-    resolution: {integrity: sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA==}
+  '@ai-sdk/provider-utils@4.0.29':
+    resolution: {integrity: sha512-uhukHaCBvqkwBHkT8C2PrnqKTCoLn3pdHXqtcR9I8ErH+flbzgW4o7VHSNIup9LRu+WBvZIZDQLsx6rwl2tiOA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider@2.0.3':
+    resolution: {integrity: sha512-h88OPkavHTiN9tMn2l5awAznGB0lXzjcLhgR1/rvjB2zlLprsNxbM2tt6OJsHUxduLC3klq0/eqaSf6fX5XVww==}
     engines: {node: '>=18'}
 
   '@ai-sdk/provider@3.0.10':
     resolution: {integrity: sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==}
     engines: {node: '>=18'}
 
-  '@ai-sdk/provider@4.0.0-canary.17':
-    resolution: {integrity: sha512-m/rtalImeIt7deuQGkEHehqlIPOM8Sjb0cF1b1SJ3B6Re+WYgbUkOK9gY2SSro1YO8jYBRgTMPz2qYzPtIzAxQ==}
+  '@ai-sdk/provider@4.0.0-canary.18':
+    resolution: {integrity: sha512-+XBwXEPkN+l/90bb7TaSK15jAq9ScsGrauJ/NLSGip0KX5Mf1pfEfqBWDuJMIYVRYHNdV1dDBy7JCoKUCQe/tA==}
     engines: {node: '>=22'}
 
   '@aws-crypto/crc32@5.2.0':
@@ -887,12 +893,6 @@ packages:
   '@mswjs/interceptors@0.41.9':
     resolution: {integrity: sha512-VVPPgHyQ6ShqnrmDWuxjmUIsO9gWyOZFmuOfLd9LfBGQJwZfy0gvv9pbHSJuoFNIYC7ZDX9aoFwowjcdSC4E8w==}
     engines: {node: '>=18'}
-
-  '@napi-rs/wasm-runtime@1.1.4':
-    resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
-    peerDependencies:
-      '@emnapi/core': ^1.7.1
-      '@emnapi/runtime': ^1.7.1
 
   '@napi-rs/wasm-runtime@1.1.5':
     resolution: {integrity: sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==}
@@ -1624,8 +1624,8 @@ packages:
     resolution: {integrity: sha512-yURCknZhvywvQItHMMmFSo+fq5arCUIyz/CVk7jD89MSai7dkaX8ufjCWp3NttLojoTVbcE72ri+be/TnEbMHw==}
     engines: {node: '>=20.0.0'}
 
-  '@vercel/oidc@3.0.5':
-    resolution: {integrity: sha512-fnYhv671l+eTTp48gB4zEsTW/YtRgRPnkI2nT7x6qw5rkI1Lq2hTmQIpHPgyThI0znLK+vX2n9XxKdXZ7BUbbw==}
+  '@vercel/oidc@3.1.0':
+    resolution: {integrity: sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==}
     engines: {node: '>= 20'}
 
   '@vercel/oidc@3.2.0':
@@ -1684,14 +1684,14 @@ packages:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
 
-  ai@5.0.116:
-    resolution: {integrity: sha512-+2hYJ80/NcDWuv9K2/MLP3cTCFgwWHmHlS1tOpFUKKcmLbErAAlE/S2knsKboc3PNAu8pQkDr2N3K/Vle7ENgQ==}
+  ai@5.0.202:
+    resolution: {integrity: sha512-acC5GPzYN2k+7+SPnTjIgtUG4NYMq2VYuyCfLyVMubasH1Q2G4/eb6gZbLRrWMlcBNzzfOrIZzf0b+V9+yGUkw==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  ai@6.0.178:
-    resolution: {integrity: sha512-8PcUmzAkco40EO4fTCij3mN+u/KmX8CZrLOuMrnM7UQvtdPW1W3OBb8RrJUamMD/yFtaLkSDL4DkFzkMJ3kkFg==}
+  ai@6.0.205:
+    resolution: {integrity: sha512-F4akEGF41UdgJO3L4v+D5noVD1/czhJy6x0k9R/i1EXfxqrkBh/PdYSgRSLPiGFvrw76dzI8h4w3NYmLrTb8dw==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -3482,17 +3482,17 @@ packages:
 
 snapshots:
 
-  '@ai-sdk/gateway@2.0.23(zod@4.4.3)':
+  '@ai-sdk/gateway@2.0.101(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/provider': 2.0.0
-      '@ai-sdk/provider-utils': 3.0.19(zod@4.4.3)
-      '@vercel/oidc': 3.0.5
+      '@ai-sdk/provider': 2.0.3
+      '@ai-sdk/provider-utils': 3.0.26(zod@4.4.3)
+      '@vercel/oidc': 3.1.0
       zod: 4.4.3
 
-  '@ai-sdk/gateway@3.0.112(zod@4.4.3)':
+  '@ai-sdk/gateway@3.0.131(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 3.0.10
-      '@ai-sdk/provider-utils': 4.0.27(zod@4.4.3)
+      '@ai-sdk/provider-utils': 4.0.29(zod@4.4.3)
       '@vercel/oidc': 3.2.0
       zod: 4.4.3
 
@@ -3502,9 +3502,9 @@ snapshots:
       '@ai-sdk/provider-utils': 4.0.27(zod@4.4.3)
       zod: 4.4.3
 
-  '@ai-sdk/provider-utils@3.0.19(zod@4.4.3)':
+  '@ai-sdk/provider-utils@3.0.26(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/provider': 2.0.0
+      '@ai-sdk/provider': 2.0.3
       '@standard-schema/spec': 1.1.0
       eventsource-parser: 3.0.8
       zod: 4.4.3
@@ -3516,7 +3516,14 @@ snapshots:
       eventsource-parser: 3.0.8
       zod: 4.4.3
 
-  '@ai-sdk/provider@2.0.0':
+  '@ai-sdk/provider-utils@4.0.29(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.10
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.0.8
+      zod: 4.4.3
+
+  '@ai-sdk/provider@2.0.3':
     dependencies:
       json-schema: 0.4.0
 
@@ -3524,7 +3531,7 @@ snapshots:
     dependencies:
       json-schema: 0.4.0
 
-  '@ai-sdk/provider@4.0.0-canary.17':
+  '@ai-sdk/provider@4.0.0-canary.18':
     dependencies:
       json-schema: 0.4.0
 
@@ -4132,7 +4139,7 @@ snapshots:
       outvariant: 1.4.3
       strict-event-emitter: 0.5.1
 
-  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+  '@napi-rs/wasm-runtime@1.1.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
@@ -4633,7 +4640,7 @@ snapshots:
     dependencies:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@napi-rs/wasm-runtime': 1.1.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
   '@rolldown/binding-wasm32-wasi@1.1.1':
@@ -4968,8 +4975,8 @@ snapshots:
       '@typescript-eslint/visitor-keys': 8.59.3
       debug: 4.4.3
       minimatch: 10.2.5
-      semver: 7.8.0
-      tinyglobby: 0.2.16
+      semver: 7.8.4
+      tinyglobby: 0.2.17
       ts-api-utils: 2.5.0(typescript@6.0.3)
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -4999,7 +5006,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vercel/oidc@3.0.5': {}
+  '@vercel/oidc@3.1.0': {}
 
   '@vercel/oidc@3.2.0': {}
 
@@ -5062,19 +5069,19 @@ snapshots:
 
   agent-base@7.1.4: {}
 
-  ai@5.0.116(zod@4.4.3):
+  ai@5.0.202(zod@4.4.3):
     dependencies:
-      '@ai-sdk/gateway': 2.0.23(zod@4.4.3)
-      '@ai-sdk/provider': 2.0.0
-      '@ai-sdk/provider-utils': 3.0.19(zod@4.4.3)
+      '@ai-sdk/gateway': 2.0.101(zod@4.4.3)
+      '@ai-sdk/provider': 2.0.3
+      '@ai-sdk/provider-utils': 3.0.26(zod@4.4.3)
       '@opentelemetry/api': 1.9.0
       zod: 4.4.3
 
-  ai@6.0.178(zod@4.4.3):
+  ai@6.0.205(zod@4.4.3):
     dependencies:
-      '@ai-sdk/gateway': 3.0.112(zod@4.4.3)
+      '@ai-sdk/gateway': 3.0.131(zod@4.4.3)
       '@ai-sdk/provider': 3.0.10
-      '@ai-sdk/provider-utils': 4.0.27(zod@4.4.3)
+      '@ai-sdk/provider-utils': 4.0.29(zod@4.4.3)
       '@opentelemetry/api': 1.9.1
       zod: 4.4.3
 
@@ -6762,7 +6769,7 @@ snapshots:
 
   unrun@0.3.0:
     dependencies:
-      rolldown: 1.0.0
+      rolldown: 1.1.1
 
   uri-js@4.4.1:
     dependencies:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> v7 apps that relied on wrapAISDK silently lose automatic telemetry until they migrate to LaminarAiSdkTelemetry; constructor-side Laminar.initialize can change init ordering vs explicit setup.
> 
> **Overview**
> **Release 0.8.32** bumps package versions and refreshes dev AI SDK aliases (`ai-v5`, `@ai-sdk/provider` canary).
> 
> **AI SDK v7 telemetry** now **auto-initializes Laminar** when you construct `LaminarAiSdkTelemetry` (or factories) if tracing is not already up, via new optional **`laminarOptions`** on `LaminarAiSdkTelemetryOptions`. **`LaminarInitializeProps`** is exported from the public API for typing that config.
> 
> **`wrapAISDK()`** no longer patches v7 calls: if `registerTelemetry` is detected it logs a **one-time warning**, returns the module unchanged, and directs apps to **`registerTelemetry(new LaminarAiSdkTelemetry())`**. v6 still gets **`experimental_telemetry`** injection only.
> 
> Step spans are renamed from **`ai.step N`** to a fixed **`ai.step`** name with **`ai.step.number`** on attributes; tests were updated accordingly and the old “wrapAISDK injects v7 integration” test was removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f54ba5c2d691e27d57b779e6f69f598f714e95de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->