### PR TITLE
stringify for telemetry new nested data part for bare uint8arrays

### DIFF
--- a/packages/lmnr/src/opentelemetry-lib/instrumentation/aisdk/base-language-model.ts
+++ b/packages/lmnr/src/opentelemetry-lib/instrumentation/aisdk/base-language-model.ts
@@ -38,7 +38,7 @@ import { getRuntime } from "../../../debug/index";
 import { markSpanCached, replayEnabled } from "../../../debug/replay";
 import { Laminar } from "../../../laminar";
 import { peekActiveLlmSpan } from "./active-llm-span";
-import { verbatimPromptMessages } from "./utils";
+import { verbatimPromptMessages } from "./v7-integration/utils";
 
 type CacheResponse =
   | {

--- a/packages/lmnr/src/opentelemetry-lib/instrumentation/aisdk/utils.ts
+++ b/packages/lmnr/src/opentelemetry-lib/instrumentation/aisdk/utils.ts
@@ -1,4 +1,8 @@
 import {
+  type LanguageModelV4Message,
+  type LanguageModelV4Prompt,
+} from "@ai-sdk/provider";
+import {
   type LanguageModelV2Message,
   type LanguageModelV2Prompt,
 } from "@ai-sdk/provider-v2";
@@ -9,58 +13,50 @@ import {
 import { errorMessage } from "@lmnr-ai/types";
 import { type DataContent } from "ai";
 
-// Mirrors https://github.com/vercel/ai/blob/main/packages/ai/src/telemetry/stringify-for-telemetry.ts
+// Mirrors https://github.com/vercel/ai/blob/ai@6.0.221/packages/ai/src/telemetry/stringify-for-telemetry.ts
 // This function is initially implemented by us, and is not exported from the ai sdk.
 // We copy it here for our own use.
 export const stringifyPromptForTelemetry = (
-  prompt: LanguageModelV2Prompt | LanguageModelV3Prompt,
+  prompt: LanguageModelV2Prompt | LanguageModelV3Prompt | LanguageModelV4Prompt,
 ): string =>
   JSON.stringify(
-    prompt.map((message: LanguageModelV2Message | LanguageModelV3Message) => ({
-      ...message,
-      content:
-        typeof message.content === "string"
-          ? message.content
-          : message.content.map((part) =>
-            part.type === "file"
-              ? {
-                ...part,
-                data:
-                      part.data instanceof Uint8Array
-                        ? convertDataContentToBase64String(part.data)
-                        : part.data,
-              }
-              : part,
-          ),
-    })),
+    prompt.map(
+      (
+        message:
+          | LanguageModelV2Message
+          | LanguageModelV3Message
+          | LanguageModelV4Message,
+      ) => ({
+        ...message,
+        content:
+          typeof message.content === "string"
+            ? message.content
+            : message.content.map((part) =>
+              part.type === "file"
+                ? {
+                  ...part,
+                  data:
+                        part.data instanceof Uint8Array
+                          ? convertDataContentToBase64String(part.data)
+                          : part.data &&
+                              typeof part.data === "object" &&
+                              (part.data as { type?: string }).type ===
+                                "data" &&
+                              (part.data as { data?: unknown }).data instanceof
+                                Uint8Array
+                            ? {
+                              ...part.data,
+                              data: convertDataContentToBase64String(
+                                (part.data as { data: Uint8Array }).data,
+                              ),
+                            }
+                            : part.data,
+                }
+                : part,
+            ),
+      }),
+    ),
   );
-
-// The recorded `gen_ai.input.messages` attribute (v7 integration) and the
-// debugger-replay input hash (base-language-model.ts) MUST be computed from
-// the same serialized bytes, or record-time and replay-time cache keys drift.
-// Both go through these two helpers — do NOT serialize the prompt any other
-// way on either path.
-export const verbatimPromptString = (prompt: unknown): string | null => {
-  try {
-    const serialized = stringifyPromptForTelemetry(
-      prompt as LanguageModelV3Prompt,
-    );
-    return typeof serialized === "string" ? serialized : null;
-  } catch {
-    return null;
-  }
-};
-
-export const verbatimPromptMessages = (prompt: unknown): unknown[] | null => {
-  const serialized = verbatimPromptString(prompt);
-  if (serialized === null) return null;
-  try {
-    const parsed: unknown = JSON.parse(serialized);
-    return Array.isArray(parsed) ? parsed : null;
-  } catch {
-    return null;
-  }
-};
 
 // https://github.com/vercel/ai/blob/main/packages/ai/src/prompt/data-content.ts
 /**

--- a/packages/lmnr/src/opentelemetry-lib/instrumentation/aisdk/v7-integration/index.ts
+++ b/packages/lmnr/src/opentelemetry-lib/instrumentation/aisdk/v7-integration/index.ts
@@ -53,7 +53,6 @@ import {
 } from "../../../tracing/attributes";
 import { LaminarContextManager } from "../../../tracing/context";
 import { pushActiveLlmSpan, removeActiveLlmSpan } from "../active-llm-span";
-import { verbatimPromptString } from "../utils";
 import { buildAiSdkInstrumentationAttributes } from "./package-versions";
 import {
   type LlmState,
@@ -72,6 +71,7 @@ import {
   normalizeProvider,
   readSpanEndTime,
   serializeJSON,
+  verbatimPromptString,
   verbatimStandardizedMessages,
 } from "./utils";
 

--- a/packages/lmnr/src/opentelemetry-lib/instrumentation/aisdk/v7-integration/utils.ts
+++ b/packages/lmnr/src/opentelemetry-lib/instrumentation/aisdk/v7-integration/utils.ts
@@ -1,6 +1,9 @@
+
+import { LanguageModelV4Prompt } from "@ai-sdk/provider";
 import type { HrTime, Span } from "@opentelemetry/api";
 
 import { LaminarAttributes } from "../../../tracing/attributes";
+import { stringifyPromptForTelemetry } from "../utils";
 
 export const serializeJSON = (value: unknown): string => {
   if (typeof value === "string") return value;
@@ -156,4 +159,33 @@ export const readSpanEndTime = (span: Span): HrTime | undefined => {
   const outerEnd = (span as unknown as { endTime?: HrTime }).endTime;
   if (outerEnd && (outerEnd[0] !== 0 || outerEnd[1] !== 0)) return outerEnd;
   return undefined;
+};
+
+// The recorded `gen_ai.input.messages` attribute (v7 integration) and the
+// debugger-replay input hash (base-language-model.ts) MUST be computed from
+// the same serialized bytes, or record-time and replay-time cache keys drift.
+// Both go through these two helpers — do NOT serialize the prompt any other
+// way on either path.
+export const verbatimPromptString = (prompt: unknown): string | null => {
+  try {
+    console.log(Array.isArray(prompt));
+    console.log((prompt as any[])?.[0]?.content?.[0]?.data);
+    const serialized = stringifyPromptForTelemetry(
+      prompt as LanguageModelV4Prompt,
+    );
+    return typeof serialized === "string" ? serialized : null;
+  } catch {
+    return null;
+  }
+};
+
+export const verbatimPromptMessages = (prompt: unknown): unknown[] | null => {
+  const serialized = verbatimPromptString(prompt);
+  if (serialized === null) return null;
+  try {
+    const parsed: unknown = JSON.parse(serialized);
+    return Array.isArray(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
 };

--- a/packages/lmnr/src/opentelemetry-lib/instrumentation/aisdk/v7-integration/utils.ts
+++ b/packages/lmnr/src/opentelemetry-lib/instrumentation/aisdk/v7-integration/utils.ts
@@ -1,4 +1,3 @@
-
 import { LanguageModelV4Prompt } from "@ai-sdk/provider";
 import type { HrTime, Span } from "@opentelemetry/api";
 
@@ -168,8 +167,6 @@ export const readSpanEndTime = (span: Span): HrTime | undefined => {
 // way on either path.
 export const verbatimPromptString = (prompt: unknown): string | null => {
   try {
-    console.log(Array.isArray(prompt));
-    console.log((prompt as any[])?.[0]?.content?.[0]?.data);
     const serialized = stringifyPromptForTelemetry(
       prompt as LanguageModelV4Prompt,
     );

--- a/packages/lmnr/test/debug/hash.test.ts
+++ b/packages/lmnr/test/debug/hash.test.ts
@@ -7,7 +7,7 @@ import { canonicalJson, debugInputHash } from "../../src/debug/hash";
 import {
   verbatimPromptMessages,
   verbatimPromptString,
-} from "../../src/opentelemetry-lib/instrumentation/aisdk/utils";
+} from "../../src/opentelemetry-lib/instrumentation/aisdk/v7-integration/utils";
 
 interface HashCase {
   name: string;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes affect debug-replay input hashing and `gen_ai.input.messages` serialization; incorrect nested file handling could cause cache key drift, but scope is limited to AI SDK instrumentation.
> 
> **Overview**
> **Telemetry prompt serialization** now accepts **LanguageModel V4** prompts and matches AI SDK **6.0.221** behavior for file parts: besides a bare `Uint8Array` on `part.data`, it base64-encodes bytes inside nested **`{ type: "data", data: Uint8Array }`** wrappers so multimodal prompts stringify consistently for spans and hashing.
> 
> **`verbatimPromptString` / `verbatimPromptMessages`** moved from `aisdk/utils.ts` into **`v7-integration/utils`** (still built on `stringifyPromptForTelemetry`), with **`base-language-model`**, v7 integration, and **`hash.test`** imports updated so **`gen_ai.input.messages`** and debug replay input hashes keep using the same bytes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 819b9aa284771de0e6f887155efcefded60462c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->