### PR TITLE
fix: record gen_ai.tool.definitions

### DIFF
--- a/packages/lmnr/src/opentelemetry-lib/instrumentation/aisdk/v7-integration/index.ts
+++ b/packages/lmnr/src/opentelemetry-lib/instrumentation/aisdk/v7-integration/index.ts
@@ -33,6 +33,7 @@
 
 import * as diagnosticsChannel from "node:diagnostics_channel";
 
+import { errorMessage } from "@lmnr-ai/types";
 import {
   context as contextApi,
   type HrTime,
@@ -42,6 +43,7 @@ import {
 } from "@opentelemetry/api";
 
 import { Laminar, type LaminarInitializeProps } from "../../../../laminar";
+import { initializeLogger } from "../../../../utils";
 import { getTracer } from "../../../tracing";
 import {
   LaminarAttributes,
@@ -139,6 +141,8 @@ export class LaminarAiSdkTelemetry {
   // serialization the replay wrapper hashes, so recording level == replay
   // level for the debugger cache.
   private readonly promptByCallId = new Map<string, string>();
+
+  private readonly logger = initializeLogger();
 
   constructor(options: LaminarAiSdkTelemetryOptions = {}) {
     this.recordInputs = options.recordInputs ?? true;
@@ -306,6 +310,18 @@ export class LaminarAiSdkTelemetry {
     span.setAttribute(SPAN_TYPE, "LLM");
     applyRequestModelAttributes(span, event);
     if (this.recordInputs) {
+      if (event.tools) {
+        try {
+          span.setAttribute(
+            "gen_ai.tool.definitions",
+            JSON.stringify(event.tools),
+          );
+        } catch (e) {
+          this.logger.debug(
+            `Failed to record span tool definitions: ${errorMessage(e)}`,
+          );
+        }
+      }
       // Verbatim LanguageModel-level prompt, stashed by onStepStart. This is
       // the exact serialization the replay wrapper hashes, so the server-side
       // debugger cache keys match at record and replay time. There is NO
@@ -433,9 +449,7 @@ export class LaminarAiSdkTelemetry {
       // the backend stores one consistent output format and the debugger can
       // replay it.
       if (this.recordOutputs && llm.textDeltas.length > 0) {
-        const outputMessages = buildTextOutputMessages(
-          llm.textDeltas.join(""),
-        );
+        const outputMessages = buildTextOutputMessages(llm.textDeltas.join(""));
         if (outputMessages) {
           llm.span.setAttribute("gen_ai.output.messages", outputMessages);
         }

--- a/packages/lmnr/test/aisdk-v7-telemetry.test.ts
+++ b/packages/lmnr/test/aisdk-v7-telemetry.test.ts
@@ -241,6 +241,51 @@ void describe("AI SDK v7 LaminarTelemetry integration", () => {
     assert.ok(byName.has("ai.step"));
   });
 
+  void it("records gen_ai.tool.definitions on the LLM span when tools are present", () => {
+    const tel = new LaminarAiSdkTelemetry({ createStepSpan: true });
+    const callId = "call-tools";
+    const tools = [
+      {
+        type: "function",
+        name: "get_weather",
+        description: "Get the weather for a city",
+        inputSchema: { type: "object", properties: { city: { type: "string" } } },
+      },
+    ];
+
+    tel.onStart(mkStartEvent(callId, { tools }));
+    tel.onStepStart(mkStepStartEvent(callId, 0));
+    tel.onLanguageModelCallStart(mkLlmCallStart(callId, { tools }));
+    tel.onLanguageModelCallEnd(mkLlmCallEnd(callId));
+    tel.onStepFinish(mkStepEnd(callId, 0));
+    tel.onEnd(mkFinish(callId));
+
+    const spans = exporter.getFinishedSpans();
+    const llm = spans.find((s) => s.name.startsWith("ai.llm "));
+    assert.ok(llm, "llm span missing");
+    assert.deepEqual(
+      JSON.parse(llm.attributes["gen_ai.tool.definitions"] as string),
+      tools,
+    );
+  });
+
+  void it("omits gen_ai.tool.definitions when no tools are present", () => {
+    const tel = new LaminarAiSdkTelemetry({ createStepSpan: true });
+    const callId = "call-no-tools";
+
+    tel.onStart(mkStartEvent(callId));
+    tel.onStepStart(mkStepStartEvent(callId, 0));
+    tel.onLanguageModelCallStart(mkLlmCallStart(callId));
+    tel.onLanguageModelCallEnd(mkLlmCallEnd(callId));
+    tel.onStepFinish(mkStepEnd(callId, 0));
+    tel.onEnd(mkFinish(callId));
+
+    const spans = exporter.getFinishedSpans();
+    const llm = spans.find((s) => s.name.startsWith("ai.llm "));
+    assert.ok(llm, "llm span missing");
+    assert.equal(llm.attributes["gen_ai.tool.definitions"], undefined);
+  });
+
   void it("records verbatim gen_ai.input.messages even when step spans are disabled", () => {
     // createStepSpan defaults to false — onStepStart must still stash
     // event.promptMessages BEFORE its early return so the following


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Observability-only addition behind existing `recordInputs`; failures are swallowed with debug logging and do not affect request execution.
> 
> **Overview**
> **AI SDK v7 LLM spans now include tool schemas when inputs are recorded.** In `onLanguageModelCallStart`, if the language-model event carries `tools`, the integration sets `gen_ai.tool.definitions` to `JSON.stringify(event.tools)`, aligning v7 telemetry with other Laminar instrumentations that already emit that attribute.
> 
> Serialization failures are caught and logged at debug level so span creation is not blocked. Tests cover both tool-present and tool-absent flows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1d07d8843a0a1c7fec1240293261ccebea38374. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->