### PR TITLE
fix: bump CLI version for this SQL clusters schema changes

### DIFF
--- a/packages/lmnr-cli/package.json
+++ b/packages/lmnr-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lmnr-cli",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "CLI for the Laminar agent observability platform",
   "main": "dist/index.cjs",
   "bin": {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Metadata-only version increment with no runtime or schema code changes in this PR.
> 
> **Overview**
> Bumps **`lmnr-cli`** from **0.1.13** to **0.1.14** in `packages/lmnr-cli/package.json` so the next npm publish reflects the SQL clusters schema work (per PR intent); no other files change in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74360389c34918e7a865e1c669910f8cd8fcb5cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->