### PR TITLE
bump version to 0.8.34

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@lmnr-ai/lmnr-ts",
   "private": true,
-  "version": "0.8.33",
+  "version": "0.8.34",
   "description": "Laminar AI TypeScript SDK",
   "scripts": {
     "build": "pnpm -r build",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lmnr-ai/client",
-  "version": "0.8.33",
+  "version": "0.8.34",
   "description": "HTTP client for Laminar AI API",
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",

--- a/packages/lmnr/package.json
+++ b/packages/lmnr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lmnr-ai/lmnr",
-  "version": "0.8.33",
+  "version": "0.8.34",
   "description": "TypeScript SDK for Laminar AI",
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lmnr-ai/types",
-  "version": "0.8.33",
+  "version": "0.8.34",
   "description": "Shared types for Laminar AI SDK",
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Metadata-only version bumps with no runtime or API code changes.
> 
> **Overview**
> Bumps the published SDK version from **0.8.33** to **0.8.34** across the monorepo so workspace packages stay aligned for release.
> 
> The `version` field is updated in the root `@lmnr-ai/lmnr-ts` package and in `@lmnr-ai/client`, `@lmnr-ai/lmnr`, and `@lmnr-ai/types`; no application or library source changes are included in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d02233b1d65ea703cac2c6c884bd1a2dc07f919e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->