### PR TITLE
feat/ask agent

### DIFF
--- a/packages/lmnr-cli/package.json
+++ b/packages/lmnr-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lmnr-cli",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "CLI for the Laminar agent observability platform",
   "main": "dist/index.cjs",
   "bin": {

--- a/packages/lmnr-cli/src/commands/ask.ts
+++ b/packages/lmnr-cli/src/commands/ask.ts
@@ -94,7 +94,9 @@ export const handleAsk = async (query: string, opts: AskOpts): Promise<void> => 
         if (frame.conversationId) conversationId = frame.conversationId;
         break;
       case "delta":
-        if (typeof frame.text === "string") {
+        // Only a NON-EMPTY delta counts as streamed: an empty token writes nothing but would still
+        // flip `streamed`, suppressing the `message`-frame fallback that carries the full answer.
+        if (typeof frame.text === "string" && frame.text.length > 0) {
           answer += frame.text;
           process.stdout.write(frame.text);
           streamed = true;

--- a/packages/lmnr-cli/src/commands/ask.ts
+++ b/packages/lmnr-cli/src/commands/ask.ts
@@ -43,7 +43,8 @@ export const handleAsk = async (query: string, opts: GlobalOpts): Promise<void> 
       Authorization: `Bearer ${bearer}`,
       "x-lmnr-project-id": projectId,
       "Content-Type": "application/json",
-      Accept: "text/event-stream",
+      // Content negotiation: agents/scripts (`--json`) get one buffered JSON result; humans stream.
+      Accept: opts.json ? "application/json" : "text/event-stream",
     },
     body: JSON.stringify({ message: question }),
   });
@@ -54,16 +55,21 @@ export const handleAsk = async (query: string, opts: GlobalOpts): Promise<void> 
     throw new Error(`Agent request failed (HTTP ${res.status})${suffix}`);
   }
 
-  // Stream-parse the SSE frames: `delta` tokens form the answer (stdout), tool
-  // calls surface as activity (stderr), a trailing `error` frame aborts.
+  // `--json`: the server buffered the whole run into one `{ answer, sessionId, tools }` object — no
+  // stream to parse. Emit it verbatim.
+  if (opts.json) {
+    outputJson(await res.json());
+    return;
+  }
+
+  // Human mode: stream-parse the SSE frames — `delta` tokens form the answer (stdout), thoughts +
+  // tool calls surface as activity (stderr), a trailing `error` frame aborts.
   const reader = res.body.getReader();
   const decoder = new TextDecoder();
   let buffer = "";
-  let sessionId: string | undefined;
   let answer = "";
   let streamed = false;
   let failure: string | undefined;
-  const tools: string[] = [];
 
   const onFrame = (data: string): void => {
     let frame: AgentFrame;
@@ -73,20 +79,15 @@ export const handleAsk = async (query: string, opts: GlobalOpts): Promise<void> 
       return; // ignore keep-alives / malformed lines
     }
     switch (frame.type) {
-      case "session":
-        sessionId = frame.sessionId;
-        break;
       case "delta":
         if (typeof frame.text === "string") {
           answer += frame.text;
-          if (!opts.json) {
-            process.stdout.write(frame.text);
-            streamed = true;
-          }
+          process.stdout.write(frame.text);
+          streamed = true;
         }
         break;
       case "thought":
-        if (!opts.json && typeof frame.text === "string") {
+        if (typeof frame.text === "string") {
           process.stderr.write(pc.dim(frame.text));
         }
         break;
@@ -95,8 +96,7 @@ export const handleAsk = async (query: string, opts: GlobalOpts): Promise<void> 
         if (frame.message?.role === "assistant") {
           for (const part of parts) {
             if (part.type === "toolCall" && part.name) {
-              tools.push(part.name);
-              if (!opts.json) process.stderr.write(pc.dim(`\n  → ${part.name}\n`));
+              process.stderr.write(pc.dim(`\n  → ${part.name}\n`));
             }
           }
           // Final assistant text: only used if no deltas streamed it (defensive).
@@ -143,10 +143,6 @@ export const handleAsk = async (query: string, opts: GlobalOpts): Promise<void> 
 
   if (failure) throw new Error(failure);
 
-  if (opts.json) {
-    outputJson({ answer: answer.trim(), sessionId, tools });
-    return;
-  }
   if (streamed) {
     process.stdout.write("\n");
   } else if (answer.trim()) {

--- a/packages/lmnr-cli/src/commands/ask.ts
+++ b/packages/lmnr-cli/src/commands/ask.ts
@@ -9,8 +9,8 @@ import { outputJson } from "../utils/output";
  * stream stays forward-compatible.
  */
 interface AgentFrame {
-  type: "session" | "delta" | "thought" | "message" | "finish" | "error";
-  sessionId?: string;
+  type: "conversation" | "delta" | "thought" | "message" | "finish" | "error";
+  conversationId?: string;
   text?: string;
   message?: { role: string; parts?: { type: string; text?: string; name?: string }[] };
 }
@@ -55,7 +55,7 @@ export const handleAsk = async (query: string, opts: GlobalOpts): Promise<void> 
     throw new Error(`Agent request failed (HTTP ${res.status})${suffix}`);
   }
 
-  // `--json`: the server buffered the whole run into one `{ answer, sessionId, tools }` object — no
+  // `--json`: the server buffered the whole run into one `{ answer, conversationId, tools }` object — no
   // stream to parse. Emit it verbatim.
   if (opts.json) {
     outputJson(await res.json());

--- a/packages/lmnr-cli/src/commands/ask.ts
+++ b/packages/lmnr-cli/src/commands/ask.ts
@@ -1,0 +1,200 @@
+import { probeProjectKey } from "../auth/project-id";
+import { envHttpPort, resolveBaseUrl } from "../auth/resolve";
+import type { GlobalOpts } from "../auth/with-client";
+import { pc } from "../utils/colors";
+import { readLocalProjectFile } from "../utils/local-project-file";
+import { outputJson } from "../utils/output";
+
+const PROJECT_API_KEY_ENV = "LMNR_PROJECT_API_KEY";
+
+/**
+ * One SSE frame from the app-server agent stream (`AgentEvent`, camelCase). Only
+ * the fields the CLI consumes are typed; unknown variants are ignored so the
+ * stream stays forward-compatible.
+ */
+interface AgentFrame {
+  type: "session" | "delta" | "thought" | "message" | "finish" | "error";
+  sessionId?: string;
+  text?: string;
+  message?: { role: string; parts?: { type: string; text?: string; name?: string }[] };
+}
+
+/**
+ * Resolve the project the question targets: explicit `--project-id` → the linked
+ * `.lmnr/project.json` → `LMNR_PROJECT_ID` → probe which project the API key owns.
+ */
+async function resolveProjectId(
+  optProjectId: string | undefined,
+  projectApiKey: string,
+  baseUrl: string,
+  port: number | undefined,
+): Promise<string> {
+  const explicit =
+    optProjectId?.trim() ||
+    (await readLocalProjectFile())?.projectId ||
+    process.env.LMNR_PROJECT_ID?.trim();
+  if (explicit) return explicit;
+
+  const probe = await probeProjectKey(projectApiKey, baseUrl, port);
+  if (probe.status === "ok") return probe.projectId;
+  if (probe.status === "invalid") {
+    throw new Error(
+      "Project API key is invalid or revoked. Run `lmnr-cli setup` to mint a fresh one.",
+    );
+  }
+  throw new Error(
+    "No project resolved. Pass --project-id, set LMNR_PROJECT_ID, or run `lmnr-cli setup`.",
+  );
+}
+
+/**
+ * `lmnr-cli ask "<question>"` — ask the Laminar agent a natural-language question
+ * about the project. Streams the agent's answer to stdout (tool activity to
+ * stderr). Authenticates with the project API key (`LMNR_PROJECT_API_KEY`, written
+ * by `lmnr-cli setup`) against the project-scoped agent endpoint, tagging the run
+ * as the `cli` channel. Pure handler: `withLocalOpts` owns the error envelope.
+ */
+export const handleAsk = async (query: string, opts: GlobalOpts): Promise<void> => {
+  const question = query?.trim();
+  if (!question) {
+    throw new Error('Provide a question, e.g. lmnr-cli ask "why did my latest trace fail?"');
+  }
+
+  const projectApiKey = process.env[PROJECT_API_KEY_ENV]?.trim();
+  if (!projectApiKey) {
+    throw new Error(
+      `No ${PROJECT_API_KEY_ENV}. Run \`lmnr-cli setup\` to write it to ./.env, ` +
+        "or set it in the environment.",
+    );
+  }
+
+  const baseUrl = resolveBaseUrl(opts.baseUrl);
+  const port = opts.port ?? envHttpPort();
+  const projectId = await resolveProjectId(opts.projectId, projectApiKey, baseUrl, port);
+
+  // baseUrl carries no port by convention; splice the resolved port onto the URL.
+  const url = new URL(baseUrl.replace(/\/+$/, ""));
+  if (port) url.port = String(port);
+  url.pathname = `/api/v1/projects/${projectId}/agent/chat`;
+
+  const res = await fetch(url.toString(), {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${projectApiKey}`,
+      "Content-Type": "application/json",
+      Accept: "text/event-stream",
+    },
+    body: JSON.stringify({
+      context: { type: "project" },
+      channelType: "cli",
+      messages: [{ role: "user", parts: [{ type: "text", text: question }] }],
+    }),
+  });
+
+  if (!res.ok || !res.body) {
+    const detail = await res.text().catch(() => "");
+    const suffix = detail ? `: ${detail.slice(0, 500)}` : "";
+    throw new Error(`Agent request failed (HTTP ${res.status})${suffix}`);
+  }
+
+  // Stream-parse the SSE frames: `delta` tokens form the answer (stdout), tool
+  // calls surface as activity (stderr), a trailing `error` frame aborts.
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  let sessionId: string | undefined;
+  let answer = "";
+  let streamed = false;
+  let failure: string | undefined;
+  const tools: string[] = [];
+
+  const onFrame = (data: string): void => {
+    let frame: AgentFrame;
+    try {
+      frame = JSON.parse(data) as AgentFrame;
+    } catch {
+      return; // ignore keep-alives / malformed lines
+    }
+    switch (frame.type) {
+      case "session":
+        sessionId = frame.sessionId;
+        break;
+      case "delta":
+        if (typeof frame.text === "string") {
+          answer += frame.text;
+          if (!opts.json) {
+            process.stdout.write(frame.text);
+            streamed = true;
+          }
+        }
+        break;
+      case "thought":
+        if (!opts.json && typeof frame.text === "string") {
+          process.stderr.write(pc.dim(frame.text));
+        }
+        break;
+      case "message": {
+        const parts = frame.message?.parts ?? [];
+        if (frame.message?.role === "assistant") {
+          for (const part of parts) {
+            if (part.type === "toolCall" && part.name) {
+              tools.push(part.name);
+              if (!opts.json) process.stderr.write(pc.dim(`\n  → ${part.name}\n`));
+            }
+          }
+          // Final assistant text: only used if no deltas streamed it (defensive).
+          const text = parts
+            .filter((p) => p.type === "text" && typeof p.text === "string")
+            .map((p) => p.text)
+            .join("");
+          if (text) answer = text;
+        }
+        break;
+      }
+      case "error": {
+        // The `error` frame's `message` is a string (the `message` frame's is the
+        // ChatMessage object) — read it off the raw payload.
+        const raw = (frame as unknown as { message?: unknown }).message;
+        failure = typeof raw === "string" && raw.length > 0 ? raw : "Agent error";
+        break;
+      }
+      case "finish":
+        break;
+    }
+  };
+
+  const drain = (chunk: string): void => {
+    buffer += chunk;
+    let idx: number;
+    while ((idx = buffer.indexOf("\n\n")) !== -1) {
+      const event = buffer.slice(0, idx);
+      buffer = buffer.slice(idx + 2);
+      const dataLine = event.split("\n").find((l) => l.startsWith("data:"));
+      if (dataLine) onFrame(dataLine.slice("data:".length).trim());
+    }
+  };
+
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    drain(decoder.decode(value, { stream: true }));
+  }
+  drain(decoder.decode());
+  // Flush a trailing unterminated frame, if any.
+  const tail = buffer.split("\n").find((l) => l.startsWith("data:"));
+  if (tail) onFrame(tail.slice("data:".length).trim());
+
+  if (failure) throw new Error(failure);
+
+  if (opts.json) {
+    outputJson({ answer: answer.trim(), sessionId, tools });
+    return;
+  }
+  if (streamed) {
+    process.stdout.write("\n");
+  } else if (answer.trim()) {
+    process.stdout.write(`${answer.trim()}\n`);
+  } else {
+    process.stderr.write(pc.dim("(the agent returned no answer)\n"));
+  }
+};

--- a/packages/lmnr-cli/src/commands/ask.ts
+++ b/packages/lmnr-cli/src/commands/ask.ts
@@ -1,11 +1,7 @@
-import { probeProjectKey } from "../auth/project-id";
-import { envHttpPort, resolveBaseUrl } from "../auth/resolve";
+import { resolveAuth } from "../auth/resolve";
 import type { GlobalOpts } from "../auth/with-client";
 import { pc } from "../utils/colors";
-import { readLocalProjectFile } from "../utils/local-project-file";
 import { outputJson } from "../utils/output";
-
-const PROJECT_API_KEY_ENV = "LMNR_PROJECT_API_KEY";
 
 /**
  * One SSE frame from the app-server agent stream (`AgentEvent`, camelCase). Only
@@ -20,39 +16,12 @@ interface AgentFrame {
 }
 
 /**
- * Resolve the project the question targets: explicit `--project-id` → the linked
- * `.lmnr/project.json` → `LMNR_PROJECT_ID` → probe which project the API key owns.
- */
-async function resolveProjectId(
-  optProjectId: string | undefined,
-  projectApiKey: string,
-  baseUrl: string,
-  port: number | undefined,
-): Promise<string> {
-  const explicit =
-    optProjectId?.trim() ||
-    (await readLocalProjectFile())?.projectId ||
-    process.env.LMNR_PROJECT_ID?.trim();
-  if (explicit) return explicit;
-
-  const probe = await probeProjectKey(projectApiKey, baseUrl, port);
-  if (probe.status === "ok") return probe.projectId;
-  if (probe.status === "invalid") {
-    throw new Error(
-      "Project API key is invalid or revoked. Run `lmnr-cli setup` to mint a fresh one.",
-    );
-  }
-  throw new Error(
-    "No project resolved. Pass --project-id, set LMNR_PROJECT_ID, or run `lmnr-cli setup`.",
-  );
-}
-
-/**
  * `lmnr-cli ask "<question>"` — ask the Laminar agent a natural-language question
  * about the project. Streams the agent's answer to stdout (tool activity to
- * stderr). Authenticates with the project API key (`LMNR_PROJECT_API_KEY`, written
- * by `lmnr-cli setup`) against the project-scoped agent endpoint, tagging the run
- * as the `cli` channel. Pure handler: `withLocalOpts` owns the error envelope.
+ * stderr). User-token authed (the stored BetterAuth JWT, auto-refreshed — like the
+ * rest of the CLI) against the `/v1/cli/agent/chat` twin: the project rides in the
+ * `x-lmnr-project-id` header and the run is tagged the `cli` channel server-side.
+ * Pure handler: `withLocalOpts` owns the error envelope.
  */
 export const handleAsk = async (query: string, opts: GlobalOpts): Promise<void> => {
   const question = query?.trim();
@@ -60,33 +29,23 @@ export const handleAsk = async (query: string, opts: GlobalOpts): Promise<void> 
     throw new Error('Provide a question, e.g. lmnr-cli ask "why did my latest trace fail?"');
   }
 
-  const projectApiKey = process.env[PROJECT_API_KEY_ENV]?.trim();
-  if (!projectApiKey) {
-    throw new Error(
-      `No ${PROJECT_API_KEY_ENV}. Run \`lmnr-cli setup\` to write it to ./.env, ` +
-        "or set it in the environment.",
-    );
-  }
-
-  const baseUrl = resolveBaseUrl(opts.baseUrl);
-  const port = opts.port ?? envHttpPort();
-  const projectId = await resolveProjectId(opts.projectId, projectApiKey, baseUrl, port);
+  // User-token auth (auto-refreshed) + resolved project — same resolution `withProjectClient` uses.
+  const { bearer, baseUrl, port, projectId } = await resolveAuth(opts);
 
   // baseUrl carries no port by convention; splice the resolved port onto the URL.
   const url = new URL(baseUrl.replace(/\/+$/, ""));
   if (port) url.port = String(port);
-  url.pathname = `/api/v1/projects/${projectId}/agent/chat`;
+  url.pathname = "/v1/cli/agent/chat";
 
   const res = await fetch(url.toString(), {
     method: "POST",
     headers: {
-      Authorization: `Bearer ${projectApiKey}`,
+      Authorization: `Bearer ${bearer}`,
+      "x-lmnr-project-id": projectId,
       "Content-Type": "application/json",
       Accept: "text/event-stream",
     },
     body: JSON.stringify({
-      context: { type: "project" },
-      channelType: "cli",
       messages: [{ role: "user", parts: [{ type: "text", text: question }] }],
     }),
   });

--- a/packages/lmnr-cli/src/commands/ask.ts
+++ b/packages/lmnr-cli/src/commands/ask.ts
@@ -55,8 +55,8 @@ export const handleAsk = async (query: string, opts: GlobalOpts): Promise<void> 
     throw new Error(`Agent request failed (HTTP ${res.status})${suffix}`);
   }
 
-  // `--json`: the server buffered the whole run into one `{ answer, conversationId, tools }` object — no
-  // stream to parse. Emit it verbatim.
+  // `--json`: the server buffered the run into `{ answer, conversationId, tools }` — no stream
+  // to parse. Emit it verbatim.
   if (opts.json) {
     outputJson(await res.json());
     return;

--- a/packages/lmnr-cli/src/commands/ask.ts
+++ b/packages/lmnr-cli/src/commands/ask.ts
@@ -15,15 +15,20 @@ interface AgentFrame {
   message?: { role: string; parts?: { type: string; text?: string; name?: string }[] };
 }
 
+/** `ask`-specific opts on top of the shared globals. `conversation` continues a prior session. */
+type AskOpts = GlobalOpts & { conversation?: string };
+
 /**
  * `lmnr-cli ask "<question>"` — ask the Laminar agent a natural-language question
  * about the project. Streams the agent's answer to stdout (tool activity to
  * stderr). User-token authed (the stored BetterAuth JWT, auto-refreshed — like the
  * rest of the CLI) against the `/v1/cli/agent/chat` twin: the project rides in the
  * `x-lmnr-project-id` header and the run is tagged the `cli` channel server-side.
+ * Pass `--conversation <id>` to continue a prior session; the resolved id is echoed
+ * (muted, on stderr) after each answer so the next turn can reuse it.
  * Pure handler: `withLocalOpts` owns the error envelope.
  */
-export const handleAsk = async (query: string, opts: GlobalOpts): Promise<void> => {
+export const handleAsk = async (query: string, opts: AskOpts): Promise<void> => {
   const question = query?.trim();
   if (!question) {
     throw new Error('Provide a question, e.g. lmnr-cli ask "why did my latest trace fail?"');
@@ -46,7 +51,11 @@ export const handleAsk = async (query: string, opts: GlobalOpts): Promise<void> 
       // Content negotiation: agents/scripts (`--json`) get one buffered JSON result; humans stream.
       Accept: opts.json ? "application/json" : "text/event-stream",
     },
-    body: JSON.stringify({ message: question }),
+    // `--conversation` continues a prior session; omitted → server mints a fresh one and echoes it.
+    body: JSON.stringify({
+      message: question,
+      ...(opts.conversation ? { conversationId: opts.conversation } : {}),
+    }),
   });
 
   if (!res.ok || !res.body) {
@@ -70,6 +79,8 @@ export const handleAsk = async (query: string, opts: GlobalOpts): Promise<void> 
   let answer = "";
   let streamed = false;
   let failure: string | undefined;
+  // Resolved server-side; arrives on the leading `conversation` frame (or equals `--conversation`).
+  let conversationId: string | undefined = opts.conversation;
 
   const onFrame = (data: string): void => {
     let frame: AgentFrame;
@@ -79,6 +90,9 @@ export const handleAsk = async (query: string, opts: GlobalOpts): Promise<void> 
       return; // ignore keep-alives / malformed lines
     }
     switch (frame.type) {
+      case "conversation":
+        if (frame.conversationId) conversationId = frame.conversationId;
+        break;
       case "delta":
         if (typeof frame.text === "string") {
           answer += frame.text;
@@ -149,5 +163,13 @@ export const handleAsk = async (query: string, opts: GlobalOpts): Promise<void> 
     process.stdout.write(`${answer.trim()}\n`);
   } else {
     process.stderr.write(pc.dim("(the agent returned no answer)\n"));
+  }
+
+  // Echo a ready-to-run continuation hint (muted, on stderr so stdout stays the clean answer) —
+  // copy it into the next turn's `--conversation`.
+  if (conversationId) {
+    process.stderr.write(
+      pc.dim(`\ncontinue with: lmnr-cli ask "<question>" --conversation ${conversationId}\n`),
+    );
   }
 };

--- a/packages/lmnr-cli/src/commands/ask.ts
+++ b/packages/lmnr-cli/src/commands/ask.ts
@@ -19,14 +19,10 @@ interface AgentFrame {
 type AskOpts = GlobalOpts & { conversation?: string };
 
 /**
- * `lmnr-cli ask "<question>"` — ask the Laminar agent a natural-language question
- * about the project. Streams the agent's answer to stdout (tool activity to
- * stderr). User-token authed (the stored BetterAuth JWT, auto-refreshed — like the
- * rest of the CLI) against the `/v1/cli/agent/chat` twin: the project rides in the
- * `x-lmnr-project-id` header and the run is tagged the `cli` channel server-side.
- * Pass `--conversation <id>` to continue a prior session; the resolved id is echoed
- * (muted, on stderr) after each answer so the next turn can reuse it.
- * Pure handler: `withLocalOpts` owns the error envelope.
+ * `lmnr-cli ask "<question>"` — ask the Laminar agent a natural-language question.
+ * User-token authed (like the rest of the CLI) against `/v1/cli/agent/chat`, project
+ * in the `x-lmnr-project-id` header; streams the answer to stdout (activity to stderr).
+ * `--conversation <id>` continues a prior session (its id is echoed on stderr).
  */
 export const handleAsk = async (query: string, opts: AskOpts): Promise<void> => {
   const question = query?.trim();

--- a/packages/lmnr-cli/src/commands/ask.ts
+++ b/packages/lmnr-cli/src/commands/ask.ts
@@ -45,9 +45,7 @@ export const handleAsk = async (query: string, opts: GlobalOpts): Promise<void> 
       "Content-Type": "application/json",
       Accept: "text/event-stream",
     },
-    body: JSON.stringify({
-      messages: [{ role: "user", parts: [{ type: "text", text: question }] }],
-    }),
+    body: JSON.stringify({ message: question }),
   });
 
   if (!res.ok || !res.body) {

--- a/packages/lmnr-cli/src/commands/setup/index.ts
+++ b/packages/lmnr-cli/src/commands/setup/index.ts
@@ -9,6 +9,7 @@ import { type Credentials, readCredentials } from "../../auth/credentials";
 import { envHttpPort, refreshIfNeeded } from "../../auth/resolve";
 import { orange, pc, pcOut } from "../../utils/colors";
 import {
+  type EnvKeyLocation,
   findEnvKey,
   isPathGitIgnored,
   resolveEnvWriteTarget,
@@ -142,7 +143,7 @@ export async function handleSetup(options: SetupOptions): Promise<void> {
     if (link) {
       // Directory already declares the project — ignore the metadata-borne id
       // and assert the freshly-authenticated user can access the linked project.
-      await assertAccess(creds, userBaseUrl, link.projectId, isJson);
+      await assertAccess(creds, userBaseUrl, link, existingKey, isJson);
     } else if (login.projectId) {
       // Browser-selected (or just-created) project. Trust it and write the link.
       link = await writeLink(issuer, userBaseUrl, login.projectId, isJson);
@@ -156,7 +157,7 @@ export async function handleSetup(options: SetupOptions): Promise<void> {
     const userBaseUrl = baseUrl;
     const issuer = creds.issuer || frontendUrl;
     if (link) {
-      await assertAccess(creds, userBaseUrl, link.projectId, isJson);
+      await assertAccess(creds, userBaseUrl, link, existingKey, isJson);
     } else {
       link = await resolveProjectViaCli(creds, userBaseUrl, issuer, isJson, options);
     }
@@ -495,14 +496,18 @@ async function writeLink(
 }
 
 /**
- * Access check: the user must be a member of `projectId`. Calls
- * GET /v1/cli/projects (user JWT) and asserts the id is present; aborts
- * otherwise (SPEC: "You don't have access to the project in this directory").
+ * Access check: the logged-in user must be a member of the directory-linked
+ * project (`link.projectId`). Calls GET /v1/cli/projects (user JWT) and asserts
+ * the id is present; aborts otherwise (SPEC: "You don't have access to the
+ * project in this directory"). On failure, names the actual mismatch (linked
+ * project vs. logged-in account) and the two things that pin a stale project —
+ * `.lmnr/project.json` and any `LMNR_PROJECT_API_KEY` in the environment.
  */
 async function assertAccess(
   creds: Credentials,
   userBaseUrl: string,
-  projectId: string,
+  link: LocalProjectFile,
+  existingKey: EnvKeyLocation | null,
   isJson: boolean,
 ): Promise<void> {
   let projects: CliProject[];
@@ -515,14 +520,50 @@ async function assertAccess(
     emitError(isJson, "list_projects_failed", describeError(err));
     process.exit(EXIT_LIST_PROJECTS_FAILED);
   }
-  if (!projects.some((p) => p.id === projectId)) {
-    emitError(
-      isJson,
-      "no_access",
-      "You don't have access to the project in this directory",
-    );
+  if (!projects.some((p) => p.id === link.projectId)) {
+    emitError(isJson, "no_access", buildNoAccessDetail(link, creds, existingKey, projects));
     process.exit(EXIT_NO_ACCESS);
   }
+}
+
+/**
+ * Build the `no_access` detail: lead with the SPEC sentence (so substring
+ * matchers keep working), then explain the linked-project-vs-account mismatch
+ * and the concrete remediation steps.
+ */
+function buildNoAccessDetail(
+  link: LocalProjectFile,
+  creds: Credentials,
+  existingKey: EnvKeyLocation | null,
+  accessible: CliProject[],
+): string {
+  const project = link.projectName ? `"${link.projectName}" (${link.projectId})` : link.projectId;
+  const account = creds.userEmail ?? "the current account";
+  const workspace = link.workspaceName ? ` in workspace "${link.workspaceName}"` : "";
+  const keyWhere =
+    existingKey === null
+      ? null
+      : existingKey.source.type === "process-env"
+        ? { loc: "your environment", verb: "unset it" }
+        : { loc: relative(process.cwd(), existingKey.source.path), verb: "remove that line" };
+  const envHint = keyWhere
+    ? `\n  • A stale LMNR_PROJECT_API_KEY in ${keyWhere.loc} can pin a different project — ` +
+      `${keyWhere.verb}, then re-run setup.`
+    : "";
+  const accessLine =
+    accessible.length > 0
+      ? `You're logged in as ${account}, which has access to ${accessible.length} ` +
+        `project(s), but not this one.`
+      : `You're logged in as ${account}, which has access to no projects.`;
+
+  return (
+    `You don't have access to the project in this directory. ` +
+    `It's linked (.lmnr/project.json) to project ${project}${workspace}. ${accessLine}\n\n` +
+    `To fix, pick one:\n` +
+    `  • Wrong account? Run \`lmnr-cli login\` as someone with access, then re-run setup.\n` +
+    `  • Want a different project here? Remove the link and re-run setup: ` +
+    `\`rm .lmnr/project.json && lmnr-cli setup\`.${envHint}`
+  );
 }
 
 /** List the projects the user can access (user-JWT-authed discovery). */

--- a/packages/lmnr-cli/src/index.ts
+++ b/packages/lmnr-cli/src/index.ts
@@ -212,6 +212,11 @@ Examples:
       "Port for the Laminar API. Defaults to 443",
       (val) => parseInt(val, 10),
     )
+    .option(
+      "--conversation <id>",
+      "Continue a previous conversation by its id (printed after each answer in human mode, " +
+      "or in the `--json` output as `conversationId`)",
+    )
     .option("--json", "Output structured JSON ({ answer, conversationId, tools }) to stdout")
     .action(withLocalOpts(handleAsk))
     .addHelpText(
@@ -225,6 +230,7 @@ Examples:
   $ lmnr-cli ask "why did my latest trace fail?"
   $ lmnr-cli ask "how many traces errored in the last day?"
   $ lmnr-cli ask "summarize the most expensive trace today" --json
+  $ lmnr-cli ask "and which model did it use?" --conversation <id>
 `,
     );
 

--- a/packages/lmnr-cli/src/index.ts
+++ b/packages/lmnr-cli/src/index.ts
@@ -5,6 +5,7 @@ import { Command } from "commander";
 
 import { version } from "../package.json";
 import { withLocalOpts, withProjectClient, withUserToken } from "./auth/with-client";
+import { handleAsk } from "./commands/ask";
 import {
   handleDatasetsCreate,
   handleDatasetsList,
@@ -192,6 +193,40 @@ Examples:
     .action(() => {
       process.stdout.write(SQL_SCHEMA_HELP);
     });
+
+  program
+    .command("ask")
+    .description("Ask the Laminar agent a natural-language question about your project")
+    .argument("<query>", "Natural-language question")
+    .option(
+      "--project-id <id>",
+      "Target project id. Defaults to .lmnr/project.json, LMNR_PROJECT_ID, or the " +
+      "project the API key belongs to.",
+    )
+    .option(
+      "--base-url <url>",
+      "Base URL for the Laminar API. Defaults to https://api.lmnr.ai or LMNR_BASE_URL env variable",
+    )
+    .option(
+      "--port <port>",
+      "Port for the Laminar API. Defaults to 443",
+      (val) => parseInt(val, 10),
+    )
+    .option("--json", "Output structured JSON ({ answer, sessionId, tools }) to stdout")
+    .action(withLocalOpts(handleAsk))
+    .addHelpText(
+      "after",
+      `
+Authenticates with the project API key (LMNR_PROJECT_API_KEY, written by
+\`lmnr-cli setup\`). The agent answers from your project's traces/spans/evals via
+read-only SQL and trace inspection.
+
+Examples:
+  $ lmnr-cli ask "why did my latest trace fail?"
+  $ lmnr-cli ask "how many traces errored in the last day?"
+  $ lmnr-cli ask "summarize the most expensive trace today" --json
+`,
+    );
 
   const projectCmd = program.command("project").description("Work with Laminar projects");
 

--- a/packages/lmnr-cli/src/index.ts
+++ b/packages/lmnr-cli/src/index.ts
@@ -200,8 +200,8 @@ Examples:
     .argument("<query>", "Natural-language question")
     .option(
       "--project-id <id>",
-      "Target project id. Defaults to .lmnr/project.json, LMNR_PROJECT_ID, or the " +
-      "project the API key belongs to.",
+      "Target project id. Defaults to the linked .lmnr/project.json. " +
+      "Run `lmnr-cli login` first.",
     )
     .option(
       "--base-url <url>",
@@ -222,9 +222,9 @@ Examples:
     .addHelpText(
       "after",
       `
-Authenticates with the project API key (LMNR_PROJECT_API_KEY, written by
-\`lmnr-cli setup\`). The agent answers from your project's traces/spans/evals via
-read-only SQL and trace inspection.
+Runs on your logged-in user session (\`lmnr-cli login\`) and targets a project via
+--project-id or the linked .lmnr/project.json. The agent answers from your
+project's traces/spans/evals via read-only SQL and trace inspection.
 
 Examples:
   $ lmnr-cli ask "why did my latest trace fail?"

--- a/packages/lmnr-cli/src/index.ts
+++ b/packages/lmnr-cli/src/index.ts
@@ -212,7 +212,7 @@ Examples:
       "Port for the Laminar API. Defaults to 443",
       (val) => parseInt(val, 10),
     )
-    .option("--json", "Output structured JSON ({ answer, sessionId, tools }) to stdout")
+    .option("--json", "Output structured JSON ({ answer, conversationId, tools }) to stdout")
     .action(withLocalOpts(handleAsk))
     .addHelpText(
       "after",


### PR DESCRIPTION
- **feat(cli): add `lmnr-cli ask` for natural-language agent queries**
- **feat(cli): ask command uses user-token auth via /v1/cli/agent/chat**
- **refactor(cli): ask sends { message } matching the slimmed agent wire shape**
- **feat(cli): ask --json does a buffered HTTP call, not SSE**
- **fix(cli): match renamed agent wire (conversation/conversationId)**
- **style(cli): wrap overlong comment in ask.ts**
- **docs(cli): fix stale sessionId in `ask --json` help text**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New authenticated agent API surface and streaming client logic; setup error text changes could affect automation that matches on `no_access` detail strings (leading sentence preserved).
> 
> **Overview**
> Adds **`lmnr-cli ask`** (v **0.3.0**): natural-language questions against the project agent via **`POST /v1/cli/agent/chat`**, using the logged-in user token and **`x-lmnr-project-id`**. Interactive mode streams **SSE** (answer on stdout, thoughts/tool calls on stderr); **`--json`** requests a buffered **`{ answer, conversationId, tools }`** response. **`--conversation`** continues a prior thread and the CLI prints a continuation hint after each run.
> 
> **Setup** **`no_access`** errors are expanded: they still start with the spec sentence, then name the linked project vs. the logged-in account and suggest fixes (re-login, remove **`.lmnr/project.json`**, and unset a stale **`LMNR_PROJECT_API_KEY`** when one was detected).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a356369e41319390f086facaeda691021f265ec3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->