### PR TITLE
mimic pre v7 behaviour when function id is passed

### DIFF
--- a/packages/lmnr/src/opentelemetry-lib/instrumentation/aisdk/v7-integration/index.ts
+++ b/packages/lmnr/src/opentelemetry-lib/instrumentation/aisdk/v7-integration/index.ts
@@ -143,9 +143,27 @@ export class LaminarAiSdkTelemetry {
     if (!callId) return;
     const parentCtx = LaminarContextManager.getContext();
     const tracer = getTracer();
+    let spanName = event.operationId ?? "ai.operation";
+    // If an explicit { telemetry: { functionId: "..." } } is passed
+    // rename the span to match the pre-v7 AI SDK behaviour
+    if (typeof event.functionId === "string") {
+      spanName += ` ${event.functionId}`;
+    }
     const span = tracer.startSpan(
-      event.operationId ?? "unknown",
-      { kind: SpanKind.CLIENT },
+      spanName,
+      {
+        kind: SpanKind.CLIENT,
+        attributes: {
+          [SPAN_TYPE]: "DEFAULT",
+          ...(typeof event.functionId === "string"
+            ? {
+              "operation.name": event.functionId,
+              // legacy, needed for older parsing at the backend to work
+              "ai.prompt": "_",
+            }
+            : {}),
+        },
+      },
       parentCtx,
     );
     const spanCtx = trace.setSpan(parentCtx, span);

--- a/packages/lmnr/test/aisdk-v7-telemetry.test.ts
+++ b/packages/lmnr/test/aisdk-v7-telemetry.test.ts
@@ -937,4 +937,37 @@ void describe("AI SDK v7 LaminarTelemetry integration", () => {
       [{ role: "assistant", parts: [{ type: "text", content: '{"x":1}' }] }],
     );
   });
+
+  void it("appends functionId to name and sets attributes when functionId is provided", () => {
+    const tel = new LaminarAiSdkTelemetry();
+    const callId = "call-functionid";
+
+    tel.onStart(mkStartEvent(callId, { functionId: "myFunction" }));
+    tel.onEnd(mkFinish(callId));
+
+    const spans = exporter.getFinishedSpans();
+    const op = spans.find((s) => s.name === "ai.generateText myFunction");
+    assert.ok(op, "operation span with functionId suffix missing");
+    assert.equal(op.attributes["operation.name"], "myFunction");
+    assert.equal(
+      typeof op.attributes["ai.prompt"],
+      "string",
+      "ai.prompt should be a string",
+    );
+    assert.equal(op.attributes["ai.functionId"], "myFunction");
+  });
+
+  void it("does not set operation.name or ai.prompt when functionId is absent", () => {
+    const tel = new LaminarAiSdkTelemetry();
+    const callId = "call-no-functionid";
+
+    tel.onStart(mkStartEvent(callId));
+    tel.onEnd(mkFinish(callId));
+
+    const spans = exporter.getFinishedSpans();
+    const op = spans.find((s) => s.name === "ai.generateText");
+    assert.ok(op, "operation span missing");
+    assert.equal(op.attributes["operation.name"], undefined);
+    assert.equal(op.attributes["ai.prompt"], undefined);
+  });
 });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Telemetry-only span naming and attribute tweaks for an optional field; no auth, data, or runtime execution changes.
> 
> **Overview**
> When **`experimental_telemetry.functionId`** is passed on AI SDK v7 calls, the Laminar v7 integration now matches older telemetry behavior for the root operation span.
> 
> **Span naming:** the operation span name is **`{operationId} {functionId}`** (e.g. `ai.generateText myFunction`) instead of only the operation id; the default fallback name is **`ai.operation`** rather than `unknown`.
> 
> **Attributes at span start:** if `functionId` is a string, the span gets **`operation.name`**, a legacy placeholder **`ai.prompt: "_"`** (for existing backend parsing), and **`SPAN_TYPE: DEFAULT`** in the initial attribute set. **`ai.functionId`** was already set later in `onStart` and is unchanged.
> 
> **Tests** assert the suffixed name and attributes when `functionId` is present, and that **`operation.name`** / **`ai.prompt`** stay unset when it is omitted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1265c299d761dd0e36219c921f9271be945f59c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->