### PR TITLE
pin npm to v11 in publish workflow

### DIFF
--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -18,13 +18,11 @@ jobs:
           version: 10
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           registry-url: https://registry.npmjs.org
-      # temp fix, direct install of versions of 11.12.0+ fails to install
-      # promise-retry. This is the suggested fix, see
-      # https://github.com/npm/cli/issues/9151
-      - run: npm install -g npm@11.11.1
-      - run: npm install -g npm@latest
+      # Freeze to latest 11, because 12 / latest fails in publish
+      # https://github.com/npm/cli/issues/9722
+      - run: npm install -g npm@next-11
       - run: pnpm install --frozen-lockfile
       - run: pnpm --filter lmnr-cli build
       - name: Publish CLI package
@@ -43,13 +41,11 @@ jobs:
           version: 10
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           registry-url: https://registry.npmjs.org
-      # temp fix, direct install of versions of 11.12.0+ fails to install
-      # promise-retry. This is the suggested fix, see
-      # https://github.com/npm/cli/issues/9151
-      - run: npm install -g npm@11.11.1
-      - run: npm install -g npm@latest
+      # Freeze to latest 11, because 12 / latest fails in publish
+      # https://github.com/npm/cli/issues/9722
+      - run: npm install -g npm@next-11
       - run: pnpm install --frozen-lockfile
       - run: pnpm build
 
@@ -57,7 +53,7 @@ jobs:
         run: pnpm check-versions
 
       - name: Run tests
-        run: pnpm --filter @lmnr-ai/lmnr test
+        run: pnpm --filter @lmnr-ai/* test
 
       - name: Publish types package
         run: cd packages/types && pnpm publish --provenance --access public --no-git-checks


### PR DESCRIPTION
also bump to node 24 and small fixes around

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only changes to Node/npm versions and test scope; no runtime SDK or publish script logic changes beyond the workflow.
> 
> **Overview**
> Updates the **Publish to npm** workflow for both `publish-cli` and `publish-sdk` so releases run on **Node 24** instead of 22.
> 
> Replaces the old two-step npm workaround (`npm@11.11.1` then `npm@latest`) with a single global install of **`npm@next-11`**, keeping npm on the v11 line because npm 12 breaks publish (see npm/cli#9722).
> 
> On the SDK job, pre-publish tests now run with **`pnpm --filter @lmnr-ai/* test`** instead of only `@lmnr-ai/lmnr`, so other scoped packages get exercised before publish.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ea11e6edb005510b52bb0774d75329e16153cf5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->