### PR TITLE
bump lmnr v0.8.35, cli v0.1.15

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@lmnr-ai/lmnr-ts",
   "private": true,
-  "version": "0.8.34",
+  "version": "0.8.35",
   "description": "Laminar AI TypeScript SDK",
   "scripts": {
     "build": "pnpm -r build",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lmnr-ai/client",
-  "version": "0.8.34",
+  "version": "0.8.35",
   "description": "HTTP client for Laminar AI API",
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",

--- a/packages/lmnr-cli/package.json
+++ b/packages/lmnr-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lmnr-cli",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "description": "CLI for the Laminar agent observability platform",
   "main": "dist/index.cjs",
   "bin": {

--- a/packages/lmnr/package.json
+++ b/packages/lmnr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lmnr-ai/lmnr",
-  "version": "0.8.34",
+  "version": "0.8.35",
   "description": "TypeScript SDK for Laminar AI",
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",
@@ -108,7 +108,7 @@
     "@opencode-ai/sdk": "^1.4.3",
     "@pinecone-database/pinecone": "^5.1.2",
     "@playwright/test": "^1.54.2",
-    "@qdrant/js-client-rest": "^1.17.0",
+    "@qdrant/js-client-rest": "^1.18.0",
     "@temporalio/workflow": "^1.18.1",
     "@types/cli-progress": "^3.11.6",
     "@types/node": "^24.12.0",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lmnr-ai/types",
-  "version": "0.8.34",
+  "version": "0.8.35",
   "description": "Shared types for Laminar AI SDK",
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -271,9 +271,6 @@ importers:
       puppeteer-core:
         specifier: ^25.1.0
         version: 25.1.0
-      undici:
-        specifier: ^6.27.0
-        version: 6.27.0
       undici-types:
         specifier: ^8.0.2
         version: 8.2.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -233,7 +233,7 @@ importers:
         specifier: ^1.54.2
         version: 1.60.0
       '@qdrant/js-client-rest':
-        specifier: ^1.17.0
+        specifier: ^1.18.0
         version: 1.18.0(typescript@6.0.3)
       '@temporalio/workflow':
         specifier: ^1.18.1
@@ -271,6 +271,9 @@ importers:
       puppeteer-core:
         specifier: ^25.1.0
         version: 25.1.0
+      undici:
+        specifier: ^6.27.0
+        version: 6.27.0
       undici-types:
         specifier: ^8.0.2
         version: 8.2.0
@@ -3034,8 +3037,8 @@ packages:
   undici-types@8.2.0:
     resolution: {integrity: sha512-uciYZ5yCmf+QJb18kJw10HjquzM7K0z992vWcI+84KeBpTfXT4hfgfGJ5DQbf/mCBPACofkrjvqgcjZfuujjFA==}
 
-  undici@6.25.0:
-    resolution: {integrity: sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==}
+  undici@6.27.0:
+    resolution: {integrity: sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==}
     engines: {node: '>=18.17'}
 
   unpipe@1.0.0:
@@ -4271,7 +4274,7 @@ snapshots:
     dependencies:
       '@qdrant/openapi-typescript-fetch': 1.2.6
       typescript: 6.0.3
-      undici: 6.25.0
+      undici: 6.27.0
 
   '@qdrant/openapi-typescript-fetch@1.2.6': {}
 
@@ -6221,7 +6224,7 @@ snapshots:
 
   undici-types@8.2.0: {}
 
-  undici@6.25.0: {}
+  undici@6.27.0: {}
 
   unpipe@1.0.0:
     optional: true


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Version and lockfile-only changes with a minor devDependency bump; no runtime SDK or CLI logic changes in the diff.
> 
> **Overview**
> Release-only PR: bumps **@lmnr-ai/lmnr**, **@lmnr-ai/client**, **@lmnr-ai/types**, and the workspace root from **0.8.34** to **0.8.35**, and **lmnr-cli** from **0.1.14** to **0.1.15**.
> 
> The only dependency change is raising the **@lmnr-ai/lmnr** devDependency **@qdrant/js-client-rest** from `^1.17.0` to `^1.18.0`, with **pnpm-lock.yaml** updated (including transitive **undici** `6.25.0` → `6.27.0`). No application or SDK source files are modified.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba0780536e306531de240f31fa75e98773d95a9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->