### PR TITLE
feat(cli): `lmnr-cli plugin add <agent>` installer

### DIFF
--- a/packages/lmnr-cli/README.md
+++ b/packages/lmnr-cli/README.md
@@ -183,13 +183,14 @@ not touch `.lmnr/project.json` or `.env`.
 
 ```bash
 lmnr-cli plugin add claude-code             # Claude Code plugin marketplace install
-lmnr-cli plugin add codex                   # Codex Stop hook install
+lmnr-cli plugin add codex                   # Codex plugin marketplace install
 lmnr-cli plugin add codex --project-id <uuid>
 lmnr-cli plugin add codex --print-only      # Show equivalent manual steps
 ```
 
 The command logs in if needed, lets you pick a project, mints a plugin-named
-project API key, and stores it in the host agent's own config/launcher.
+project API key, and writes it to `~/.config/lmnr/<agent>-plugin.json`, which
+the plugin reads.
 
 ### `login` / `logout` - Authentication
 

--- a/packages/lmnr-cli/README.md
+++ b/packages/lmnr-cli/README.md
@@ -176,6 +176,21 @@ dir (`.claude`, `.cursor`, `.codex`, `.agents`), defaulting to `.claude/` +
 `.agents/` when none exist. `skill update` only replaces copies that are
 already installed. Both accept `--json`.
 
+### `plugin` - Agent observability plugins
+
+Install Laminar tracing hooks/plugins for coding agents. This is global and does
+not touch `.lmnr/project.json` or `.env`.
+
+```bash
+lmnr-cli plugin add claude-code             # Claude Code plugin marketplace install
+lmnr-cli plugin add codex                   # Codex Stop hook install
+lmnr-cli plugin add codex --project-id <uuid>
+lmnr-cli plugin add codex --print-only      # Show equivalent manual steps
+```
+
+The command logs in if needed, lets you pick a project, mints a plugin-named
+project API key, and stores it in the host agent's own config/launcher.
+
 ### `login` / `logout` - Authentication
 
 See [Authentication](#authentication) above.

--- a/packages/lmnr-cli/package.json
+++ b/packages/lmnr-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lmnr-cli",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "CLI for the Laminar agent observability platform",
   "main": "dist/index.cjs",
   "bin": {

--- a/packages/lmnr-cli/package.json
+++ b/packages/lmnr-cli/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "cli-table3": "^0.6.5",
     "commander": "^14.0.2",
+    "cross-spawn": "^7.0.6",
     "csv-parser": "^3.2.0",
     "export-to-csv": "^1.4.0",
     "giget": "^3.2.0",
@@ -41,6 +42,7 @@
   "devDependencies": {
     "@lmnr-ai/client": "workspace:*",
     "@lmnr-ai/types": "workspace:*",
+    "@types/cross-spawn": "^6.0.6",
     "vitest": "^4.1.9"
   }
 }

--- a/packages/lmnr-cli/src/auth/api-key.ts
+++ b/packages/lmnr-cli/src/auth/api-key.ts
@@ -1,0 +1,35 @@
+/**
+ * Mint a project API key from a logged-in user session. Shared by `setup` and
+ * `plugin add` — both POST /api/cli/api-key with the session bearer for an
+ * explicit project; the only difference is the `deviceName` label the key shows
+ * under in the dashboard.
+ */
+
+export interface MintedApiKey {
+  apiKey: string;
+  apiKeyId?: string;
+  projectId?: string;
+  projectName?: string;
+  workspaceId?: string;
+  workspaceName?: string;
+}
+
+const trimTrailingSlashes = (url: string): string => url.replace(/\/+$/, "");
+
+export const mintProjectApiKey = async (
+  issuer: string,
+  sessionToken: string,
+  projectId: string,
+  deviceName: string,
+): Promise<MintedApiKey> => {
+  const res = await fetch(`${trimTrailingSlashes(issuer)}/api/cli/api-key`, {
+    method: "POST",
+    headers: { authorization: `Bearer ${sessionToken}`, "content-type": "application/json" },
+    body: JSON.stringify({ deviceName, projectId }),
+  });
+  if (res.ok) {
+    return (await res.json()) as MintedApiKey;
+  }
+  const body = (await res.json().catch(() => ({}))) as { error?: string };
+  throw new Error(body.error ?? `api-key request failed (${res.status})`);
+};

--- a/packages/lmnr-cli/src/auth/credentials.ts
+++ b/packages/lmnr-cli/src/auth/credentials.ts
@@ -71,6 +71,15 @@ export async function readCredentials(): Promise<Credentials | null> {
   return null;
 }
 
+/** Read credentials, treating any read/parse error as "not logged in" (null). */
+export async function safeReadCredentials(): Promise<Credentials | null> {
+  try {
+    return await readCredentials();
+  } catch {
+    return null;
+  }
+}
+
 export async function writeCredentials(creds: Credentials): Promise<void> {
   const path = credentialsPath();
   const parent = dirname(path);

--- a/packages/lmnr-cli/src/commands/login/index.ts
+++ b/packages/lmnr-cli/src/commands/login/index.ts
@@ -12,6 +12,7 @@ import {
 } from "../../auth/device";
 import { DEFAULT_FRONTEND_URL } from "../../constants";
 import { pc } from "../../utils/colors";
+import { firstNonEmpty } from "../../utils/text";
 
 export interface LoginOptions {
   frontendUrl?: string;
@@ -32,7 +33,11 @@ export interface LoginResult {
 }
 
 export async function handleLogin(options: LoginOptions): Promise<LoginResult> {
-  const issuer = pick(options.frontendUrl, process.env.LMNR_FRONTEND_URL, DEFAULT_FRONTEND_URL);
+  const issuer = firstNonEmpty(
+    options.frontendUrl,
+    process.env.LMNR_FRONTEND_URL,
+    DEFAULT_FRONTEND_URL,
+  );
   // NOTE: login does NOT resolve/store a data-API baseUrl — the device flow,
   // JWT mint and session fetch all hit `issuer` (frontend). `--base-url` on
   // login is accepted but inert (candidate for removal); data commands resolve
@@ -93,11 +98,4 @@ export async function handleLogin(options: LoginOptions): Promise<LoginResult> {
     userEmail: session.email || null,
     projectId: parseProjectFromMetadata(token.metadata),
   };
-}
-
-function pick(...candidates: (string | undefined)[]): string {
-  for (const c of candidates) {
-    if (c && c.length > 0) return c;
-  }
-  return "";
 }

--- a/packages/lmnr-cli/src/commands/plugin/index.test.ts
+++ b/packages/lmnr-cli/src/commands/plugin/index.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "vitest";
 
-import { buildInstallCommands, renderCommand } from "./index";
+import {
+  type AgentSpec,
+  buildCodexLauncherSource,
+  buildInstallCommands,
+  renderCommand,
+  upsertCodexHookConfig,
+} from "./index";
 
 // AgentSpec is not exported (internal registry shape); reconstruct the minimal
 // fields buildInstallCommands reads. Kept in sync with the claude-code entry.
@@ -10,7 +16,8 @@ const spec = {
   pluginRef: "laminar@laminar",
   keyEnvName: "LMNR_PROJECT_API_KEY",
   hostCli: "claude",
-} as any;
+  installer: "claude-plugin",
+} satisfies AgentSpec;
 
 describe("buildInstallCommands", () => {
   it("emits marketplace-add then install, with the key in --config and user scope", () => {
@@ -37,6 +44,44 @@ describe("buildInstallCommands", () => {
     ]);
     // install failure IS fatal.
     expect(cmds[1].lenient).toBe(false);
+  });
+});
+
+describe("codex hook install helpers", () => {
+  it("writes a private launcher that injects Laminar config before loading the hook", () => {
+    const source = buildCodexLauncherSource({
+      hookPath: "/Users/me/.codex/lmnr/hook.cjs",
+      apiKey: "SECRET_KEY",
+      baseUrl: "https://api.lmnr.ai",
+    });
+
+    expect(source).toContain('process.env.LMNR_PROJECT_API_KEY = "SECRET_KEY";');
+    expect(source).toContain('process.env.LMNR_BASE_URL = "https://api.lmnr.ai";');
+    expect(source).toContain('require("/Users/me/.codex/lmnr/hook.cjs");');
+  });
+
+  it("adds hooks=true and a single Laminar Stop hook block", () => {
+    const input = `model = "openai.gpt-5.5"
+
+[features]
+shell_tool = true
+
+# >>> Laminar Codex plugin
+old block
+# <<< Laminar Codex plugin
+`;
+
+    const output = upsertCodexHookConfig(input, "/Users/me/.codex/lmnr/hook-launcher.cjs");
+
+    expect(output).toContain("[features]\nhooks = true\nshell_tool = true");
+    expect(output).toContain("[[hooks.Stop]]");
+    expect(output).toContain("[[hooks.Stop.hooks]]");
+    expect(output).toContain('type = "command"');
+    expect(output).toContain(
+      'command = "node /Users/me/.codex/lmnr/hook-launcher.cjs"',
+    );
+    expect(output.match(/Laminar Codex plugin/g)).toHaveLength(2);
+    expect(output).not.toContain("old block");
   });
 });
 

--- a/packages/lmnr-cli/src/commands/plugin/index.test.ts
+++ b/packages/lmnr-cli/src/commands/plugin/index.test.ts
@@ -11,8 +11,7 @@ const claudeSpec = {
   label: "Claude Code",
   hostCli: "claude",
   marketplaceRef: "lmnr-ai/lmnr-claude-code-plugin",
-  pluginRef: "laminar@laminar",
-  installArgv: ["install", "laminar@laminar", "--scope", "user"],
+  installArgv: ["install", "lmnr@lmnr", "--scope", "user"],
   configFile: "claude-code-plugin.json",
 } as any;
 
@@ -20,8 +19,7 @@ const codexSpec = {
   label: "Codex",
   hostCli: "codex",
   marketplaceRef: "lmnr-ai/lmnr-codex-plugin",
-  pluginRef: "laminar@laminar",
-  installArgv: ["add", "laminar@laminar"],
+  installArgv: ["add", "lmnr@lmnr"],
   configFile: "codex-plugin.json",
 } as any;
 
@@ -33,14 +31,14 @@ describe("buildInstallCommands", () => {
       "plugin", "marketplace", "add", "lmnr-ai/lmnr-claude-code-plugin",
     ]);
     expect(cmds[0].lenient).toBe(true);
-    expect(cmds[1].argv).toEqual(["plugin", "install", "laminar@laminar", "--scope", "user"]);
+    expect(cmds[1].argv).toEqual(["plugin", "install", "lmnr@lmnr", "--scope", "user"]);
     expect(cmds[1].lenient).toBe(false);
   });
 
   it("codex: marketplace add then `plugin add` (no scope flag)", () => {
     const cmds = buildInstallCommands(codexSpec);
     expect(cmds[0].argv).toEqual(["plugin", "marketplace", "add", "lmnr-ai/lmnr-codex-plugin"]);
-    expect(cmds[1].argv).toEqual(["plugin", "add", "laminar@laminar"]);
+    expect(cmds[1].argv).toEqual(["plugin", "add", "lmnr@lmnr"]);
   });
 
   it("no secret ever appears in the install commands (key is file-delivered)", () => {
@@ -56,12 +54,12 @@ describe("buildInstallCommands", () => {
 
 describe("renderCommand", () => {
   it("prefixes the host CLI and joins argv", () => {
-    const claudeArgv = ["plugin", "install", "laminar@laminar", "--scope", "user"];
+    const claudeArgv = ["plugin", "install", "lmnr@lmnr", "--scope", "user"];
     expect(renderCommand("claude", claudeArgv)).toBe(
-      "claude plugin install laminar@laminar --scope user",
+      "claude plugin install lmnr@lmnr --scope user",
     );
-    expect(renderCommand("codex", ["plugin", "add", "laminar@laminar"])).toBe(
-      "codex plugin add laminar@laminar",
+    expect(renderCommand("codex", ["plugin", "add", "lmnr@lmnr"])).toBe(
+      "codex plugin add lmnr@lmnr",
     );
   });
 });

--- a/packages/lmnr-cli/src/commands/plugin/index.test.ts
+++ b/packages/lmnr-cli/src/commands/plugin/index.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+
+import { buildInstallCommands, renderCommand } from "./index";
+
+// AgentSpec is not exported (internal registry shape); reconstruct the minimal
+// fields buildInstallCommands reads. Kept in sync with the claude-code entry.
+const spec = {
+  label: "Claude Code",
+  marketplaceRef: "lmnr-ai/lmnr-claude-code-plugin",
+  pluginRef: "laminar@laminar",
+  keyEnvName: "LMNR_PROJECT_API_KEY",
+  hostCli: "claude",
+} as any;
+
+describe("buildInstallCommands", () => {
+  it("emits marketplace-add then install, with the key in --config and user scope", () => {
+    const cmds = buildInstallCommands(spec, "SECRET_KEY");
+    expect(cmds).toHaveLength(2);
+
+    expect(cmds[0].argv).toEqual([
+      "plugin",
+      "marketplace",
+      "add",
+      "lmnr-ai/lmnr-claude-code-plugin",
+    ]);
+    // marketplace-add is lenient: re-running (already added) must not fail the flow.
+    expect(cmds[0].lenient).toBe(true);
+
+    expect(cmds[1].argv).toEqual([
+      "plugin",
+      "install",
+      "laminar@laminar",
+      "--config",
+      "LMNR_PROJECT_API_KEY=SECRET_KEY",
+      "--scope",
+      "user",
+    ]);
+    // install failure IS fatal.
+    expect(cmds[1].lenient).toBe(false);
+  });
+});
+
+describe("renderCommand", () => {
+  const argv = [
+    "plugin",
+    "install",
+    "laminar@laminar",
+    "--config",
+    "LMNR_PROJECT_API_KEY=SECRET_KEY",
+    "--scope",
+    "user",
+  ];
+
+  it("shows the full key when not masking (copy-paste path)", () => {
+    expect(renderCommand("claude", argv, false)).toBe(
+      "claude plugin install laminar@laminar --config LMNR_PROJECT_API_KEY=SECRET_KEY --scope user",
+    );
+  });
+
+  it("masks only the --config value when masking (echo-to-terminal path)", () => {
+    const out = renderCommand("claude", argv, true);
+    expect(out).toBe(
+      "claude plugin install laminar@laminar --config LMNR_PROJECT_API_KEY=*** --scope user",
+    );
+    expect(out).not.toContain("SECRET_KEY");
+  });
+
+  it("leaves a bare --config token untouched when it has no '='", () => {
+    // Defensive: a value-less --config shouldn't throw or mangle.
+    expect(renderCommand("claude", ["--config", "NOEQUALS"], true)).toBe(
+      "claude --config NOEQUALS",
+    );
+  });
+});

--- a/packages/lmnr-cli/src/commands/plugin/index.test.ts
+++ b/packages/lmnr-cli/src/commands/plugin/index.test.ts
@@ -1,119 +1,92 @@
-import { describe, expect, it } from "vitest";
+import { mkdtempSync, readFileSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
-import {
-  type AgentSpec,
-  buildCodexLauncherSource,
-  buildInstallCommands,
-  renderCommand,
-  upsertCodexHookConfig,
-} from "./index";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-// AgentSpec is not exported (internal registry shape); reconstruct the minimal
-// fields buildInstallCommands reads. Kept in sync with the claude-code entry.
-const spec = {
+import { buildInstallCommands, renderCommand, writeAgentConfig } from "./index";
+
+// AgentSpec is internal; reconstruct the fields the exported helpers read.
+const claudeSpec = {
   label: "Claude Code",
+  hostCli: "claude",
   marketplaceRef: "lmnr-ai/lmnr-claude-code-plugin",
   pluginRef: "laminar@laminar",
-  keyEnvName: "LMNR_PROJECT_API_KEY",
-  hostCli: "claude",
-  installer: "claude-plugin",
-} satisfies AgentSpec;
+  installArgv: ["install", "laminar@laminar", "--scope", "user"],
+  configFile: "claude-code-plugin.json",
+} as any;
+
+const codexSpec = {
+  label: "Codex",
+  hostCli: "codex",
+  marketplaceRef: "lmnr-ai/lmnr-codex-plugin",
+  pluginRef: "laminar@laminar",
+  installArgv: ["add", "laminar@laminar"],
+  configFile: "codex-plugin.json",
+} as any;
 
 describe("buildInstallCommands", () => {
-  it("emits marketplace-add then install, with the key in --config and user scope", () => {
-    const cmds = buildInstallCommands(spec, "SECRET_KEY");
+  it("claude: marketplace add (lenient) then `plugin install ... --scope user` (fatal)", () => {
+    const cmds = buildInstallCommands(claudeSpec);
     expect(cmds).toHaveLength(2);
-
     expect(cmds[0].argv).toEqual([
-      "plugin",
-      "marketplace",
-      "add",
-      "lmnr-ai/lmnr-claude-code-plugin",
+      "plugin", "marketplace", "add", "lmnr-ai/lmnr-claude-code-plugin",
     ]);
-    // marketplace-add is lenient: re-running (already added) must not fail the flow.
     expect(cmds[0].lenient).toBe(true);
-
-    expect(cmds[1].argv).toEqual([
-      "plugin",
-      "install",
-      "laminar@laminar",
-      "--config",
-      "LMNR_PROJECT_API_KEY=SECRET_KEY",
-      "--scope",
-      "user",
-    ]);
-    // install failure IS fatal.
+    expect(cmds[1].argv).toEqual(["plugin", "install", "laminar@laminar", "--scope", "user"]);
     expect(cmds[1].lenient).toBe(false);
   });
-});
 
-describe("codex hook install helpers", () => {
-  it("writes a private launcher that injects Laminar config before loading the hook", () => {
-    const source = buildCodexLauncherSource({
-      hookPath: "/Users/me/.codex/lmnr/hook.cjs",
-      apiKey: "SECRET_KEY",
-      baseUrl: "https://api.lmnr.ai",
-    });
-
-    expect(source).toContain('process.env.LMNR_PROJECT_API_KEY = "SECRET_KEY";');
-    expect(source).toContain('process.env.LMNR_BASE_URL = "https://api.lmnr.ai";');
-    expect(source).toContain('require("/Users/me/.codex/lmnr/hook.cjs");');
+  it("codex: marketplace add then `plugin add` (no scope flag)", () => {
+    const cmds = buildInstallCommands(codexSpec);
+    expect(cmds[0].argv).toEqual(["plugin", "marketplace", "add", "lmnr-ai/lmnr-codex-plugin"]);
+    expect(cmds[1].argv).toEqual(["plugin", "add", "laminar@laminar"]);
   });
 
-  it("adds hooks=true and a single Laminar Stop hook block", () => {
-    const input = `model = "openai.gpt-5.5"
-
-[features]
-shell_tool = true
-
-# >>> Laminar Codex plugin
-old block
-# <<< Laminar Codex plugin
-`;
-
-    const output = upsertCodexHookConfig(input, "/Users/me/.codex/lmnr/hook-launcher.cjs");
-
-    expect(output).toContain("[features]\nhooks = true\nshell_tool = true");
-    expect(output).toContain("[[hooks.Stop]]");
-    expect(output).toContain("[[hooks.Stop.hooks]]");
-    expect(output).toContain('type = "command"');
-    expect(output).toContain(
-      'command = "node /Users/me/.codex/lmnr/hook-launcher.cjs"',
-    );
-    expect(output.match(/Laminar Codex plugin/g)).toHaveLength(2);
-    expect(output).not.toContain("old block");
+  it("no secret ever appears in the install commands (key is file-delivered)", () => {
+    for (const spec of [claudeSpec, codexSpec]) {
+      const joined = buildInstallCommands(spec)
+        .map((c) => c.argv.join(" "))
+        .join(" ");
+      expect(joined).not.toContain("--config");
+      expect(joined.toLowerCase()).not.toContain("api");
+    }
   });
 });
 
 describe("renderCommand", () => {
-  const argv = [
-    "plugin",
-    "install",
-    "laminar@laminar",
-    "--config",
-    "LMNR_PROJECT_API_KEY=SECRET_KEY",
-    "--scope",
-    "user",
-  ];
-
-  it("shows the full key when not masking (copy-paste path)", () => {
-    expect(renderCommand("claude", argv, false)).toBe(
-      "claude plugin install laminar@laminar --config LMNR_PROJECT_API_KEY=SECRET_KEY --scope user",
+  it("prefixes the host CLI and joins argv", () => {
+    const claudeArgv = ["plugin", "install", "laminar@laminar", "--scope", "user"];
+    expect(renderCommand("claude", claudeArgv)).toBe(
+      "claude plugin install laminar@laminar --scope user",
+    );
+    expect(renderCommand("codex", ["plugin", "add", "laminar@laminar"])).toBe(
+      "codex plugin add laminar@laminar",
     );
   });
+});
 
-  it("masks only the --config value when masking (echo-to-terminal path)", () => {
-    const out = renderCommand("claude", argv, true);
-    expect(out).toBe(
-      "claude plugin install laminar@laminar --config LMNR_PROJECT_API_KEY=*** --scope user",
-    );
-    expect(out).not.toContain("SECRET_KEY");
+describe("writeAgentConfig", () => {
+  let home: string;
+  const saved: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "lmnr-cfg-"));
+    saved.XDG_CONFIG_HOME = process.env.XDG_CONFIG_HOME;
+    process.env.XDG_CONFIG_HOME = home;
+  });
+  afterEach(() => {
+    if (saved.XDG_CONFIG_HOME === undefined) delete process.env.XDG_CONFIG_HOME;
+    else process.env.XDG_CONFIG_HOME = saved.XDG_CONFIG_HOME;
+    rmSync(home, { recursive: true, force: true });
   });
 
-  it("leaves a bare --config token untouched when it has no '='", () => {
-    // Defensive: a value-less --config shouldn't throw or mangle.
-    expect(renderCommand("claude", ["--config", "NOEQUALS"], true)).toBe(
-      "claude --config NOEQUALS",
-    );
+  it("writes {projectApiKey, baseUrl} to ~/.config/lmnr/<agent>-plugin.json at mode 0600", () => {
+    const p = writeAgentConfig(codexSpec, "SECRET_KEY", "https://api.lmnr.ai");
+    expect(p).toBe(join(home, "lmnr", "codex-plugin.json"));
+    const parsed = JSON.parse(readFileSync(p, "utf-8"));
+    expect(parsed).toEqual({ projectApiKey: "SECRET_KEY", baseUrl: "https://api.lmnr.ai" });
+    // 0600: owner read/write only.
+    expect(statSync(p).mode & 0o777).toBe(0o600);
   });
 });

--- a/packages/lmnr-cli/src/commands/plugin/index.ts
+++ b/packages/lmnr-cli/src/commands/plugin/index.ts
@@ -354,6 +354,8 @@ const resolveProject = async (
  */
 export const writeAgentConfig = (spec: AgentSpec, apiKey: string, baseUrl: string): string => {
   const dir = globalLmnrDirectory();
+  // recursive == `mkdir -p` (no error if it exists). 0700 not 0600: a dir needs the
+  // execute bit to traverse into it; the key file itself is written 0600 below.
   mkdirSync(dir, { recursive: true, mode: 0o700 });
   const filePath = join(dir, spec.configFile);
   const body = JSON.stringify({ projectApiKey: apiKey, baseUrl }, null, 2) + "\n";

--- a/packages/lmnr-cli/src/commands/plugin/index.ts
+++ b/packages/lmnr-cli/src/commands/plugin/index.ts
@@ -19,7 +19,9 @@ import { handleLogin } from "../login";
 // Exit codes (machine-readable; distinct so automation can branch on the mode):
 //   4  no_access          — user lacks access to the requested --project-id
 //   6  login_failed       — device-flow login failed / no creds after login
-//   7  no_project         — no project to select / ambiguous (see error string)
+//   7  no_project         — no project to select, or (as `project_ambiguous`)
+//                            more than one matched in --json mode
+
 //   8  config_write_failed — minted a key but couldn't write the plugin config file
 //   9  mint_failed        — POST /api/cli/api-key failed
 //   13 unsupported_agent  — unknown <agent> argument
@@ -47,12 +49,16 @@ export interface AgentSpec {
   hostCli: string;
   /** `<cli> plugin marketplace add <ref>` argument (owner/repo or Git URL). */
   marketplaceRef: string;
-  /** `<cli> plugin <install-verb> <ref>` argument (plugin@marketplace). */
-  pluginRef: string;
   /** The install subcommand + trailing flags this host uses (after `plugin`). */
   installArgv: string[];
   /** Per-user config file (under ~/.config/lmnr) the plugin reads the key from. */
   configFile: string;
+  /**
+   * Host-specific imperative for activating the freshly installed plugin.
+   * Claude Code exposes `/reload-plugins` (reloads hooks in-session, no restart);
+   * Codex has no in-session reload, so it restarts.
+   */
+  activationHint: string;
 }
 
 const AGENTS: Record<string, AgentSpec> = {
@@ -60,17 +66,17 @@ const AGENTS: Record<string, AgentSpec> = {
     label: "Claude Code",
     hostCli: "claude",
     marketplaceRef: "lmnr-ai/lmnr-claude-code-plugin",
-    pluginRef: "laminar@laminar",
-    installArgv: ["install", "laminar@laminar", "--scope", "user"],
+    installArgv: ["install", "lmnr@lmnr", "--scope", "user"],
     configFile: "claude-code-plugin.json",
+    activationHint: "Run `/reload-plugins`",
   },
   codex: {
     label: "Codex",
     hostCli: "codex",
     marketplaceRef: "lmnr-ai/lmnr-codex-plugin",
-    pluginRef: "laminar@laminar",
-    installArgv: ["add", "laminar@laminar"],
+    installArgv: ["add", "lmnr@lmnr"],
     configFile: "codex-plugin.json",
+    activationHint: "Restart Codex",
   },
 };
 
@@ -241,12 +247,13 @@ export const handlePluginAdd = async (agent: string, options: PluginAddOptions):
     process.stdout.write(
       `\n${pc.green("✓")} ${spec.label} plugin installed.\n\n` +
         `Next steps:\n` +
-        `  1. ${pc.bold(`Restart ${spec.label}`)} to activate the plugin.\n` +
+        `  1. ${pc.bold(spec.activationHint)} to activate the plugin.\n` +
         `  2. Use ${spec.label} as usual — each turn becomes a Laminar trace.\n`,
     );
   } else {
     process.stdout.write(
-      `\nRun the commands above to finish, then ${pc.bold(`restart ${spec.label}`)}.\n`,
+      `\nRun the commands above to finish, then activate the plugin ` +
+        `(${pc.bold(spec.activationHint)}).\n`,
     );
   }
 };

--- a/packages/lmnr-cli/src/commands/plugin/index.ts
+++ b/packages/lmnr-cli/src/commands/plugin/index.ts
@@ -1,0 +1,524 @@
+import { spawn, spawnSync } from "node:child_process";
+import { hostname } from "node:os";
+import { createInterface } from "node:readline/promises";
+
+import { type CliProject, LaminarClient } from "@lmnr-ai/client";
+
+import { version } from "../../../package.json";
+import { type Credentials, readCredentials } from "../../auth/credentials";
+import { envHttpPort, refreshIfNeeded } from "../../auth/resolve";
+import { DEFAULT_BASE_URL, DEFAULT_FRONTEND_URL } from "../../constants";
+import { orange, pc } from "../../utils/colors";
+import { handleLogin } from "../login";
+
+// Exit codes (machine-readable; distinct so automation can branch on the mode):
+//   4  no_access          — user lacks access to the requested --project-id
+//   6  login_failed       — device-flow login failed / no creds after login
+//   7  no_project         — no project to select (create one first)
+//   9  mint_failed        — POST /api/cli/api-key failed
+//   13 unsupported_agent  — unknown <agent> argument
+//   14 install_failed     — a `claude plugin ...` command exited non-zero
+const EXIT_NO_ACCESS = 4;
+const EXIT_LOGIN_FAILED = 6;
+const EXIT_NO_PROJECT = 7;
+const EXIT_MINT_FAILED = 9;
+const EXIT_UNSUPPORTED_AGENT = 13;
+const EXIT_INSTALL_FAILED = 14;
+
+/**
+ * Registry of agents `plugin add <agent>` can wire up. Keyed by the CLI argument
+ * the user types. Adding a new coding agent (cursor, codex, …) is a matter of
+ * appending an entry here plus its install-command shape.
+ */
+interface AgentSpec {
+  /** Human-facing label (banners, key name). */
+  label: string;
+  /** `claude plugin marketplace add <ref>` argument. */
+  marketplaceRef: string;
+  /** `claude plugin install <ref>` argument (plugin@marketplace). */
+  pluginRef: string;
+  /** userConfig key the project API key is delivered under. */
+  keyEnvName: string;
+  /** The host CLI binary (`claude`) that installs the plugin. */
+  hostCli: string;
+}
+
+const AGENTS: Record<string, AgentSpec> = {
+  "claude-code": {
+    label: "Claude Code",
+    marketplaceRef: "lmnr-ai/lmnr-claude-code-plugin",
+    pluginRef: "laminar@laminar",
+    keyEnvName: "LMNR_PROJECT_API_KEY",
+    hostCli: "claude",
+  },
+};
+
+export interface PluginAddOptions {
+  projectId?: string;
+  printOnly?: boolean;
+  json?: boolean;
+  noBrowser?: boolean;
+  frontendUrl?: string;
+  baseUrl?: string;
+}
+
+interface PluginAddResult {
+  agent: string;
+  projectId: string;
+  projectName: string | null;
+  workspaceName: string | null;
+  apiKey: string;
+  apiKeyId: string | null;
+  /** true when we ran the host-CLI install; false when we only printed commands. */
+  installed: boolean;
+  /** The `claude plugin ...` commands, as copy-pasteable strings (key shown). */
+  commands: string[];
+  restartRequired: boolean;
+}
+
+/**
+ * `plugin add <agent>`: onboard the Laminar plugin for a coding agent.
+ *
+ * Flow: log in (device flow) if needed → pick the project that should receive
+ * this agent's traces (deliberately NOT the directory-linked app project) →
+ * mint a project API key named after the plugin+host → install the plugin via
+ * the host CLI (`claude plugin ...`), or print those commands when the host CLI
+ * is missing / lacks `--config` / `--print-only` was passed.
+ *
+ * Unlike `setup`, this is a GLOBAL, directory-independent operation: it never
+ * reads or writes `.lmnr/project.json` and never writes `.env`. The key lives
+ * only in the host CLI's own (keychain-backed) config via `--config`.
+ */
+export async function handlePluginAdd(agent: string, options: PluginAddOptions): Promise<void> {
+  const isJson = options.json === true;
+  const spec = AGENTS[agent];
+  if (!spec) {
+    emitError(
+      isJson,
+      "unsupported_agent",
+      `Unknown agent "${agent}". Supported: ${Object.keys(AGENTS).join(", ")}.`,
+    );
+    process.exit(EXIT_UNSUPPORTED_AGENT);
+  }
+
+  const frontendUrl = pick(
+    options.frontendUrl,
+    process.env.LMNR_FRONTEND_URL,
+    DEFAULT_FRONTEND_URL,
+  );
+  const baseUrl = pick(options.baseUrl, process.env.LMNR_BASE_URL, DEFAULT_BASE_URL);
+
+  if (!isJson) {
+    process.stderr.write(`\n${orange("Laminar CLI")} ${pc.dim(`v${version}`)}\n`);
+    process.stderr.write(pc.dim(`Setting up the Laminar plugin for ${spec.label}.\n\n`));
+  }
+
+  // --- 1. Login ------------------------------------------------------------
+  let creds = await safeReadCredentials();
+  let loginProjectId: string | null = null;
+  if (!creds) {
+    let login;
+    try {
+      login = await handleLogin({ frontendUrl, noBrowser: options.noBrowser });
+    } catch (err) {
+      emitError(isJson, "login_failed", describeError(err));
+      process.exit(EXIT_LOGIN_FAILED);
+    }
+    loginProjectId = login.projectId;
+    creds = await safeReadCredentials();
+    if (!creds) {
+      emitError(isJson, "login_failed", "credentials missing after login");
+      process.exit(EXIT_LOGIN_FAILED);
+    }
+  }
+
+  const issuer = creds.issuer || frontendUrl;
+  if (!isJson) {
+    process.stderr.write(`${pc.green("✓")} Logged in as ${creds.userEmail ?? "<unknown>"}\n`);
+  }
+
+  // --- 2. Project selection (deliberate — the dedicated coding-agent project) --
+  const project = await resolveProject(creds, baseUrl, options, loginProjectId, isJson);
+  if (!isJson) {
+    process.stderr.write(
+      `${pc.green("✓")} Traces will go to project ${project.name ?? project.id}` +
+        (project.workspaceName ? pc.dim(` (${project.workspaceName})`) : "") +
+        "\n",
+    );
+  }
+
+  // --- 3. Mint a plugin-named key ------------------------------------------
+  const keyName = `${spec.label} plugin @ ${hostname()}`;
+  let key: MintResponse;
+  try {
+    key = await mintApiKey(issuer, creds.sessionToken, project.id, keyName);
+  } catch (err) {
+    emitError(isJson, "mint_failed", describeError(err));
+    process.exit(EXIT_MINT_FAILED);
+  }
+  if (!isJson) {
+    process.stderr.write(
+      `${pc.green("✓")} Minted a project API key named "${pc.bold(keyName)}"\n`,
+    );
+  }
+
+  // --- 4. Install via the host CLI, or print the commands ------------------
+  const commands = buildInstallCommands(spec, key.apiKey);
+  const canRun = !options.printOnly && hostCliSupportsConfig(spec.hostCli);
+
+  let installed = false;
+  if (canRun) {
+    installed = await runInstall(spec, commands, isJson);
+    if (!installed) {
+      // A hard install failure (not the lenient marketplace-add path). Fall back
+      // to printing so the user can finish by hand.
+      printCommands(spec, commands, isJson, "install-failed");
+      emitError(
+        isJson,
+        "install_failed",
+        `A \`${spec.hostCli} plugin\` command failed; commands printed above.`,
+      );
+      // Non-fatal-to-JSON: still emit the result below? No — exit with the code
+      // so automation sees the failure. The printed commands remain the recovery.
+      process.exit(EXIT_INSTALL_FAILED);
+    }
+  } else {
+    printCommands(spec, commands, isJson, options.printOnly ? "print-only" : "no-host-cli");
+  }
+
+  // --- 5. Summary ----------------------------------------------------------
+  const result: PluginAddResult = {
+    agent,
+    projectId: project.id,
+    projectName: project.name ?? null,
+    workspaceName: project.workspaceName ?? null,
+    apiKey: key.apiKey,
+    apiKeyId: key.apiKeyId ?? null,
+    installed,
+    commands: commands.map((c) => renderCommand(spec.hostCli, c.argv, false)),
+    restartRequired: installed,
+  };
+
+  if (isJson) {
+    process.stdout.write(JSON.stringify(result) + "\n");
+    return;
+  }
+
+  if (installed) {
+    process.stdout.write(
+      `\n${pc.green("✓")} ${spec.label} plugin installed.\n\n` +
+        `Next steps:\n` +
+        `  1. ${pc.bold(`Restart ${spec.label}`)} to activate the plugin.\n` +
+        `  2. Use ${spec.label} as usual — each turn becomes a Laminar trace.\n`,
+    );
+  } else {
+    process.stdout.write(
+      `\nRun the commands above to finish, then ${pc.bold(`restart ${spec.label}`)}.\n`,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Project selection
+// ---------------------------------------------------------------------------
+
+/**
+ * Pick the project this agent's traces go to. `--project-id` wins (validated
+ * against accessible projects). Otherwise: 0 → instruct to create one; 1 →
+ * auto-select; >1 → interactive picker (or require --project-id in --json).
+ *
+ * We nudge toward a DEDICATED project so agent traces don't mix into an app's
+ * project. When we just logged in and the browser handed back a selected/created
+ * project (loginProjectId), that's honored as the deliberate choice.
+ */
+async function resolveProject(
+  creds: Credentials,
+  baseUrl: string,
+  options: PluginAddOptions,
+  loginProjectId: string | null,
+  isJson: boolean,
+): Promise<CliProject> {
+  const projects = await listProjects(creds, baseUrl);
+
+  if (options.projectId) {
+    const match = projects.find((p) => p.id === options.projectId);
+    if (!match) {
+      emitError(
+        isJson,
+        "no_access",
+        `You don't have access to project ${options.projectId}. Accessible: ` +
+          projects.map((p) => `${p.id} (${p.workspaceName}/${p.name})`).join(", "),
+      );
+      process.exit(EXIT_NO_ACCESS);
+    }
+    return match;
+  }
+
+  // Browser-selected/created project from a fresh login is the deliberate choice.
+  if (loginProjectId) {
+    const match = projects.find((p) => p.id === loginProjectId);
+    if (match) return match;
+    // Metadata id we can't see in the list (fresh/other workspace) — trust it.
+    return { id: loginProjectId, name: "", workspaceId: "", workspaceName: "" };
+  }
+
+  if (projects.length === 0) {
+    emitError(
+      isJson,
+      "no_project",
+      `No projects found. Create one in the dashboard, then re-run \`lmnr-cli plugin add\`.`,
+    );
+    process.exit(EXIT_NO_PROJECT);
+  }
+  if (projects.length === 1) {
+    return projects[0];
+  }
+  if (isJson) {
+    emitError(
+      isJson,
+      "project_ambiguous",
+      `Multiple projects: pass --project-id <id>. ` +
+        projects.map((p) => `${p.id} (${p.workspaceName}/${p.name})`).join(", "),
+    );
+    process.exit(EXIT_NO_PROJECT);
+  }
+  return promptProjectChoice(projects);
+}
+
+/** List the projects the user can access (user-JWT discovery). */
+async function listProjects(creds: Credentials, baseUrl: string): Promise<CliProject[]> {
+  const updated = await refreshIfNeeded(creds);
+  const client = new LaminarClient({
+    baseUrl,
+    port: envHttpPort(),
+    auth: { type: "userToken", token: updated.accessToken, projectId: "" },
+  });
+  return client.cli.listProjects();
+}
+
+async function promptProjectChoice(projects: CliProject[]): Promise<CliProject> {
+  process.stderr.write(
+    "\nPick the project to send this agent's traces to " +
+      pc.dim("(a dedicated project keeps agent traces separate from your app traces)") +
+      ":\n",
+  );
+  projects.forEach((p, i) => {
+    process.stderr.write(`  ${i + 1}) ${p.workspaceName} / ${p.name}\n`);
+  });
+  const rl = createInterface({ input: process.stdin, output: process.stderr });
+  try {
+    while (true) {
+      const answer = (await rl.question(`Select [1-${projects.length}]: `)).trim();
+      const idx = Number.parseInt(answer, 10);
+      if (Number.isInteger(idx) && idx >= 1 && idx <= projects.length) {
+        return projects[idx - 1];
+      }
+      process.stderr.write(`${pc.red("Invalid selection.")}\n`);
+    }
+  } finally {
+    rl.close();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Key minting
+// ---------------------------------------------------------------------------
+
+interface MintResponse {
+  apiKey: string;
+  apiKeyId?: string;
+  projectId?: string;
+  projectName?: string;
+  workspaceName?: string;
+}
+
+/**
+ * POST /api/cli/api-key with the session bearer for an explicit project.
+ * `deviceName` is the human-visible name the key shows under in the dashboard —
+ * we pass a plugin-evident label so the key is recognizable and revocable.
+ */
+async function mintApiKey(
+  issuer: string,
+  sessionToken: string,
+  projectId: string,
+  deviceName: string,
+): Promise<MintResponse> {
+  const url = `${trimSlash(issuer)}/api/cli/api-key`;
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { authorization: `Bearer ${sessionToken}`, "content-type": "application/json" },
+    body: JSON.stringify({ deviceName, projectId }),
+  });
+  if (res.ok) {
+    return (await res.json()) as MintResponse;
+  }
+  const body = (await res.json().catch(() => ({}))) as { error?: string };
+  throw new Error(body.error ?? `api-key request failed (${res.status})`);
+}
+
+// ---------------------------------------------------------------------------
+// Host-CLI (claude) install
+// ---------------------------------------------------------------------------
+
+interface HostCommand {
+  label: string;
+  argv: string[];
+  /** true for steps whose non-zero exit is benign (e.g. marketplace already added). */
+  lenient: boolean;
+}
+
+export function buildInstallCommands(spec: AgentSpec, apiKey: string): HostCommand[] {
+  return [
+    {
+      label: "Add the Laminar marketplace",
+      argv: ["plugin", "marketplace", "add", spec.marketplaceRef],
+      lenient: true,
+    },
+    {
+      label: "Install the plugin",
+      argv: [
+        "plugin",
+        "install",
+        spec.pluginRef,
+        "--config",
+        `${spec.keyEnvName}=${apiKey}`,
+        "--scope",
+        "user",
+      ],
+      lenient: false,
+    },
+  ];
+}
+
+/**
+ * Probe whether the host CLI is present AND its `plugin install` supports
+ * `--config`. A single `--help` call covers both: a missing binary throws /
+ * non-zero, and older versions won't list `--config`. Cheaper and more robust
+ * than parsing a version string.
+ */
+export function hostCliSupportsConfig(hostCli: string): boolean {
+  try {
+    const r = spawnSync(hostCli, ["plugin", "install", "--help"], { encoding: "utf-8" });
+    if (r.error || r.status !== 0) return false;
+    return (r.stdout ?? "").includes("--config");
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Run the install commands in order, narrating each. The API key is masked in
+ * the echoed command line (it's still passed to the child). A lenient step's
+ * non-zero exit is warned-and-continued (e.g. marketplace already added);
+ * a non-lenient failure returns false.
+ */
+async function runInstall(
+  spec: AgentSpec,
+  commands: HostCommand[],
+  isJson: boolean,
+): Promise<boolean> {
+  if (!isJson) process.stderr.write("\n");
+  for (const cmd of commands) {
+    if (!isJson) {
+      process.stderr.write(`${pc.dim(`$ ${renderCommand(spec.hostCli, cmd.argv, true)}`)}\n`);
+    }
+    const code = await runChild(spec.hostCli, cmd.argv);
+    if (code !== 0) {
+      if (cmd.lenient) {
+        if (!isJson) {
+          process.stderr.write(
+            `${pc.yellow("⚠")} "${cmd.label}" exited ${code} ` +
+              `(continuing — usually means already configured)\n`,
+          );
+        }
+        continue;
+      }
+      return false;
+    }
+  }
+  return true;
+}
+
+function runChild(cmd: string, argv: string[]): Promise<number> {
+  return new Promise((resolve) => {
+    const child = spawn(cmd, argv, { stdio: "inherit" });
+    child.on("error", () => resolve(-1));
+    child.on("close", (code) => resolve(code ?? -1));
+  });
+}
+
+/**
+ * Print the install commands for the user to run by hand. Used when the host CLI
+ * is absent / too old / `--print-only`, or as recovery after an install failure.
+ * The key IS shown here (copy-paste must be complete) — the one place we print it.
+ */
+function printCommands(
+  spec: AgentSpec,
+  commands: HostCommand[],
+  isJson: boolean,
+  reason: "print-only" | "no-host-cli" | "install-failed",
+): void {
+  if (isJson) return;
+  const preamble =
+    reason === "no-host-cli"
+      ? `${pc.yellow("⚠")} \`${spec.hostCli}\` not found (or too old for --config). ` +
+        `Run these yourself:`
+      : reason === "install-failed"
+        ? `${pc.yellow("⚠")} Install failed. Finish by running these yourself:`
+        : `Run these to install the ${spec.label} plugin:`;
+  process.stderr.write(`\n${preamble}\n\n`);
+  for (const cmd of commands) {
+    process.stderr.write(`  ${renderCommand(spec.hostCli, cmd.argv, false)}\n`);
+  }
+  process.stderr.write("\n");
+}
+
+/**
+ * Render a host-CLI command line. When `mask`, replace the secret value in a
+ * `--config KEY=secret` pair with `***` so it doesn't hit terminal scrollback.
+ */
+export function renderCommand(hostCli: string, argv: string[], mask: boolean): string {
+  const parts = argv.map((arg, i) => {
+    if (mask && i > 0 && argv[i - 1] === "--config") {
+      const eq = arg.indexOf("=");
+      return eq === -1 ? arg : `${arg.slice(0, eq + 1)}***`;
+    }
+    return arg;
+  });
+  return `${hostCli} ${parts.join(" ")}`;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function safeReadCredentials(): Promise<Credentials | null> {
+  try {
+    return await readCredentials();
+  } catch {
+    return null;
+  }
+}
+
+function pick(...candidates: (string | undefined)[]): string {
+  for (const c of candidates) {
+    if (c && c.length > 0) return c;
+  }
+  return "";
+}
+
+function trimSlash(url: string): string {
+  return url.replace(/\/+$/, "");
+}
+
+function describeError(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+function emitError(json: boolean, code: string, detail: string): void {
+  if (json) {
+    process.stdout.write(JSON.stringify({ error: code, detail }) + "\n");
+  } else {
+    process.stderr.write(`\n${pc.red(`ERROR (${code})`)}: ${detail}\n`);
+  }
+}

--- a/packages/lmnr-cli/src/commands/plugin/index.ts
+++ b/packages/lmnr-cli/src/commands/plugin/index.ts
@@ -1,13 +1,13 @@
 import { spawn, spawnSync } from "node:child_process";
-import { chmod, mkdir, readFile, writeFile } from "node:fs/promises";
-import { homedir, hostname } from "node:os";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { hostname } from "node:os";
 import { join } from "node:path";
 import { createInterface } from "node:readline/promises";
 
 import { type CliProject, LaminarClient } from "@lmnr-ai/client";
 
 import { version } from "../../../package.json";
-import { type Credentials, readCredentials } from "../../auth/credentials";
+import { type Credentials, globalLmnrDirectory, readCredentials } from "../../auth/credentials";
 import { envHttpPort, refreshIfNeeded } from "../../auth/resolve";
 import { DEFAULT_BASE_URL, DEFAULT_FRONTEND_URL } from "../../constants";
 import { orange, pc } from "../../utils/colors";
@@ -17,52 +17,58 @@ import { handleLogin } from "../login";
 //   4  no_access          — user lacks access to the requested --project-id
 //   6  login_failed       — device-flow login failed / no creds after login
 //   7  no_project         — no project to select (create one first)
+//   8  config_write_failed — minted a key but couldn't write the plugin config file
 //   9  mint_failed        — POST /api/cli/api-key failed
 //   13 unsupported_agent  — unknown <agent> argument
-//   14 install_failed     — a host plugin install command exited non-zero
+//   14 install_failed     — a host `plugin` command exited non-zero
 const EXIT_NO_ACCESS = 4;
 const EXIT_LOGIN_FAILED = 6;
 const EXIT_NO_PROJECT = 7;
+const EXIT_CONFIG_WRITE_FAILED = 8;
 const EXIT_MINT_FAILED = 9;
 const EXIT_UNSUPPORTED_AGENT = 13;
 const EXIT_INSTALL_FAILED = 14;
 
 /**
- * Registry of agents `plugin add <agent>` can wire up. Keyed by the CLI argument
- * the user types. Adding a new coding agent (cursor, codex, …) is a matter of
- * appending an entry here plus its install-command shape.
+ * Registry of agents `plugin add <agent>` can wire up, keyed by the CLI argument
+ * the user types. Both supported agents now use the same shape: a host CLI with
+ * a native plugin marketplace (`<cli> plugin marketplace add` + an install verb),
+ * and a shared per-agent config file under `~/.config/lmnr/` that carries the
+ * project API key. Neither agent has a per-plugin secret store, so the key lives
+ * in that file and the plugin's hook reads it (see the plugin repos' config.ts).
+ * Adding a new agent (cursor, …) is a matter of appending an entry here.
  */
-export interface AgentSpec {
-  /** Human-facing label (banners, key name). */
+interface AgentSpec {
+  /** Human-facing label (banners, minted-key name). */
   label: string;
-  installer: "claude-plugin" | "codex-hook";
-  /** `claude plugin marketplace add <ref>` argument. */
-  marketplaceRef?: string;
-  /** `claude plugin install <ref>` argument (plugin@marketplace). */
-  pluginRef?: string;
-  /** userConfig/env key the project API key is delivered under. */
-  keyEnvName: string;
-  /** The host CLI binary (`claude`, `codex`) that activates the plugin. */
+  /** Host CLI binary that owns the plugin system (`claude`, `codex`). */
   hostCli: string;
-  /** Bundled hook artifact used by host CLIs without plugin config secrets. */
-  bundleUrl?: string;
+  /** `<cli> plugin marketplace add <ref>` argument (owner/repo or Git URL). */
+  marketplaceRef: string;
+  /** `<cli> plugin <install-verb> <ref>` argument (plugin@marketplace). */
+  pluginRef: string;
+  /** The install subcommand + trailing flags this host uses (after `plugin`). */
+  installArgv: string[];
+  /** Per-user config file (under ~/.config/lmnr) the plugin reads the key from. */
+  configFile: string;
 }
 
 const AGENTS: Record<string, AgentSpec> = {
   "claude-code": {
     label: "Claude Code",
-    installer: "claude-plugin",
+    hostCli: "claude",
     marketplaceRef: "lmnr-ai/lmnr-claude-code-plugin",
     pluginRef: "laminar@laminar",
-    keyEnvName: "LMNR_PROJECT_API_KEY",
-    hostCli: "claude",
+    installArgv: ["install", "laminar@laminar", "--scope", "user"],
+    configFile: "claude-code-plugin.json",
   },
   codex: {
     label: "Codex",
-    installer: "codex-hook",
-    keyEnvName: "LMNR_PROJECT_API_KEY",
     hostCli: "codex",
-    bundleUrl: "https://raw.githubusercontent.com/lmnr-ai/lmnr-codex-plugin/main/dist/hook.cjs",
+    marketplaceRef: "lmnr-ai/lmnr-codex-plugin",
+    pluginRef: "laminar@laminar",
+    installArgv: ["add", "laminar@laminar"],
+    configFile: "codex-plugin.json",
   },
 };
 
@@ -82,9 +88,11 @@ interface PluginAddResult {
   workspaceName: string | null;
   apiKey: string;
   apiKeyId: string | null;
+  /** Path to the per-agent config file the key was written to. */
+  configPath: string;
   /** true when we ran the host-CLI install; false when we only printed commands. */
   installed: boolean;
-  /** The `claude plugin ...` commands, as copy-pasteable strings (key shown). */
+  /** The `<cli> plugin ...` commands, as copy-pasteable strings. */
   commands: string[];
   restartRequired: boolean;
 }
@@ -94,14 +102,15 @@ interface PluginAddResult {
  *
  * Flow: log in (device flow) if needed → pick the project that should receive
  * this agent's traces (deliberately NOT the directory-linked app project) →
- * mint a project API key named after the plugin+host → install the plugin via
- * the host's native activation path, or print recovery commands when the host
- * CLI is missing / too old / `--print-only` was passed.
+ * mint a project API key named after the plugin+host → write it to
+ * `~/.config/lmnr/<agent>-plugin.json` (where the plugin's hook reads it) →
+ * install the plugin natively (`<cli> plugin marketplace add` + install), or
+ * print those commands when the host CLI is missing / `--print-only`.
  *
- * Unlike `setup`, this is a GLOBAL, directory-independent operation: it never
- * reads or writes `.lmnr/project.json` and never writes `.env`. The key lives
- * only in the host's own configuration. Claude Code stores it in plugin config;
- * Codex stores it in a private launcher file referenced by user-level hooks.
+ * Unlike `setup`, this is GLOBAL and directory-independent: it never reads or
+ * writes `.lmnr/project.json` or `.env`. The key never passes through the host
+ * CLI's argv — it lives only in the per-agent config file (both agents lack a
+ * per-plugin secret store), so the install commands carry no secret.
  */
 export async function handlePluginAdd(agent: string, options: PluginAddOptions): Promise<void> {
   const isJson = options.json === true;
@@ -176,52 +185,40 @@ export async function handlePluginAdd(agent: string, options: PluginAddOptions):
     );
   }
 
-  // --- 4. Install via the host activation path, or print commands ----------
-  let installed = false;
-  let commands: string[];
-  if (spec.installer === "claude-plugin") {
-    const hostCommands = buildInstallCommands(spec, key.apiKey);
-    commands = hostCommands.map((c) => renderCommand(spec.hostCli, c.argv, false));
-    const canRun = !options.printOnly && hostCliSupportsConfig(spec.hostCli);
-
-    if (canRun) {
-      installed = await runInstall(spec, hostCommands, isJson);
-      if (!installed) {
-        // A hard install failure (not the lenient marketplace-add path). Fall back
-        // to printing so the user can finish by hand.
-        printCommands(spec, hostCommands, isJson, "install-failed");
-        emitError(
-          isJson,
-          "install_failed",
-          `A \`${spec.hostCli} plugin\` command failed; commands printed above.`,
-        );
-        // Non-fatal-to-JSON: still emit the result below? No — exit with the code
-        // so automation sees the failure. The printed commands remain the recovery.
-        process.exit(EXIT_INSTALL_FAILED);
-      }
-    } else {
-      printCommands(spec, hostCommands, isJson, options.printOnly ? "print-only" : "no-host-cli");
-    }
-  } else {
-    const codexPlan = getCodexInstallPlan(spec, key.apiKey, baseUrl);
-    commands = codexPlan.commands;
-    if (options.printOnly) {
-      printCodexCommands(spec, codexPlan, isJson, "print-only");
-    } else if (!hostCliExists(spec.hostCli)) {
-      printCodexCommands(spec, codexPlan, isJson, "no-host-cli");
-    } else {
-      try {
-        await installCodexHook(codexPlan);
-        installed = true;
-      } catch (err) {
-        printCodexCommands(spec, codexPlan, isJson, "install-failed");
-        emitError(isJson, "install_failed", describeError(err));
-        process.exit(EXIT_INSTALL_FAILED);
-      }
-    }
+  // --- 4. Write the per-agent config file the plugin reads -----------------
+  let configPath: string;
+  try {
+    configPath = writeAgentConfig(spec, key.apiKey, baseUrl);
+  } catch (err) {
+    emitError(isJson, "config_write_failed", describeError(err));
+    process.exit(EXIT_CONFIG_WRITE_FAILED);
+  }
+  if (!isJson) {
+    process.stderr.write(`${pc.green("✓")} Wrote ${configPath}\n`);
   }
 
-  // --- 5. Summary ----------------------------------------------------------
+  // --- 5. Install via the host's native plugin system, or print commands ----
+  const hostCommands = buildInstallCommands(spec);
+  const commands = hostCommands.map((c) => renderCommand(spec.hostCli, c.argv));
+  const canRun = !options.printOnly && hostCliHasPlugins(spec.hostCli);
+
+  let installed = false;
+  if (canRun) {
+    installed = await runInstall(spec, hostCommands, isJson);
+    if (!installed) {
+      printCommands(spec, hostCommands, isJson, "install-failed");
+      emitError(
+        isJson,
+        "install_failed",
+        `A \`${spec.hostCli} plugin\` command failed; commands printed above.`,
+      );
+      process.exit(EXIT_INSTALL_FAILED);
+    }
+  } else {
+    printCommands(spec, hostCommands, isJson, options.printOnly ? "print-only" : "no-host-cli");
+  }
+
+  // --- 6. Summary ----------------------------------------------------------
   const result: PluginAddResult = {
     agent,
     projectId: project.id,
@@ -229,6 +226,7 @@ export async function handlePluginAdd(agent: string, options: PluginAddOptions):
     workspaceName: project.workspaceName ?? null,
     apiKey: key.apiKey,
     apiKeyId: key.apiKeyId ?? null,
+    configPath,
     installed,
     commands,
     restartRequired: installed,
@@ -356,7 +354,7 @@ async function promptProjectChoice(projects: CliProject[]): Promise<CliProject> 
 }
 
 // ---------------------------------------------------------------------------
-// Key minting
+// Key minting + config file
 // ---------------------------------------------------------------------------
 
 interface MintResponse {
@@ -391,8 +389,23 @@ async function mintApiKey(
   throw new Error(body.error ?? `api-key request failed (${res.status})`);
 }
 
+/**
+ * Write the per-agent Laminar plugin config (`~/.config/lmnr/<agent>-plugin.json`,
+ * mode 0600). This is the sole delivery channel for the project API key: both
+ * plugins read it from here (neither agent has a per-plugin secret store), so
+ * the key never has to pass through the host CLI's argv. Returns the path.
+ */
+export function writeAgentConfig(spec: AgentSpec, apiKey: string, baseUrl: string): string {
+  const dir = globalLmnrDirectory();
+  mkdirSync(dir, { recursive: true, mode: 0o700 });
+  const filePath = join(dir, spec.configFile);
+  const body = JSON.stringify({ projectApiKey: apiKey, baseUrl }, null, 2) + "\n";
+  writeFileSync(filePath, body, { mode: 0o600 });
+  return filePath;
+}
+
 // ---------------------------------------------------------------------------
-// Host-CLI (claude) install
+// Host-CLI native install
 // ---------------------------------------------------------------------------
 
 interface HostCommand {
@@ -402,10 +415,7 @@ interface HostCommand {
   lenient: boolean;
 }
 
-export function buildInstallCommands(spec: AgentSpec, apiKey: string): HostCommand[] {
-  if (!spec.marketplaceRef || !spec.pluginRef) {
-    throw new Error(`${spec.label} does not use host plugin install commands`);
-  }
+export function buildInstallCommands(spec: AgentSpec): HostCommand[] {
   return [
     {
       label: "Add the Laminar marketplace",
@@ -414,41 +424,32 @@ export function buildInstallCommands(spec: AgentSpec, apiKey: string): HostComma
     },
     {
       label: "Install the plugin",
-      argv: [
-        "plugin",
-        "install",
-        spec.pluginRef,
-        "--config",
-        `${spec.keyEnvName}=${apiKey}`,
-        "--scope",
-        "user",
-      ],
+      argv: ["plugin", ...spec.installArgv],
       lenient: false,
     },
   ];
 }
 
 /**
- * Probe whether the host CLI is present AND its `plugin install` supports
- * `--config`. A single `--help` call covers both: a missing binary throws /
- * non-zero, and older versions won't list `--config`. Cheaper and more robust
- * than parsing a version string.
+ * Probe whether the host CLI is present AND exposes a `plugin` subcommand. A
+ * single `plugin --help` call covers both: a missing binary throws / non-zero,
+ * and a too-old CLI without plugins won't succeed. Cheaper and more robust than
+ * parsing a version string.
  */
-export function hostCliSupportsConfig(hostCli: string): boolean {
+export function hostCliHasPlugins(hostCli: string): boolean {
   try {
-    const r = spawnSync(hostCli, ["plugin", "install", "--help"], { encoding: "utf-8" });
-    if (r.error || r.status !== 0) return false;
-    return (r.stdout ?? "").includes("--config");
+    const r = spawnSync(hostCli, ["plugin", "--help"], { encoding: "utf-8" });
+    return !r.error && r.status === 0;
   } catch {
     return false;
   }
 }
 
 /**
- * Run the install commands in order, narrating each. The API key is masked in
- * the echoed command line (it's still passed to the child). A lenient step's
- * non-zero exit is warned-and-continued (e.g. marketplace already added);
- * a non-lenient failure returns false.
+ * Run the install commands in order, narrating each. A lenient step's non-zero
+ * exit is warned-and-continued (e.g. marketplace already added); a non-lenient
+ * failure returns false. No secret is on the command line (the key is in the
+ * config file), so the commands are echoed verbatim.
  */
 async function runInstall(
   spec: AgentSpec,
@@ -458,7 +459,7 @@ async function runInstall(
   if (!isJson) process.stderr.write("\n");
   for (const cmd of commands) {
     if (!isJson) {
-      process.stderr.write(`${pc.dim(`$ ${renderCommand(spec.hostCli, cmd.argv, true)}`)}\n`);
+      process.stderr.write(`${pc.dim(`$ ${renderCommand(spec.hostCli, cmd.argv)}`)}\n`);
     }
     const code = await runChild(spec.hostCli, cmd.argv);
     if (code !== 0) {
@@ -487,8 +488,8 @@ function runChild(cmd: string, argv: string[]): Promise<number> {
 
 /**
  * Print the install commands for the user to run by hand. Used when the host CLI
- * is absent / too old / `--print-only`, or as recovery after an install failure.
- * The key IS shown here (copy-paste must be complete) — the one place we print it.
+ * is absent / `--print-only`, or as recovery after an install failure. The key
+ * is NOT here (it's in the config file), so these are safe to show verbatim.
  */
 function printCommands(
   spec: AgentSpec,
@@ -499,203 +500,21 @@ function printCommands(
   if (isJson) return;
   const preamble =
     reason === "no-host-cli"
-      ? `${pc.yellow("⚠")} \`${spec.hostCli}\` not found (or too old for --config). ` +
+      ? `${pc.yellow("⚠")} \`${spec.hostCli}\` not found (or has no plugin support). ` +
         `Run these yourself:`
       : reason === "install-failed"
         ? `${pc.yellow("⚠")} Install failed. Finish by running these yourself:`
         : `Run these to install the ${spec.label} plugin:`;
   process.stderr.write(`\n${preamble}\n\n`);
   for (const cmd of commands) {
-    process.stderr.write(`  ${renderCommand(spec.hostCli, cmd.argv, false)}\n`);
+    process.stderr.write(`  ${renderCommand(spec.hostCli, cmd.argv)}\n`);
   }
   process.stderr.write("\n");
 }
 
-/**
- * Render a host-CLI command line. When `mask`, replace the secret value in a
- * `--config KEY=secret` pair with `***` so it doesn't hit terminal scrollback.
- */
-export function renderCommand(hostCli: string, argv: string[], mask: boolean): string {
-  const parts = argv.map((arg, i) => {
-    if (mask && i > 0 && argv[i - 1] === "--config") {
-      const eq = arg.indexOf("=");
-      return eq === -1 ? arg : `${arg.slice(0, eq + 1)}***`;
-    }
-    return arg;
-  });
-  return `${hostCli} ${parts.join(" ")}`;
-}
-
-// ---------------------------------------------------------------------------
-// Codex hook install
-// ---------------------------------------------------------------------------
-
-interface CodexInstallPlan {
-  codexHome: string;
-  installDir: string;
-  hookPath: string;
-  launcherPath: string;
-  configPath: string;
-  bundleUrl: string;
-  apiKey: string;
-  baseUrl: string;
-  commands: string[];
-}
-
-function getCodexInstallPlan(spec: AgentSpec, apiKey: string, baseUrl: string): CodexInstallPlan {
-  const codexHome = process.env.CODEX_HOME || join(homedir(), ".codex");
-  const installDir = join(codexHome, "lmnr");
-  const hookPath = join(installDir, "hook.cjs");
-  const launcherPath = join(installDir, "hook-launcher.cjs");
-  const configPath = join(codexHome, "config.toml");
-  const bundleUrl = process.env.LMNR_CODEX_PLUGIN_BUNDLE_URL || spec.bundleUrl || "";
-  const hookCommand = `node ${shellQuote(launcherPath)}`;
-  return {
-    codexHome,
-    installDir,
-    hookPath,
-    launcherPath,
-    configPath,
-    bundleUrl,
-    apiKey,
-    baseUrl,
-    commands: [
-      `mkdir -p ${shellQuote(installDir)}`,
-      `curl -fsSL ${shellQuote(bundleUrl)} -o ${shellQuote(hookPath)}`,
-      `write ${shellQuote(launcherPath)} with ${spec.keyEnvName}=<api-key> ` +
-        `and LMNR_BASE_URL=${baseUrl}`,
-      `add a Codex Stop hook to ${shellQuote(configPath)}: ${hookCommand}`,
-    ],
-  };
-}
-
-async function installCodexHook(plan: CodexInstallPlan): Promise<void> {
-  if (!plan.bundleUrl) {
-    throw new Error("missing Codex plugin bundle URL");
-  }
-  await mkdir(plan.installDir, { recursive: true });
-  const hook = await fetchText(plan.bundleUrl);
-  await writeFile(plan.hookPath, hook, { encoding: "utf-8", mode: 0o600 });
-  await chmod(plan.hookPath, 0o600).catch(() => undefined);
-  await writeFile(plan.launcherPath, buildCodexLauncherSource(plan), {
-    encoding: "utf-8",
-    mode: 0o600,
-  });
-  await chmod(plan.launcherPath, 0o600).catch(() => undefined);
-
-  let config: string;
-  try {
-    config = await readFile(plan.configPath, "utf-8");
-  } catch {
-    config = "";
-  }
-  const next = upsertCodexHookConfig(config, plan.launcherPath);
-  await writeFile(plan.configPath, next, { encoding: "utf-8", mode: 0o600 });
-  await chmod(plan.configPath, 0o600).catch(() => undefined);
-}
-
-async function fetchText(url: string): Promise<string> {
-  const res = await fetch(url);
-  if (!res.ok) {
-    throw new Error(`failed to download Codex plugin bundle (${res.status}) from ${url}`);
-  }
-  return res.text();
-}
-
-export function buildCodexLauncherSource(plan: {
-  hookPath: string;
-  apiKey: string;
-  baseUrl: string;
-}): string {
-  return (
-    "// Generated by `lmnr-cli plugin add codex`. Do not commit this file; " +
-    "it contains a project API key.\n" +
-    `process.env.LMNR_PROJECT_API_KEY = ${JSON.stringify(plan.apiKey)};\n` +
-    `process.env.LMNR_BASE_URL = ${JSON.stringify(plan.baseUrl)};\n` +
-    `require(${JSON.stringify(plan.hookPath)});\n`
-  );
-}
-
-const CODEX_HOOK_START = "# >>> Laminar Codex plugin";
-const CODEX_HOOK_END = "# <<< Laminar Codex plugin";
-
-export function upsertCodexHookConfig(config: string, launcherPath: string): string {
-  let text = removeCodexHookBlock(config).trimEnd();
-  text = ensureCodexHooksFeature(text).trimEnd();
-  const block = [
-    CODEX_HOOK_START,
-    "[[hooks.Stop]]",
-    "[[hooks.Stop.hooks]]",
-    'type = "command"',
-    `command = ${JSON.stringify(`node ${launcherPath}`)}`,
-    "timeout = 30",
-    CODEX_HOOK_END,
-  ].join("\n");
-  return `${text ? `${text}\n\n` : ""}${block}\n`;
-}
-
-function removeCodexHookBlock(config: string): string {
-  const pattern = new RegExp(
-    `${escapeRegExp(CODEX_HOOK_START)}[\\s\\S]*?${escapeRegExp(CODEX_HOOK_END)}\\n?`,
-    "g",
-  );
-  return config.replace(pattern, "");
-}
-
-function ensureCodexHooksFeature(config: string): string {
-  const featuresMatch = /^\[features\]\s*$/m.exec(config);
-  if (!featuresMatch) {
-    return `${config.trimEnd()}${config.trimEnd() ? "\n\n" : ""}[features]\nhooks = true\n`;
-  }
-
-  const start = featuresMatch.index;
-  const afterHeader = start + featuresMatch[0].length;
-  const nextTableRel = config.slice(afterHeader).search(/^\[/m);
-  const end = nextTableRel === -1 ? config.length : afterHeader + nextTableRel;
-  const table = config.slice(start, end);
-  const nextTable = config.slice(end);
-  const updatedTable = /^hooks\s*=/m.test(table)
-    ? table.replace(/^hooks\s*=.*$/m, "hooks = true")
-    : table.replace(/^\[features\]\s*$/m, "[features]\nhooks = true");
-  return `${config.slice(0, start)}${updatedTable}${nextTable}`;
-}
-
-function printCodexCommands(
-  spec: AgentSpec,
-  plan: CodexInstallPlan,
-  isJson: boolean,
-  reason: "print-only" | "no-host-cli" | "install-failed",
-): void {
-  if (isJson) return;
-  const preamble =
-    reason === "no-host-cli"
-      ? `${pc.yellow("⚠")} \`${spec.hostCli}\` not found. ` +
-        "Run these equivalent setup steps yourself:"
-      : reason === "install-failed"
-        ? `${pc.yellow("⚠")} Codex hook install failed. Equivalent setup steps:`
-        : `Equivalent setup steps for the ${spec.label} plugin:`;
-  process.stderr.write(`\n${preamble}\n\n`);
-  for (const cmd of plan.commands) {
-    process.stderr.write(`  ${cmd}\n`);
-  }
-  process.stderr.write("\n");
-}
-
-function hostCliExists(hostCli: string): boolean {
-  try {
-    const r = spawnSync(hostCli, ["--version"], { encoding: "utf-8" });
-    return !r.error && (r.status === 0 || r.status === null);
-  } catch {
-    return false;
-  }
-}
-
-function shellQuote(value: string): string {
-  return `'${value.replace(/'/g, `'"'"'`)}'`;
-}
-
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+/** Render a host-CLI command line for display / copy-paste. */
+export function renderCommand(hostCli: string, argv: string[]): string {
+  return `${hostCli} ${argv.join(" ")}`;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/lmnr-cli/src/commands/plugin/index.ts
+++ b/packages/lmnr-cli/src/commands/plugin/index.ts
@@ -2,21 +2,24 @@ import { spawn, spawnSync } from "node:child_process";
 import { mkdirSync, writeFileSync } from "node:fs";
 import { hostname } from "node:os";
 import { join } from "node:path";
-import { createInterface } from "node:readline/promises";
 
-import { type CliProject, LaminarClient } from "@lmnr-ai/client";
+import { type CliProject } from "@lmnr-ai/client";
+import { errorMessage } from "@lmnr-ai/types";
 
 import { version } from "../../../package.json";
-import { type Credentials, globalLmnrDirectory, readCredentials } from "../../auth/credentials";
-import { envHttpPort, refreshIfNeeded } from "../../auth/resolve";
+import { mintProjectApiKey } from "../../auth/api-key";
+import { type Credentials, globalLmnrDirectory, safeReadCredentials } from "../../auth/credentials";
 import { DEFAULT_BASE_URL, DEFAULT_FRONTEND_URL } from "../../constants";
 import { orange, pc } from "../../utils/colors";
+import { emitError } from "../../utils/output";
+import { listProjects, promptProjectChoice } from "../../utils/projects";
+import { firstNonEmpty } from "../../utils/text";
 import { handleLogin } from "../login";
 
 // Exit codes (machine-readable; distinct so automation can branch on the mode):
 //   4  no_access          — user lacks access to the requested --project-id
 //   6  login_failed       — device-flow login failed / no creds after login
-//   7  no_project         — no project to select (create one first)
+//   7  no_project         — no project to select / ambiguous (see error string)
 //   8  config_write_failed — minted a key but couldn't write the plugin config file
 //   9  mint_failed        — POST /api/cli/api-key failed
 //   13 unsupported_agent  — unknown <agent> argument
@@ -31,14 +34,13 @@ const EXIT_INSTALL_FAILED = 14;
 
 /**
  * Registry of agents `plugin add <agent>` can wire up, keyed by the CLI argument
- * the user types. Both supported agents now use the same shape: a host CLI with
- * a native plugin marketplace (`<cli> plugin marketplace add` + an install verb),
+ * the user types. Both supported agents use the same shape: a host CLI with a
+ * native plugin marketplace (`<cli> plugin marketplace add` + an install verb),
  * and a shared per-agent config file under `~/.config/lmnr/` that carries the
  * project API key. Neither agent has a per-plugin secret store, so the key lives
- * in that file and the plugin's hook reads it (see the plugin repos' config.ts).
- * Adding a new agent (cursor, …) is a matter of appending an entry here.
+ * in that file and the plugin's hook reads it. Adding an agent = one entry.
  */
-interface AgentSpec {
+export interface AgentSpec {
   /** Human-facing label (banners, minted-key name). */
   label: string;
   /** Host CLI binary that owns the plugin system (`claude`, `codex`). */
@@ -112,7 +114,7 @@ interface PluginAddResult {
  * CLI's argv — it lives only in the per-agent config file (both agents lack a
  * per-plugin secret store), so the install commands carry no secret.
  */
-export async function handlePluginAdd(agent: string, options: PluginAddOptions): Promise<void> {
+export const handlePluginAdd = async (agent: string, options: PluginAddOptions): Promise<void> => {
   const isJson = options.json === true;
   const spec = AGENTS[agent];
   if (!spec) {
@@ -124,12 +126,12 @@ export async function handlePluginAdd(agent: string, options: PluginAddOptions):
     process.exit(EXIT_UNSUPPORTED_AGENT);
   }
 
-  const frontendUrl = pick(
+  const frontendUrl = firstNonEmpty(
     options.frontendUrl,
     process.env.LMNR_FRONTEND_URL,
     DEFAULT_FRONTEND_URL,
   );
-  const baseUrl = pick(options.baseUrl, process.env.LMNR_BASE_URL, DEFAULT_BASE_URL);
+  const baseUrl = firstNonEmpty(options.baseUrl, process.env.LMNR_BASE_URL, DEFAULT_BASE_URL);
 
   if (!isJson) {
     process.stderr.write(`\n${orange("Laminar CLI")} ${pc.dim(`v${version}`)}\n`);
@@ -144,7 +146,7 @@ export async function handlePluginAdd(agent: string, options: PluginAddOptions):
     try {
       login = await handleLogin({ frontendUrl, noBrowser: options.noBrowser });
     } catch (err) {
-      emitError(isJson, "login_failed", describeError(err));
+      emitError(isJson, "login_failed", errorMessage(err));
       process.exit(EXIT_LOGIN_FAILED);
     }
     loginProjectId = login.projectId;
@@ -164,7 +166,7 @@ export async function handlePluginAdd(agent: string, options: PluginAddOptions):
   const project = await resolveProject(creds, baseUrl, options, loginProjectId, isJson);
   if (!isJson) {
     process.stderr.write(
-      `${pc.green("✓")} Traces will go to project ${project.name ?? project.id}` +
+      `${pc.green("✓")} Traces will go to project ${project.name || project.id}` +
         (project.workspaceName ? pc.dim(` (${project.workspaceName})`) : "") +
         "\n",
     );
@@ -172,17 +174,15 @@ export async function handlePluginAdd(agent: string, options: PluginAddOptions):
 
   // --- 3. Mint a plugin-named key ------------------------------------------
   const keyName = `${spec.label} plugin @ ${hostname()}`;
-  let key: MintResponse;
+  let key;
   try {
-    key = await mintApiKey(issuer, creds.sessionToken, project.id, keyName);
+    key = await mintProjectApiKey(issuer, creds.sessionToken, project.id, keyName);
   } catch (err) {
-    emitError(isJson, "mint_failed", describeError(err));
+    emitError(isJson, "mint_failed", errorMessage(err));
     process.exit(EXIT_MINT_FAILED);
   }
   if (!isJson) {
-    process.stderr.write(
-      `${pc.green("✓")} Minted a project API key named "${pc.bold(keyName)}"\n`,
-    );
+    process.stderr.write(`${pc.green("✓")} Minted a project API key named "${pc.bold(keyName)}"\n`);
   }
 
   // --- 4. Write the per-agent config file the plugin reads -----------------
@@ -190,7 +190,7 @@ export async function handlePluginAdd(agent: string, options: PluginAddOptions):
   try {
     configPath = writeAgentConfig(spec, key.apiKey, baseUrl);
   } catch (err) {
-    emitError(isJson, "config_write_failed", describeError(err));
+    emitError(isJson, "config_write_failed", errorMessage(err));
     process.exit(EXIT_CONFIG_WRITE_FAILED);
   }
   if (!isJson) {
@@ -222,8 +222,8 @@ export async function handlePluginAdd(agent: string, options: PluginAddOptions):
   const result: PluginAddResult = {
     agent,
     projectId: project.id,
-    projectName: project.name ?? null,
-    workspaceName: project.workspaceName ?? null,
+    projectName: project.name || null,
+    workspaceName: project.workspaceName || null,
     apiKey: key.apiKey,
     apiKeyId: key.apiKeyId ?? null,
     configPath,
@@ -249,7 +249,7 @@ export async function handlePluginAdd(agent: string, options: PluginAddOptions):
       `\nRun the commands above to finish, then ${pc.bold(`restart ${spec.label}`)}.\n`,
     );
   }
-}
+};
 
 // ---------------------------------------------------------------------------
 // Project selection
@@ -264,13 +264,13 @@ export async function handlePluginAdd(agent: string, options: PluginAddOptions):
  * project. When we just logged in and the browser handed back a selected/created
  * project (loginProjectId), that's honored as the deliberate choice.
  */
-async function resolveProject(
+const resolveProject = async (
   creds: Credentials,
   baseUrl: string,
   options: PluginAddOptions,
   loginProjectId: string | null,
   isJson: boolean,
-): Promise<CliProject> {
+): Promise<CliProject> => {
   const projects = await listProjects(creds, baseUrl);
 
   if (options.projectId) {
@@ -315,79 +315,17 @@ async function resolveProject(
     );
     process.exit(EXIT_NO_PROJECT);
   }
-  return promptProjectChoice(projects);
-}
-
-/** List the projects the user can access (user-JWT discovery). */
-async function listProjects(creds: Credentials, baseUrl: string): Promise<CliProject[]> {
-  const updated = await refreshIfNeeded(creds);
-  const client = new LaminarClient({
-    baseUrl,
-    port: envHttpPort(),
-    auth: { type: "userToken", token: updated.accessToken, projectId: "" },
-  });
-  return client.cli.listProjects();
-}
-
-async function promptProjectChoice(projects: CliProject[]): Promise<CliProject> {
-  process.stderr.write(
+  return promptProjectChoice(
+    projects,
     "\nPick the project to send this agent's traces to " +
       pc.dim("(a dedicated project keeps agent traces separate from your app traces)") +
       ":\n",
   );
-  projects.forEach((p, i) => {
-    process.stderr.write(`  ${i + 1}) ${p.workspaceName} / ${p.name}\n`);
-  });
-  const rl = createInterface({ input: process.stdin, output: process.stderr });
-  try {
-    while (true) {
-      const answer = (await rl.question(`Select [1-${projects.length}]: `)).trim();
-      const idx = Number.parseInt(answer, 10);
-      if (Number.isInteger(idx) && idx >= 1 && idx <= projects.length) {
-        return projects[idx - 1];
-      }
-      process.stderr.write(`${pc.red("Invalid selection.")}\n`);
-    }
-  } finally {
-    rl.close();
-  }
-}
+};
 
 // ---------------------------------------------------------------------------
-// Key minting + config file
+// Per-agent config file
 // ---------------------------------------------------------------------------
-
-interface MintResponse {
-  apiKey: string;
-  apiKeyId?: string;
-  projectId?: string;
-  projectName?: string;
-  workspaceName?: string;
-}
-
-/**
- * POST /api/cli/api-key with the session bearer for an explicit project.
- * `deviceName` is the human-visible name the key shows under in the dashboard —
- * we pass a plugin-evident label so the key is recognizable and revocable.
- */
-async function mintApiKey(
-  issuer: string,
-  sessionToken: string,
-  projectId: string,
-  deviceName: string,
-): Promise<MintResponse> {
-  const url = `${trimSlash(issuer)}/api/cli/api-key`;
-  const res = await fetch(url, {
-    method: "POST",
-    headers: { authorization: `Bearer ${sessionToken}`, "content-type": "application/json" },
-    body: JSON.stringify({ deviceName, projectId }),
-  });
-  if (res.ok) {
-    return (await res.json()) as MintResponse;
-  }
-  const body = (await res.json().catch(() => ({}))) as { error?: string };
-  throw new Error(body.error ?? `api-key request failed (${res.status})`);
-}
 
 /**
  * Write the per-agent Laminar plugin config (`~/.config/lmnr/<agent>-plugin.json`,
@@ -395,14 +333,14 @@ async function mintApiKey(
  * plugins read it from here (neither agent has a per-plugin secret store), so
  * the key never has to pass through the host CLI's argv. Returns the path.
  */
-export function writeAgentConfig(spec: AgentSpec, apiKey: string, baseUrl: string): string {
+export const writeAgentConfig = (spec: AgentSpec, apiKey: string, baseUrl: string): string => {
   const dir = globalLmnrDirectory();
   mkdirSync(dir, { recursive: true, mode: 0o700 });
   const filePath = join(dir, spec.configFile);
   const body = JSON.stringify({ projectApiKey: apiKey, baseUrl }, null, 2) + "\n";
   writeFileSync(filePath, body, { mode: 0o600 });
   return filePath;
-}
+};
 
 // ---------------------------------------------------------------------------
 // Host-CLI native install
@@ -415,20 +353,18 @@ interface HostCommand {
   lenient: boolean;
 }
 
-export function buildInstallCommands(spec: AgentSpec): HostCommand[] {
-  return [
-    {
-      label: "Add the Laminar marketplace",
-      argv: ["plugin", "marketplace", "add", spec.marketplaceRef],
-      lenient: true,
-    },
-    {
-      label: "Install the plugin",
-      argv: ["plugin", ...spec.installArgv],
-      lenient: false,
-    },
-  ];
-}
+export const buildInstallCommands = (spec: AgentSpec): HostCommand[] => [
+  {
+    label: "Add the Laminar marketplace",
+    argv: ["plugin", "marketplace", "add", spec.marketplaceRef],
+    lenient: true,
+  },
+  {
+    label: "Install the plugin",
+    argv: ["plugin", ...spec.installArgv],
+    lenient: false,
+  },
+];
 
 /**
  * Probe whether the host CLI is present AND exposes a `plugin` subcommand. A
@@ -436,14 +372,14 @@ export function buildInstallCommands(spec: AgentSpec): HostCommand[] {
  * and a too-old CLI without plugins won't succeed. Cheaper and more robust than
  * parsing a version string.
  */
-export function hostCliHasPlugins(hostCli: string): boolean {
+export const hostCliHasPlugins = (hostCli: string): boolean => {
   try {
     const r = spawnSync(hostCli, ["plugin", "--help"], { encoding: "utf-8" });
     return !r.error && r.status === 0;
   } catch {
     return false;
   }
-}
+};
 
 /**
  * Run the install commands in order, narrating each. A lenient step's non-zero
@@ -451,11 +387,11 @@ export function hostCliHasPlugins(hostCli: string): boolean {
  * failure returns false. No secret is on the command line (the key is in the
  * config file), so the commands are echoed verbatim.
  */
-async function runInstall(
+const runInstall = async (
   spec: AgentSpec,
   commands: HostCommand[],
   isJson: boolean,
-): Promise<boolean> {
+): Promise<boolean> => {
   if (!isJson) process.stderr.write("\n");
   for (const cmd of commands) {
     if (!isJson) {
@@ -476,27 +412,26 @@ async function runInstall(
     }
   }
   return true;
-}
+};
 
-function runChild(cmd: string, argv: string[]): Promise<number> {
-  return new Promise((resolve) => {
+const runChild = (cmd: string, argv: string[]): Promise<number> =>
+  new Promise((resolve) => {
     const child = spawn(cmd, argv, { stdio: "inherit" });
     child.on("error", () => resolve(-1));
     child.on("close", (code) => resolve(code ?? -1));
   });
-}
 
 /**
  * Print the install commands for the user to run by hand. Used when the host CLI
  * is absent / `--print-only`, or as recovery after an install failure. The key
  * is NOT here (it's in the config file), so these are safe to show verbatim.
  */
-function printCommands(
+const printCommands = (
   spec: AgentSpec,
   commands: HostCommand[],
   isJson: boolean,
   reason: "print-only" | "no-host-cli" | "install-failed",
-): void {
+): void => {
   if (isJson) return;
   const preamble =
     reason === "no-host-cli"
@@ -510,44 +445,8 @@ function printCommands(
     process.stderr.write(`  ${renderCommand(spec.hostCli, cmd.argv)}\n`);
   }
   process.stderr.write("\n");
-}
+};
 
 /** Render a host-CLI command line for display / copy-paste. */
-export function renderCommand(hostCli: string, argv: string[]): string {
-  return `${hostCli} ${argv.join(" ")}`;
-}
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-async function safeReadCredentials(): Promise<Credentials | null> {
-  try {
-    return await readCredentials();
-  } catch {
-    return null;
-  }
-}
-
-function pick(...candidates: (string | undefined)[]): string {
-  for (const c of candidates) {
-    if (c && c.length > 0) return c;
-  }
-  return "";
-}
-
-function trimSlash(url: string): string {
-  return url.replace(/\/+$/, "");
-}
-
-function describeError(err: unknown): string {
-  return err instanceof Error ? err.message : String(err);
-}
-
-function emitError(json: boolean, code: string, detail: string): void {
-  if (json) {
-    process.stdout.write(JSON.stringify({ error: code, detail }) + "\n");
-  } else {
-    process.stderr.write(`\n${pc.red(`ERROR (${code})`)}: ${detail}\n`);
-  }
-}
+export const renderCommand = (hostCli: string, argv: string[]): string =>
+  `${hostCli} ${argv.join(" ")}`;

--- a/packages/lmnr-cli/src/commands/plugin/index.ts
+++ b/packages/lmnr-cli/src/commands/plugin/index.ts
@@ -1,5 +1,7 @@
 import { spawn, spawnSync } from "node:child_process";
-import { hostname } from "node:os";
+import { chmod, mkdir, readFile, writeFile } from "node:fs/promises";
+import { homedir, hostname } from "node:os";
+import { join } from "node:path";
 import { createInterface } from "node:readline/promises";
 
 import { type CliProject, LaminarClient } from "@lmnr-ai/client";
@@ -17,7 +19,7 @@ import { handleLogin } from "../login";
 //   7  no_project         — no project to select (create one first)
 //   9  mint_failed        — POST /api/cli/api-key failed
 //   13 unsupported_agent  — unknown <agent> argument
-//   14 install_failed     — a `claude plugin ...` command exited non-zero
+//   14 install_failed     — a host plugin install command exited non-zero
 const EXIT_NO_ACCESS = 4;
 const EXIT_LOGIN_FAILED = 6;
 const EXIT_NO_PROJECT = 7;
@@ -30,26 +32,37 @@ const EXIT_INSTALL_FAILED = 14;
  * the user types. Adding a new coding agent (cursor, codex, …) is a matter of
  * appending an entry here plus its install-command shape.
  */
-interface AgentSpec {
+export interface AgentSpec {
   /** Human-facing label (banners, key name). */
   label: string;
+  installer: "claude-plugin" | "codex-hook";
   /** `claude plugin marketplace add <ref>` argument. */
-  marketplaceRef: string;
+  marketplaceRef?: string;
   /** `claude plugin install <ref>` argument (plugin@marketplace). */
-  pluginRef: string;
-  /** userConfig key the project API key is delivered under. */
+  pluginRef?: string;
+  /** userConfig/env key the project API key is delivered under. */
   keyEnvName: string;
-  /** The host CLI binary (`claude`) that installs the plugin. */
+  /** The host CLI binary (`claude`, `codex`) that activates the plugin. */
   hostCli: string;
+  /** Bundled hook artifact used by host CLIs without plugin config secrets. */
+  bundleUrl?: string;
 }
 
 const AGENTS: Record<string, AgentSpec> = {
   "claude-code": {
     label: "Claude Code",
+    installer: "claude-plugin",
     marketplaceRef: "lmnr-ai/lmnr-claude-code-plugin",
     pluginRef: "laminar@laminar",
     keyEnvName: "LMNR_PROJECT_API_KEY",
     hostCli: "claude",
+  },
+  codex: {
+    label: "Codex",
+    installer: "codex-hook",
+    keyEnvName: "LMNR_PROJECT_API_KEY",
+    hostCli: "codex",
+    bundleUrl: "https://raw.githubusercontent.com/lmnr-ai/lmnr-codex-plugin/main/dist/hook.cjs",
   },
 };
 
@@ -82,12 +95,13 @@ interface PluginAddResult {
  * Flow: log in (device flow) if needed → pick the project that should receive
  * this agent's traces (deliberately NOT the directory-linked app project) →
  * mint a project API key named after the plugin+host → install the plugin via
- * the host CLI (`claude plugin ...`), or print those commands when the host CLI
- * is missing / lacks `--config` / `--print-only` was passed.
+ * the host's native activation path, or print recovery commands when the host
+ * CLI is missing / too old / `--print-only` was passed.
  *
  * Unlike `setup`, this is a GLOBAL, directory-independent operation: it never
  * reads or writes `.lmnr/project.json` and never writes `.env`. The key lives
- * only in the host CLI's own (keychain-backed) config via `--config`.
+ * only in the host's own configuration. Claude Code stores it in plugin config;
+ * Codex stores it in a private launcher file referenced by user-level hooks.
  */
 export async function handlePluginAdd(agent: string, options: PluginAddOptions): Promise<void> {
   const isJson = options.json === true;
@@ -162,28 +176,49 @@ export async function handlePluginAdd(agent: string, options: PluginAddOptions):
     );
   }
 
-  // --- 4. Install via the host CLI, or print the commands ------------------
-  const commands = buildInstallCommands(spec, key.apiKey);
-  const canRun = !options.printOnly && hostCliSupportsConfig(spec.hostCli);
-
+  // --- 4. Install via the host activation path, or print commands ----------
   let installed = false;
-  if (canRun) {
-    installed = await runInstall(spec, commands, isJson);
-    if (!installed) {
-      // A hard install failure (not the lenient marketplace-add path). Fall back
-      // to printing so the user can finish by hand.
-      printCommands(spec, commands, isJson, "install-failed");
-      emitError(
-        isJson,
-        "install_failed",
-        `A \`${spec.hostCli} plugin\` command failed; commands printed above.`,
-      );
-      // Non-fatal-to-JSON: still emit the result below? No — exit with the code
-      // so automation sees the failure. The printed commands remain the recovery.
-      process.exit(EXIT_INSTALL_FAILED);
+  let commands: string[];
+  if (spec.installer === "claude-plugin") {
+    const hostCommands = buildInstallCommands(spec, key.apiKey);
+    commands = hostCommands.map((c) => renderCommand(spec.hostCli, c.argv, false));
+    const canRun = !options.printOnly && hostCliSupportsConfig(spec.hostCli);
+
+    if (canRun) {
+      installed = await runInstall(spec, hostCommands, isJson);
+      if (!installed) {
+        // A hard install failure (not the lenient marketplace-add path). Fall back
+        // to printing so the user can finish by hand.
+        printCommands(spec, hostCommands, isJson, "install-failed");
+        emitError(
+          isJson,
+          "install_failed",
+          `A \`${spec.hostCli} plugin\` command failed; commands printed above.`,
+        );
+        // Non-fatal-to-JSON: still emit the result below? No — exit with the code
+        // so automation sees the failure. The printed commands remain the recovery.
+        process.exit(EXIT_INSTALL_FAILED);
+      }
+    } else {
+      printCommands(spec, hostCommands, isJson, options.printOnly ? "print-only" : "no-host-cli");
     }
   } else {
-    printCommands(spec, commands, isJson, options.printOnly ? "print-only" : "no-host-cli");
+    const codexPlan = getCodexInstallPlan(spec, key.apiKey, baseUrl);
+    commands = codexPlan.commands;
+    if (options.printOnly) {
+      printCodexCommands(spec, codexPlan, isJson, "print-only");
+    } else if (!hostCliExists(spec.hostCli)) {
+      printCodexCommands(spec, codexPlan, isJson, "no-host-cli");
+    } else {
+      try {
+        await installCodexHook(codexPlan);
+        installed = true;
+      } catch (err) {
+        printCodexCommands(spec, codexPlan, isJson, "install-failed");
+        emitError(isJson, "install_failed", describeError(err));
+        process.exit(EXIT_INSTALL_FAILED);
+      }
+    }
   }
 
   // --- 5. Summary ----------------------------------------------------------
@@ -195,7 +230,7 @@ export async function handlePluginAdd(agent: string, options: PluginAddOptions):
     apiKey: key.apiKey,
     apiKeyId: key.apiKeyId ?? null,
     installed,
-    commands: commands.map((c) => renderCommand(spec.hostCli, c.argv, false)),
+    commands,
     restartRequired: installed,
   };
 
@@ -368,6 +403,9 @@ interface HostCommand {
 }
 
 export function buildInstallCommands(spec: AgentSpec, apiKey: string): HostCommand[] {
+  if (!spec.marketplaceRef || !spec.pluginRef) {
+    throw new Error(`${spec.label} does not use host plugin install commands`);
+  }
   return [
     {
       label: "Add the Laminar marketplace",
@@ -486,6 +524,178 @@ export function renderCommand(hostCli: string, argv: string[], mask: boolean): s
     return arg;
   });
   return `${hostCli} ${parts.join(" ")}`;
+}
+
+// ---------------------------------------------------------------------------
+// Codex hook install
+// ---------------------------------------------------------------------------
+
+interface CodexInstallPlan {
+  codexHome: string;
+  installDir: string;
+  hookPath: string;
+  launcherPath: string;
+  configPath: string;
+  bundleUrl: string;
+  apiKey: string;
+  baseUrl: string;
+  commands: string[];
+}
+
+function getCodexInstallPlan(spec: AgentSpec, apiKey: string, baseUrl: string): CodexInstallPlan {
+  const codexHome = process.env.CODEX_HOME || join(homedir(), ".codex");
+  const installDir = join(codexHome, "lmnr");
+  const hookPath = join(installDir, "hook.cjs");
+  const launcherPath = join(installDir, "hook-launcher.cjs");
+  const configPath = join(codexHome, "config.toml");
+  const bundleUrl = process.env.LMNR_CODEX_PLUGIN_BUNDLE_URL || spec.bundleUrl || "";
+  const hookCommand = `node ${shellQuote(launcherPath)}`;
+  return {
+    codexHome,
+    installDir,
+    hookPath,
+    launcherPath,
+    configPath,
+    bundleUrl,
+    apiKey,
+    baseUrl,
+    commands: [
+      `mkdir -p ${shellQuote(installDir)}`,
+      `curl -fsSL ${shellQuote(bundleUrl)} -o ${shellQuote(hookPath)}`,
+      `write ${shellQuote(launcherPath)} with ${spec.keyEnvName}=<api-key> ` +
+        `and LMNR_BASE_URL=${baseUrl}`,
+      `add a Codex Stop hook to ${shellQuote(configPath)}: ${hookCommand}`,
+    ],
+  };
+}
+
+async function installCodexHook(plan: CodexInstallPlan): Promise<void> {
+  if (!plan.bundleUrl) {
+    throw new Error("missing Codex plugin bundle URL");
+  }
+  await mkdir(plan.installDir, { recursive: true });
+  const hook = await fetchText(plan.bundleUrl);
+  await writeFile(plan.hookPath, hook, { encoding: "utf-8", mode: 0o600 });
+  await chmod(plan.hookPath, 0o600).catch(() => undefined);
+  await writeFile(plan.launcherPath, buildCodexLauncherSource(plan), {
+    encoding: "utf-8",
+    mode: 0o600,
+  });
+  await chmod(plan.launcherPath, 0o600).catch(() => undefined);
+
+  let config: string;
+  try {
+    config = await readFile(plan.configPath, "utf-8");
+  } catch {
+    config = "";
+  }
+  const next = upsertCodexHookConfig(config, plan.launcherPath);
+  await writeFile(plan.configPath, next, { encoding: "utf-8", mode: 0o600 });
+  await chmod(plan.configPath, 0o600).catch(() => undefined);
+}
+
+async function fetchText(url: string): Promise<string> {
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(`failed to download Codex plugin bundle (${res.status}) from ${url}`);
+  }
+  return res.text();
+}
+
+export function buildCodexLauncherSource(plan: {
+  hookPath: string;
+  apiKey: string;
+  baseUrl: string;
+}): string {
+  return (
+    "// Generated by `lmnr-cli plugin add codex`. Do not commit this file; " +
+    "it contains a project API key.\n" +
+    `process.env.LMNR_PROJECT_API_KEY = ${JSON.stringify(plan.apiKey)};\n` +
+    `process.env.LMNR_BASE_URL = ${JSON.stringify(plan.baseUrl)};\n` +
+    `require(${JSON.stringify(plan.hookPath)});\n`
+  );
+}
+
+const CODEX_HOOK_START = "# >>> Laminar Codex plugin";
+const CODEX_HOOK_END = "# <<< Laminar Codex plugin";
+
+export function upsertCodexHookConfig(config: string, launcherPath: string): string {
+  let text = removeCodexHookBlock(config).trimEnd();
+  text = ensureCodexHooksFeature(text).trimEnd();
+  const block = [
+    CODEX_HOOK_START,
+    "[[hooks.Stop]]",
+    "[[hooks.Stop.hooks]]",
+    'type = "command"',
+    `command = ${JSON.stringify(`node ${launcherPath}`)}`,
+    "timeout = 30",
+    CODEX_HOOK_END,
+  ].join("\n");
+  return `${text ? `${text}\n\n` : ""}${block}\n`;
+}
+
+function removeCodexHookBlock(config: string): string {
+  const pattern = new RegExp(
+    `${escapeRegExp(CODEX_HOOK_START)}[\\s\\S]*?${escapeRegExp(CODEX_HOOK_END)}\\n?`,
+    "g",
+  );
+  return config.replace(pattern, "");
+}
+
+function ensureCodexHooksFeature(config: string): string {
+  const featuresMatch = /^\[features\]\s*$/m.exec(config);
+  if (!featuresMatch) {
+    return `${config.trimEnd()}${config.trimEnd() ? "\n\n" : ""}[features]\nhooks = true\n`;
+  }
+
+  const start = featuresMatch.index;
+  const afterHeader = start + featuresMatch[0].length;
+  const nextTableRel = config.slice(afterHeader).search(/^\[/m);
+  const end = nextTableRel === -1 ? config.length : afterHeader + nextTableRel;
+  const table = config.slice(start, end);
+  const nextTable = config.slice(end);
+  const updatedTable = /^hooks\s*=/m.test(table)
+    ? table.replace(/^hooks\s*=.*$/m, "hooks = true")
+    : table.replace(/^\[features\]\s*$/m, "[features]\nhooks = true");
+  return `${config.slice(0, start)}${updatedTable}${nextTable}`;
+}
+
+function printCodexCommands(
+  spec: AgentSpec,
+  plan: CodexInstallPlan,
+  isJson: boolean,
+  reason: "print-only" | "no-host-cli" | "install-failed",
+): void {
+  if (isJson) return;
+  const preamble =
+    reason === "no-host-cli"
+      ? `${pc.yellow("⚠")} \`${spec.hostCli}\` not found. ` +
+        "Run these equivalent setup steps yourself:"
+      : reason === "install-failed"
+        ? `${pc.yellow("⚠")} Codex hook install failed. Equivalent setup steps:`
+        : `Equivalent setup steps for the ${spec.label} plugin:`;
+  process.stderr.write(`\n${preamble}\n\n`);
+  for (const cmd of plan.commands) {
+    process.stderr.write(`  ${cmd}\n`);
+  }
+  process.stderr.write("\n");
+}
+
+function hostCliExists(hostCli: string): boolean {
+  try {
+    const r = spawnSync(hostCli, ["--version"], { encoding: "utf-8" });
+    return !r.error && (r.status === 0 || r.status === null);
+  } catch {
+    return false;
+  }
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'"'"'`)}'`;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/lmnr-cli/src/commands/plugin/index.ts
+++ b/packages/lmnr-cli/src/commands/plugin/index.ts
@@ -1,5 +1,5 @@
-import { spawn, spawnSync } from "node:child_process";
-import { mkdirSync, writeFileSync } from "node:fs";
+import { spawn, spawnSync, type StdioOptions } from "node:child_process";
+import { chmodSync, mkdirSync, writeFileSync } from "node:fs";
 import { hostname } from "node:os";
 import { join } from "node:path";
 
@@ -84,7 +84,8 @@ export interface PluginAddOptions {
   projectId?: string;
   printOnly?: boolean;
   json?: boolean;
-  noBrowser?: boolean;
+  /** Set by commander's `--no-browser`; false suppresses the device-flow open. */
+  browser?: boolean;
   frontendUrl?: string;
   baseUrl?: string;
 }
@@ -102,7 +103,9 @@ interface PluginAddResult {
   installed: boolean;
   /** The `<cli> plugin ...` commands, as copy-pasteable strings. */
   commands: string[];
-  restartRequired: boolean;
+  /** Coded error when install failed (JSON still emits the full result so a
+   *  caller can recover the key + commands); absent on success. */
+  error?: string;
 }
 
 /**
@@ -150,7 +153,7 @@ export const handlePluginAdd = async (agent: string, options: PluginAddOptions):
   if (!creds) {
     let login;
     try {
-      login = await handleLogin({ frontendUrl, noBrowser: options.noBrowser });
+      login = await handleLogin({ frontendUrl, noBrowser: options.browser === false });
     } catch (err) {
       emitError(isJson, "login_failed", errorMessage(err));
       process.exit(EXIT_LOGIN_FAILED);
@@ -208,24 +211,9 @@ export const handlePluginAdd = async (agent: string, options: PluginAddOptions):
   const commands = hostCommands.map((c) => renderCommand(spec.hostCli, c.argv));
   const canRun = !options.printOnly && hostCliHasPlugins(spec.hostCli);
 
-  let installed = false;
-  if (canRun) {
-    installed = await runInstall(spec, hostCommands, isJson);
-    if (!installed) {
-      printCommands(spec, hostCommands, isJson, "install-failed");
-      emitError(
-        isJson,
-        "install_failed",
-        `A \`${spec.hostCli} plugin\` command failed; commands printed above.`,
-      );
-      process.exit(EXIT_INSTALL_FAILED);
-    }
-  } else {
-    printCommands(spec, hostCommands, isJson, options.printOnly ? "print-only" : "no-host-cli");
-  }
-
-  // --- 6. Summary ----------------------------------------------------------
-  const result: PluginAddResult = {
+  // Shared by the success summary and the JSON failure path, so a caller always
+  // gets the minted key + commands regardless of outcome.
+  const makeResult = (didInstall: boolean, error?: string): PluginAddResult => ({
     agent,
     projectId: project.id,
     projectName: project.name || null,
@@ -233,10 +221,34 @@ export const handlePluginAdd = async (agent: string, options: PluginAddOptions):
     apiKey: key.apiKey,
     apiKeyId: key.apiKeyId ?? null,
     configPath,
-    installed,
+    installed: didInstall,
     commands,
-    restartRequired: installed,
-  };
+    ...(error ? { error } : {}),
+  });
+
+  let installed = false;
+  if (canRun) {
+    installed = await runInstall(spec, hostCommands, isJson);
+    if (!installed) {
+      if (isJson) {
+        // Key is already minted/on disk — emit the full result so a caller can recover it.
+        process.stdout.write(JSON.stringify(makeResult(false, "install_failed")) + "\n");
+      } else {
+        printCommands(spec, hostCommands, false, "install-failed");
+        emitError(
+          false,
+          "install_failed",
+          `A \`${spec.hostCli} plugin\` command failed; commands printed above.`,
+        );
+      }
+      process.exit(EXIT_INSTALL_FAILED);
+    }
+  } else {
+    printCommands(spec, hostCommands, isJson, options.printOnly ? "print-only" : "no-host-cli");
+  }
+
+  // --- 6. Summary ----------------------------------------------------------
+  const result = makeResult(installed);
 
   if (isJson) {
     process.stdout.write(JSON.stringify(result) + "\n");
@@ -346,6 +358,8 @@ export const writeAgentConfig = (spec: AgentSpec, apiKey: string, baseUrl: strin
   const filePath = join(dir, spec.configFile);
   const body = JSON.stringify({ projectApiKey: apiKey, baseUrl }, null, 2) + "\n";
   writeFileSync(filePath, body, { mode: 0o600 });
+  // `mode` only applies on create; chmod so a re-run can't leave an existing file looser.
+  chmodSync(filePath, 0o600);
   return filePath;
 };
 
@@ -404,7 +418,7 @@ const runInstall = async (
     if (!isJson) {
       process.stderr.write(`${pc.dim(`$ ${renderCommand(spec.hostCli, cmd.argv)}`)}\n`);
     }
-    const code = await runChild(spec.hostCli, cmd.argv);
+    const code = await runChild(spec.hostCli, cmd.argv, isJson);
     if (code !== 0) {
       if (cmd.lenient) {
         if (!isJson) {
@@ -421,9 +435,12 @@ const runInstall = async (
   return true;
 };
 
-const runChild = (cmd: string, argv: string[]): Promise<number> =>
+// In --json mode the child's stdout goes to our stderr (fd 2) so its chatter
+// can't pollute the single JSON line we print on stdout.
+const runChild = (cmd: string, argv: string[], isJson: boolean): Promise<number> =>
   new Promise((resolve) => {
-    const child = spawn(cmd, argv, { stdio: "inherit" });
+    const stdio: StdioOptions = isJson ? ["inherit", 2, "inherit"] : "inherit";
+    const child = spawn(cmd, argv, { stdio });
     child.on("error", () => resolve(-1));
     child.on("close", (code) => resolve(code ?? -1));
   });

--- a/packages/lmnr-cli/src/commands/plugin/index.ts
+++ b/packages/lmnr-cli/src/commands/plugin/index.ts
@@ -1,10 +1,12 @@
-import { spawn, spawnSync, type StdioOptions } from "node:child_process";
+import { type StdioOptions } from "node:child_process";
 import { chmodSync, mkdirSync, writeFileSync } from "node:fs";
 import { hostname } from "node:os";
 import { join } from "node:path";
 
 import { type CliProject } from "@lmnr-ai/client";
 import { errorMessage } from "@lmnr-ai/types";
+// cross-spawn: resolves Windows .cmd/.ps1 shims that node:child_process can't run by bare name.
+import spawn from "cross-spawn";
 
 import { version } from "../../../package.json";
 import { mintProjectApiKey } from "../../auth/api-key";
@@ -24,6 +26,7 @@ import { handleLogin } from "../login";
 
 //   8  config_write_failed — minted a key but couldn't write the plugin config file
 //   9  mint_failed        — POST /api/cli/api-key failed
+//   10 list_projects_failed — GET /v1/cli/projects (discovery) failed
 //   13 unsupported_agent  — unknown <agent> argument
 //   14 install_failed     — a host `plugin` command exited non-zero
 const EXIT_NO_ACCESS = 4;
@@ -31,6 +34,7 @@ const EXIT_LOGIN_FAILED = 6;
 const EXIT_NO_PROJECT = 7;
 const EXIT_CONFIG_WRITE_FAILED = 8;
 const EXIT_MINT_FAILED = 9;
+const EXIT_LIST_PROJECTS_FAILED = 10;
 const EXIT_UNSUPPORTED_AGENT = 13;
 const EXIT_INSTALL_FAILED = 14;
 
@@ -290,7 +294,15 @@ const resolveProject = async (
   loginProjectId: string | null,
   isJson: boolean,
 ): Promise<CliProject> => {
-  const projects = await listProjects(creds, baseUrl);
+  // Mirror setup: a discovery failure gets the coded envelope + exit, not a bare
+  // main().catch stderr line (which --json callers can't parse).
+  let projects: CliProject[];
+  try {
+    projects = await listProjects(creds, baseUrl);
+  } catch (err) {
+    emitError(isJson, "list_projects_failed", errorMessage(err));
+    process.exit(EXIT_LIST_PROJECTS_FAILED);
+  }
 
   if (options.projectId) {
     const match = projects.find((p) => p.id === options.projectId);
@@ -397,7 +409,7 @@ export const buildInstallCommands = (spec: AgentSpec): HostCommand[] => [
  */
 export const hostCliHasPlugins = (hostCli: string): boolean => {
   try {
-    const r = spawnSync(hostCli, ["plugin", "--help"], { encoding: "utf-8" });
+    const r = spawn.sync(hostCli, ["plugin", "--help"], { encoding: "utf-8" });
     return !r.error && r.status === 0;
   } catch {
     return false;

--- a/packages/lmnr-cli/src/commands/setup/index.ts
+++ b/packages/lmnr-cli/src/commands/setup/index.ts
@@ -2,6 +2,7 @@ import { hostname } from "node:os";
 import { relative } from "node:path";
 
 import { type CliProject, LaminarClient, type ProjectKeyProbe } from "@lmnr-ai/client";
+import { errorMessage } from "@lmnr-ai/types";
 
 import { version } from "../../../package.json";
 import { type MintedApiKey, mintProjectApiKey } from "../../auth/api-key";
@@ -123,7 +124,7 @@ export async function handleSetup(options: SetupOptions): Promise<void> {
     try {
       login = await handleLogin({ frontendUrl, noBrowser: options.browser === false });
     } catch (err) {
-      emitError(isJson, "login_failed", describeError(err));
+      emitError(isJson, "login_failed", errorMessage(err));
       process.exit(EXIT_LOGIN_FAILED);
     }
     creds = await safeReadCredentials();
@@ -231,7 +232,7 @@ export async function handleSetup(options: SetupOptions): Promise<void> {
     try {
       keyMeta = await mintProjectApiKey(issuer, creds.sessionToken, link.projectId, hostname());
     } catch (err) {
-      emitError(isJson, "setup_key_failed", describeError(err));
+      emitError(isJson, "setup_key_failed", errorMessage(err));
       process.exit(EXIT_SETUP_KEY_FAILED);
     }
     apiKey = keyMeta.apiKey;
@@ -263,7 +264,7 @@ export async function handleSetup(options: SetupOptions): Promise<void> {
         }
       } catch (err) {
         process.stderr.write(
-          `\n${pc.red("ERROR")}: failed to write ${target}: ${describeError(err)}\n` +
+          `\n${pc.red("ERROR")}: failed to write ${target}: ${errorMessage(err)}\n` +
           pc.dim("Your API key (set it manually):") +
           `\n  LMNR_PROJECT_API_KEY=${apiKey}\n\n`,
         );
@@ -273,7 +274,7 @@ export async function handleSetup(options: SetupOptions): Promise<void> {
               error: "env_write_failed",
               apiKey,
               projectId: link.projectId,
-              message: describeError(err),
+              message: errorMessage(err),
             }) + "\n",
           );
         }
@@ -305,7 +306,7 @@ export async function handleSetup(options: SetupOptions): Promise<void> {
   } catch (err) {
     if (!isJson) {
       process.stderr.write(
-        `${pc.yellow("Warning")}: could not install Laminar skill (${describeError(err)}).\n`,
+        `${pc.yellow("Warning")}: could not install Laminar skill (${errorMessage(err)}).\n`,
       );
     }
   }
@@ -366,7 +367,7 @@ async function resolveProjectViaCli(
   try {
     projects = await listProjects(creds, userBaseUrl);
   } catch (err) {
-    emitError(isJson, "list_projects_failed", describeError(err));
+    emitError(isJson, "list_projects_failed", errorMessage(err));
     process.exit(EXIT_LIST_PROJECTS_FAILED);
   }
 
@@ -393,7 +394,7 @@ async function resolveProjectViaCli(
         noBrowser: options.browser === false,
       });
     } catch (err) {
-      emitError(isJson, "login_failed", describeError(err));
+      emitError(isJson, "login_failed", errorMessage(err));
       process.exit(EXIT_LOGIN_FAILED);
     }
     if (!login.projectId) {
@@ -481,7 +482,7 @@ async function writeLink(
   } catch (err) {
     if (!isJson) {
       process.stderr.write(
-        `${pc.yellow("Warning")}: could not write .lmnr/project.json (${describeError(err)}). ` +
+        `${pc.yellow("Warning")}: could not write .lmnr/project.json (${errorMessage(err)}). ` +
         `CLI commands will need --project-id ${projectId}.\n`,
       );
     }
@@ -511,7 +512,7 @@ async function assertAccess(
     // Discovery FAILED (network/5xx) — we couldn't determine access. Report it
     // as a transient list failure (exit 10), NOT no_access (exit 4): automation
     // must be able to retry instead of concluding the user lacks access.
-    emitError(isJson, "list_projects_failed", describeError(err));
+    emitError(isJson, "list_projects_failed", errorMessage(err));
     process.exit(EXIT_LIST_PROJECTS_FAILED);
   }
   if (!projects.some((p) => p.id === link.projectId)) {
@@ -583,9 +584,4 @@ async function probeProjectKey(
 
 function trimSlash(url: string): string {
   return url.replace(/\/+$/, "");
-}
-
-function describeError(err: unknown): string {
-  if (err instanceof Error) return err.message;
-  return String(err);
 }

--- a/packages/lmnr-cli/src/commands/setup/index.ts
+++ b/packages/lmnr-cli/src/commands/setup/index.ts
@@ -21,6 +21,7 @@ import {
   readLocalProjectFile,
   writeLocalProjectFile,
 } from "../../utils/local-project-file";
+import { emitError } from "../../utils/output";
 import { listProjects, promptProjectChoice } from "../../utils/projects";
 import { handleLogin } from "../login";
 
@@ -49,7 +50,8 @@ const EXIT_KEY_MISMATCH = 12;
 export interface SetupOptions {
   writeEnv?: boolean;
   json?: boolean;
-  noBrowser?: boolean;
+  /** Set by commander's `--no-browser`; false suppresses the device-flow open. */
+  browser?: boolean;
   frontendUrl?: string;
   baseUrl?: string;
   /**
@@ -118,7 +120,7 @@ export async function handleSetup(options: SetupOptions): Promise<void> {
     // the device-token metadata (parseProjectFromMetadata).
     let login;
     try {
-      login = await handleLogin({ frontendUrl, noBrowser: options.noBrowser });
+      login = await handleLogin({ frontendUrl, noBrowser: options.browser === false });
     } catch (err) {
       emitError(isJson, "login_failed", describeError(err));
       process.exit(EXIT_LOGIN_FAILED);
@@ -387,7 +389,7 @@ async function resolveProjectViaCli(
     try {
       login = await handleLogin({
         frontendUrl: issuer,
-        noBrowser: options.noBrowser,
+        noBrowser: options.browser === false,
       });
     } catch (err) {
       emitError(isJson, "login_failed", describeError(err));
@@ -592,12 +594,4 @@ function trimSlash(url: string): string {
 function describeError(err: unknown): string {
   if (err instanceof Error) return err.message;
   return String(err);
-}
-
-function emitError(json: boolean, code: string, detail: string): void {
-  if (json) {
-    process.stdout.write(JSON.stringify({ error: code, detail }) + "\n");
-  } else {
-    process.stderr.write(`\n${pc.red(`ERROR (${code})`)}: ${detail}\n`);
-  }
 }

--- a/packages/lmnr-cli/src/commands/setup/index.ts
+++ b/packages/lmnr-cli/src/commands/setup/index.ts
@@ -1,11 +1,11 @@
 import { hostname } from "node:os";
 import { relative } from "node:path";
-import { createInterface } from "node:readline/promises";
 
 import { type CliProject, LaminarClient, type ProjectKeyProbe } from "@lmnr-ai/client";
 
 import { version } from "../../../package.json";
-import { type Credentials, readCredentials } from "../../auth/credentials";
+import { type MintedApiKey, mintProjectApiKey } from "../../auth/api-key";
+import { type Credentials, safeReadCredentials } from "../../auth/credentials";
 import { envHttpPort, refreshIfNeeded } from "../../auth/resolve";
 import { orange, pc, pcOut } from "../../utils/colors";
 import {
@@ -21,6 +21,7 @@ import {
   readLocalProjectFile,
   writeLocalProjectFile,
 } from "../../utils/local-project-file";
+import { listProjects, promptProjectChoice } from "../../utils/projects";
 import { handleLogin } from "../login";
 
 const DEFAULT_FRONTEND_URL = "https://laminar.sh";
@@ -57,15 +58,6 @@ export interface SetupOptions {
    * user's accessible projects before linking.
    */
   projectId?: string;
-}
-
-interface SetupKeyResponse {
-  apiKey: string;
-  apiKeyId: string;
-  projectId: string;
-  projectName: string;
-  workspaceId: string;
-  workspaceName: string;
 }
 
 export interface SetupResult {
@@ -146,7 +138,7 @@ export async function handleSetup(options: SetupOptions): Promise<void> {
       await assertAccess(creds, userBaseUrl, link, existingKey, isJson);
     } else if (login.projectId) {
       // Browser-selected (or just-created) project. Trust it and write the link.
-      link = await writeLink(issuer, userBaseUrl, login.projectId, isJson);
+      link = await writeLink(userBaseUrl, login.projectId, isJson);
     } else {
       // Defensive: fall back to the CLI picker if the browser didn't attach a
       // project via metadata.
@@ -186,7 +178,7 @@ export async function handleSetup(options: SetupOptions): Promise<void> {
 
   let apiKey: string | null = null;
   let envPath: string | null = null;
-  let keyMeta: SetupKeyResponse | null = null;
+  let keyMeta: MintedApiKey | null = null;
 
   let needMint = true;
   if (existingKey) {
@@ -234,7 +226,7 @@ export async function handleSetup(options: SetupOptions): Promise<void> {
 
   if (needMint) {
     try {
-      keyMeta = await mintSetupKey(issuer, creds.sessionToken, link.projectId);
+      keyMeta = await mintProjectApiKey(issuer, creds.sessionToken, link.projectId, hostname());
     } catch (err) {
       emitError(isJson, "setup_key_failed", describeError(err));
       process.exit(EXIT_SETUP_KEY_FAILED);
@@ -409,7 +401,7 @@ async function resolveProjectViaCli(
       );
       process.exit(EXIT_NO_PROJECT);
     }
-    return writeLink(issuer, userBaseUrl, login.projectId, isJson);
+    return writeLink(userBaseUrl, login.projectId, isJson);
   }
 
   let chosen: CliProject;
@@ -438,7 +430,7 @@ async function resolveProjectViaCli(
       );
       process.exit(EXIT_NO_PROJECT);
     }
-    chosen = await promptProjectChoice(projects);
+    chosen = await promptProjectChoice(projects, "\nMultiple projects available. Choose one:\n");
   }
 
   const linkPath = await writeLocalProjectFile({
@@ -458,7 +450,6 @@ async function resolveProjectViaCli(
 
 /** Write `.lmnr/project.json`, enriching display details from listProjects when possible. */
 async function writeLink(
-  issuer: string,
   userBaseUrl: string,
   projectId: string,
   isJson: boolean,
@@ -566,21 +557,6 @@ function buildNoAccessDetail(
   );
 }
 
-/** List the projects the user can access (user-JWT-authed discovery). */
-async function listProjects(creds: Credentials, baseUrl: string): Promise<CliProject[]> {
-  const updated = await refreshIfNeeded(creds);
-  // Discovery client: CliResource hits /v1/cli/projects with the bare bearer,
-  // no project id needed (it overrides BaseResource's headers/prefix).
-  const client = new LaminarClient({
-    baseUrl,
-    // setup has no --port flag, so honor LMNR_HTTP_PORT for local self-host
-    // (baseUrl carries no port by convention). Cloud falls back to 443.
-    port: envHttpPort(),
-    auth: { type: "userToken", token: updated.accessToken, projectId: "" },
-  });
-  return client.cli.listProjects();
-}
-
 /**
  * Resolve which project an existing project API key belongs to, via the
  * user-token CLI endpoint (`POST /v1/cli/project`, key in body). By setup time
@@ -600,57 +576,6 @@ async function probeProjectKey(
     auth: { type: "userToken", token: updated.accessToken, projectId: "" },
   });
   return client.cli.resolveProjectByApiKey(apiKey);
-}
-
-async function safeReadCredentials(): Promise<Credentials | null> {
-  try {
-    return await readCredentials();
-  } catch {
-    return null;
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Key minting
-// ---------------------------------------------------------------------------
-
-/** POST /api/cli/api-key with the session bearer for an explicit project. */
-async function mintSetupKey(
-  issuer: string,
-  sessionToken: string,
-  projectId: string,
-): Promise<SetupKeyResponse> {
-  const url = `${trimSlash(issuer)}/api/cli/api-key`;
-  const res = await fetch(url, {
-    method: "POST",
-    headers: { authorization: `Bearer ${sessionToken}`, "content-type": "application/json" },
-    body: JSON.stringify({ deviceName: hostname(), projectId }),
-  });
-  if (res.ok) {
-    return (await res.json()) as SetupKeyResponse;
-  }
-  const body = (await res.json().catch(() => ({}))) as { error?: string };
-  throw new Error(body.error ?? `api-key request failed (${res.status})`);
-}
-
-async function promptProjectChoice(projects: CliProject[]): Promise<CliProject> {
-  process.stderr.write("\nMultiple projects available. Choose one:\n");
-  projects.forEach((p, i) => {
-    process.stderr.write(`  ${i + 1}) ${p.workspaceName} / ${p.name}\n`);
-  });
-  const rl = createInterface({ input: process.stdin, output: process.stderr });
-  try {
-    while (true) {
-      const answer = (await rl.question(`Select [1-${projects.length}]: `)).trim();
-      const idx = Number.parseInt(answer, 10);
-      if (Number.isInteger(idx) && idx >= 1 && idx <= projects.length) {
-        return projects[idx - 1];
-      }
-      process.stderr.write(`${pc.red("Invalid selection.")}\n`);
-    }
-  } finally {
-    rl.close();
-  }
 }
 
 function pick(...candidates: (string | undefined)[]): string {

--- a/packages/lmnr-cli/src/commands/setup/index.ts
+++ b/packages/lmnr-cli/src/commands/setup/index.ts
@@ -23,6 +23,7 @@ import {
 } from "../../utils/local-project-file";
 import { emitError } from "../../utils/output";
 import { listProjects, promptProjectChoice } from "../../utils/projects";
+import { firstNonEmpty } from "../../utils/text";
 import { handleLogin } from "../login";
 
 const DEFAULT_FRONTEND_URL = "https://laminar.sh";
@@ -93,12 +94,12 @@ export interface SetupResult {
  */
 export async function handleSetup(options: SetupOptions): Promise<void> {
   const writeEnv = options.writeEnv !== false;
-  const frontendUrl = pick(
+  const frontendUrl = firstNonEmpty(
     options.frontendUrl,
     process.env.LMNR_FRONTEND_URL,
     DEFAULT_FRONTEND_URL,
   );
-  const baseUrl = pick(options.baseUrl, process.env.LMNR_BASE_URL, DEFAULT_BASE_URL);
+  const baseUrl = firstNonEmpty(options.baseUrl, process.env.LMNR_BASE_URL, DEFAULT_BASE_URL);
   const isJson = options.json === true;
 
   if (!isJson) {
@@ -578,13 +579,6 @@ async function probeProjectKey(
     auth: { type: "userToken", token: updated.accessToken, projectId: "" },
   });
   return client.cli.resolveProjectByApiKey(apiKey);
-}
-
-function pick(...candidates: (string | undefined)[]): string {
-  for (const c of candidates) {
-    if (c && c.length > 0) return c;
-  }
-  return "";
 }
 
 function trimSlash(url: string): string {

--- a/packages/lmnr-cli/src/index.ts
+++ b/packages/lmnr-cli/src/index.ts
@@ -379,12 +379,13 @@ Examples:
       "after",
       `
 Global, directory-independent setup: it does NOT touch .lmnr/project.json or
-.env. The project API key is stored in the host agent's own config/launcher,
-named after the plugin so you can find and revoke it in the dashboard. Restart
-the agent after install to activate it.
+.env. The minted key is named after the plugin (find/revoke it in the dashboard)
+and written to ~/.config/lmnr/<agent>-plugin.json, where the plugin reads it. The
+plugin is installed via the agent's native plugin marketplace. Restart the agent
+after install to activate it.
 
-When the host CLI isn't found (or is too old for native plugin config), or with
---print-only, equivalent setup commands are printed for you to run by hand.
+When the host CLI isn't found (or has no plugin support), or with --print-only,
+the install commands are printed for you to run by hand.
 
 Examples:
   $ lmnr-cli plugin add claude-code

--- a/packages/lmnr-cli/src/index.ts
+++ b/packages/lmnr-cli/src/index.ts
@@ -356,7 +356,7 @@ Examples:
     .description(
       "Log in, pick a project, mint a key, and install the Laminar plugin for a coding agent",
     )
-    .argument("<agent>", "Which agent to set up (currently: claude-code)")
+    .argument("<agent>", "Which agent to set up (currently: claude-code, codex)")
     .option(
       "--project-id <id>",
       "Project to send this agent's traces to (skips the interactive picker)",
@@ -379,16 +379,17 @@ Examples:
       "after",
       `
 Global, directory-independent setup: it does NOT touch .lmnr/project.json or
-.env. The project API key is stored in the host CLI's own config (via
-\`claude plugin install --config\`), named after the plugin so you can find and
-revoke it in the dashboard. Restart the agent after install to activate it.
+.env. The project API key is stored in the host agent's own config/launcher,
+named after the plugin so you can find and revoke it in the dashboard. Restart
+the agent after install to activate it.
 
-When \`claude\` isn't found (or is too old for --config), or with --print-only,
-the exact commands are printed for you to run by hand.
+When the host CLI isn't found (or is too old for native plugin config), or with
+--print-only, equivalent setup commands are printed for you to run by hand.
 
 Examples:
   $ lmnr-cli plugin add claude-code
-  $ lmnr-cli plugin add claude-code --project-id <id>
+  $ lmnr-cli plugin add codex
+  $ lmnr-cli plugin add codex --project-id <id>
   $ lmnr-cli plugin add claude-code --print-only
 `,
     );
@@ -579,6 +580,7 @@ Examples:
   lmnr-cli skill add                                       # Install the Laminar agent skill
   lmnr-cli skill update                                    # Update installed Laminar skills
   lmnr-cli plugin add claude-code                          # Install the Claude Code plugin
+  lmnr-cli plugin add codex                                # Install the Codex hook
 
 For more information about the Laminar platfrom:
   Documentation: https://laminar.sh/docs

--- a/packages/lmnr-cli/src/index.ts
+++ b/packages/lmnr-cli/src/index.ts
@@ -21,6 +21,7 @@ import {
 } from "./commands/debug";
 import { handleLogin } from "./commands/login";
 import { handleLogout } from "./commands/logout";
+import { handlePluginAdd } from "./commands/plugin";
 import { handleProjectsList } from "./commands/project";
 import { handleSetup } from "./commands/setup";
 import { handleSkillAdd, handleSkillUpdate } from "./commands/skill";
@@ -346,6 +347,52 @@ Examples:
 `,
     );
 
+  const pluginCmd = program
+    .command("plugin")
+    .description("Set up the Laminar plugin for a coding agent");
+
+  pluginCmd
+    .command("add")
+    .description(
+      "Log in, pick a project, mint a key, and install the Laminar plugin for a coding agent",
+    )
+    .argument("<agent>", "Which agent to set up (currently: claude-code)")
+    .option(
+      "--project-id <id>",
+      "Project to send this agent's traces to (skips the interactive picker)",
+    )
+    .option("--print-only", "Print the install commands instead of running them")
+    .option("--json", "Emit a machine-readable JSON line on stdout")
+    .option("--no-browser", "Do not auto-open the device-flow URL")
+    .option(
+      "--frontend-url <url>",
+      "Frontend URL (issuer). Defaults to LMNR_FRONTEND_URL or https://laminar.sh",
+    )
+    .option(
+      "--base-url <url>",
+      "Base URL for the Laminar API. Defaults to LMNR_BASE_URL or https://api.lmnr.ai",
+    )
+    .action(async (agent: string, options) => {
+      await handlePluginAdd(agent, options);
+    })
+    .addHelpText(
+      "after",
+      `
+Global, directory-independent setup: it does NOT touch .lmnr/project.json or
+.env. The project API key is stored in the host CLI's own config (via
+\`claude plugin install --config\`), named after the plugin so you can find and
+revoke it in the dashboard. Restart the agent after install to activate it.
+
+When \`claude\` isn't found (or is too old for --config), or with --print-only,
+the exact commands are printed for you to run by hand.
+
+Examples:
+  $ lmnr-cli plugin add claude-code
+  $ lmnr-cli plugin add claude-code --project-id <id>
+  $ lmnr-cli plugin add claude-code --print-only
+`,
+    );
+
   const debugCmd = program
     .command("debug")
     .description("Operate on debug sessions")
@@ -531,6 +578,7 @@ Examples:
   lmnr-cli debug session summary                           # All blocks in the session, oldest first
   lmnr-cli skill add                                       # Install the Laminar agent skill
   lmnr-cli skill update                                    # Update installed Laminar skills
+  lmnr-cli plugin add claude-code                          # Install the Claude Code plugin
 
 For more information about the Laminar platfrom:
   Documentation: https://laminar.sh/docs

--- a/packages/lmnr-cli/src/index.ts
+++ b/packages/lmnr-cli/src/index.ts
@@ -581,7 +581,7 @@ Examples:
   lmnr-cli skill add                                       # Install the Laminar agent skill
   lmnr-cli skill update                                    # Update installed Laminar skills
   lmnr-cli plugin add claude-code                          # Install the Claude Code plugin
-  lmnr-cli plugin add codex                                # Install the Codex hook
+  lmnr-cli plugin add codex                                # Install the Codex plugin
 
 For more information about the Laminar platfrom:
   Documentation: https://laminar.sh/docs

--- a/packages/lmnr-cli/src/utils/install-skill.ts
+++ b/packages/lmnr-cli/src/utils/install-skill.ts
@@ -2,6 +2,8 @@ import { access, cp, mkdir, mkdtemp, readdir, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, relative } from "node:path";
 
+import { errorMessage } from "@lmnr-ai/types";
+
 import { downloadSkill } from "../skill/fetch-skill";
 import { SKILL_NAME, skillSource } from "../skill/laminar-skill";
 
@@ -56,7 +58,7 @@ export class SkillInstallError extends Error {
     /** Absolute paths of files written before the failure (may be empty). */
     readonly written: string[],
   ) {
-    super(describeError(cause));
+    super(errorMessage(cause));
     this.name = "SkillInstallError";
   }
 }
@@ -142,7 +144,7 @@ export async function installSkill(
     const written = err instanceof SkillInstallError ? err.written : [];
     process.stderr.write(
       `Warning: could not install the Laminar skill (${skillSource()}): ` +
-      `${describeError(err)}; skipping skill install.\n`,
+      `${errorMessage(err)}; skipping skill install.\n`,
     );
     if (written.length > 0) {
       process.stderr.write(
@@ -161,8 +163,4 @@ async function dirExists(path: string): Promise<boolean> {
   } catch {
     return false;
   }
-}
-
-function describeError(err: unknown): string {
-  return err instanceof Error ? err.message : String(err);
 }

--- a/packages/lmnr-cli/src/utils/output.ts
+++ b/packages/lmnr-cli/src/utils/output.ts
@@ -16,13 +16,13 @@ export function outputJson(data: unknown): void {
  * envelope for the interactive device-flow commands (`setup`, `plugin add`),
  * which manage their own exit codes rather than using the with-client wrapper.
  */
-export function emitError(json: boolean, code: string, detail: string): void {
+export const emitError = (json: boolean, code: string, detail: string): void => {
   if (json) {
     process.stdout.write(JSON.stringify({ error: code, detail }) + '\n');
   } else {
     process.stderr.write(`\n${pc.red(`ERROR (${code})`)}: ${detail}\n`);
   }
-}
+};
 
 /**
  * Write a JSON error to stdout and exit with code 1.

--- a/packages/lmnr-cli/src/utils/output.ts
+++ b/packages/lmnr-cli/src/utils/output.ts
@@ -1,11 +1,27 @@
 import { errorMessage } from '@lmnr-ai/types';
 
+import { pc } from './colors';
+
 /**
  * Write structured JSON to stdout. Use this for machine-readable output
  * when --json is set.
  */
 export function outputJson(data: unknown): void {
   console.log(JSON.stringify(data));
+}
+
+/**
+ * Emit a coded error without exiting: `{error, detail}` JSON on stdout in --json
+ * mode, otherwise a colored `ERROR (code): detail` line on stderr. Shared error
+ * envelope for the interactive device-flow commands (`setup`, `plugin add`),
+ * which manage their own exit codes rather than using the with-client wrapper.
+ */
+export function emitError(json: boolean, code: string, detail: string): void {
+  if (json) {
+    process.stdout.write(JSON.stringify({ error: code, detail }) + '\n');
+  } else {
+    process.stderr.write(`\n${pc.red(`ERROR (${code})`)}: ${detail}\n`);
+  }
 }
 
 /**

--- a/packages/lmnr-cli/src/utils/projects.ts
+++ b/packages/lmnr-cli/src/utils/projects.ts
@@ -1,0 +1,51 @@
+import { createInterface } from "node:readline/promises";
+
+import { type CliProject, LaminarClient } from "@lmnr-ai/client";
+
+import type { Credentials } from "../auth/credentials";
+import { envHttpPort, refreshIfNeeded } from "../auth/resolve";
+import { pc } from "./colors";
+
+/**
+ * List the projects the logged-in user can access (user-JWT discovery, no
+ * project scope). Shared by every command that resolves a project before one is
+ * selected (`setup`, `plugin add`).
+ */
+export const listProjects = async (creds: Credentials, baseUrl: string): Promise<CliProject[]> => {
+  const updated = await refreshIfNeeded(creds);
+  const client = new LaminarClient({
+    baseUrl,
+    // setup/plugin have no --port flag; honor LMNR_HTTP_PORT for local self-host.
+    port: envHttpPort(),
+    auth: { type: "userToken", token: updated.accessToken, projectId: "" },
+  });
+  return client.cli.listProjects();
+};
+
+/**
+ * Interactive numbered project picker on stderr (stdout is the --json contract).
+ * `intro` is the prompt line so callers can tailor it (e.g. `setup` vs the
+ * dedicated-project nudge in `plugin add`).
+ */
+export const promptProjectChoice = async (
+  projects: CliProject[],
+  intro: string,
+): Promise<CliProject> => {
+  process.stderr.write(intro);
+  projects.forEach((p, i) => {
+    process.stderr.write(`  ${i + 1}) ${p.workspaceName} / ${p.name}\n`);
+  });
+  const rl = createInterface({ input: process.stdin, output: process.stderr });
+  try {
+    while (true) {
+      const answer = (await rl.question(`Select [1-${projects.length}]: `)).trim();
+      const idx = Number.parseInt(answer, 10);
+      if (Number.isInteger(idx) && idx >= 1 && idx <= projects.length) {
+        return projects[idx - 1];
+      }
+      process.stderr.write(`${pc.red("Invalid selection.")}\n`);
+    }
+  } finally {
+    rl.close();
+  }
+};

--- a/packages/lmnr-cli/src/utils/text.ts
+++ b/packages/lmnr-cli/src/utils/text.ts
@@ -1,0 +1,10 @@
+/** First non-empty string among the candidates, or "" if none. */
+export const firstNonEmpty = (...candidates: (string | undefined)[]): string => {
+  for (const c of candidates) {
+    if (c && c.length > 0) return c;
+  }
+  return "";
+};
+
+/** Strip trailing slashes from a URL. */
+export const trimTrailingSlashes = (url: string): string => url.replace(/\/+$/, "");

--- a/packages/lmnr-cli/src/utils/text.ts
+++ b/packages/lmnr-cli/src/utils/text.ts
@@ -5,6 +5,3 @@ export const firstNonEmpty = (...candidates: (string | undefined)[]): string => 
   }
   return "";
 };
-
-/** Strip trailing slashes from a URL. */
-export const trimTrailingSlashes = (url: string): string => url.replace(/\/+$/, "");

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -198,7 +198,7 @@ importers:
         version: '@ai-sdk/provider@2.0.3'
       '@ai-sdk/provider-v3':
         specifier: npm:@ai-sdk/provider@ai-v6
-        version: '@ai-sdk/provider@3.0.13'
+        version: '@ai-sdk/provider@3.0.14'
       '@aws-sdk/client-bedrock-runtime':
         specifier: ^3.1057.0
         version: 3.1057.0
@@ -249,10 +249,10 @@ importers:
         version: 7.0.17(zod@4.4.3)
       ai-v5:
         specifier: npm:ai@ai-v5
-        version: ai@5.0.210(zod@4.4.3)
+        version: ai@5.0.213(zod@4.4.3)
       ai-v6:
         specifier: npm:ai@ai-v6
-        version: ai@6.0.221(zod@4.4.3)
+        version: ai@6.0.226(zod@4.4.3)
       chromadb:
         specifier: ^3.0.10
         version: 3.4.3
@@ -286,6 +286,9 @@ importers:
       commander:
         specifier: ^14.0.2
         version: 14.0.3
+      cross-spawn:
+        specifier: ^7.0.6
+        version: 7.0.6
       csv-parser:
         specifier: ^3.2.0
         version: 3.2.1
@@ -314,6 +317,9 @@ importers:
       '@lmnr-ai/types':
         specifier: workspace:*
         version: link:../types
+      '@types/cross-spawn':
+        specifier: ^6.0.6
+        version: 6.0.6
       vitest:
         specifier: ^4.1.9
         version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0))
@@ -326,14 +332,14 @@ importers:
 
 packages:
 
-  '@ai-sdk/gateway@2.0.109':
-    resolution: {integrity: sha512-jvTQnfmcKD/bc8fbp2bbaO8QvqSPaj7lv5rj9kj/GLHUfTGpjQV3pH7GdO4fDi1SX2PdHpPQY0y6rxJ05Xo5cg==}
+  '@ai-sdk/gateway@2.0.112':
+    resolution: {integrity: sha512-M58LfWXTTmwDqYJNDxGfzlAyXDAg8iV2gPq2ZvIGlIZzJ9oTA7yX85lVFEZ0Owc/Gm+j/sVUczu0tnvc575jpg==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/gateway@3.0.145':
-    resolution: {integrity: sha512-cqSQ+I0Bjj2W9g1oFyE1O1mSowsWXb+U1wK9vtg5kRQqB95iWVIKbtdr14gGf46cueJSiBlKfPTT24gDDVuFmw==}
+  '@ai-sdk/gateway@3.0.150':
+    resolution: {integrity: sha512-mA5iaIf7mja+D+CGagS/PjLgJiujN5/0JcNVm1u5a62ZlxD2UVMOBA0oreFGTmGcU5nY/J6njijVI6s+wGCb+g==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -350,14 +356,14 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/provider-utils@3.0.28':
-    resolution: {integrity: sha512-bXlX1WX7E50a2N+AJW+1a/x63m52aPhm+6xYe5THxWrx9vW9NR7E2Ay+1G1ndlCdMdYKo2Fnsd7kBhuyQPaphw==}
+  '@ai-sdk/provider-utils@3.0.29':
+    resolution: {integrity: sha512-4oNFrqBcy24KNclF1tWp/7ks+kSkDF6VZ1ccIfQoFVIgAAaoNH8bOTbOadVa4Dk70ghsh32caSHYWlzBI8F10g==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/provider-utils@4.0.37':
-    resolution: {integrity: sha512-VG4tpVXCuzm21U9xjg05BCMZnjZOazC72+MxBkLAa7hCKsnqNt542GYWUUqwmHSczJwgbSXN8UvaNgSerUaKdw==}
+  '@ai-sdk/provider-utils@4.0.39':
+    resolution: {integrity: sha512-XPR6o7561RYUkfYlLYouWsvm6Gv2tYIQy5pttGRkvML98u138ClPThn5yiQg5rMQutTtZLB+GUC8qFFCzDKQQQ==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -372,8 +378,8 @@ packages:
     resolution: {integrity: sha512-h88OPkavHTiN9tMn2l5awAznGB0lXzjcLhgR1/rvjB2zlLprsNxbM2tt6OJsHUxduLC3klq0/eqaSf6fX5XVww==}
     engines: {node: '>=18'}
 
-  '@ai-sdk/provider@3.0.13':
-    resolution: {integrity: sha512-ZPtVYt5QIJzOta1kdUiDuCx4HhFkvNPv/rvmZ2b1iXwybYjJsCnNYR4PAw4kW7rgVfDARvHXcU64efWuqNp6bw==}
+  '@ai-sdk/provider@3.0.14':
+    resolution: {integrity: sha512-5X1k57JBJ4H7H1QjX7CnJYAB1I19r/trVZTMcSms7/kLNZ8RaU4Nt2agcwZzv82Hfx6Q7/TOLU7agAKeFfc8cA==}
     engines: {node: '>=18'}
 
   '@ai-sdk/provider@4.0.2':
@@ -1271,84 +1277,72 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-gnu@1.1.1':
     resolution: {integrity: sha512-at2EO4o7D/PJLC4Xik16bU4CcjQE2tSv1LfqMA0TRYQYQihRm3gZeDB8xaX28A9SFedibcAk5DeMCKt4REKG0A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.3':
     resolution: {integrity: sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-arm64-musl@1.1.1':
     resolution: {integrity: sha512-5PUjZx366h9tkJTPJF5eibxOlK3sGoeRiBJLLjjEB5/kLDuhr6qB3LkhqLz1smXNgsX+pBhnbcJBrPE30HznAA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.3':
     resolution: {integrity: sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-ppc64-gnu@1.1.1':
     resolution: {integrity: sha512-1WK84XPeio3tjP1sM/TMXiC0G1i1iq1qGZ71KfNQjEFLU1kwD+Cv5T8nGySg/JUFwLbaScu6ve9DmeXlmqpkFA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.3':
     resolution: {integrity: sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.1.1':
     resolution: {integrity: sha512-1nS1X5z1uMJ369RU25hTpKCFvUwXZp12dIzlzk4S+UxCTcSVGsAE6tzkOSufv/7jnmAtK0ZlrsJxh2fGmsnVSw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.3':
     resolution: {integrity: sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.1.1':
     resolution: {integrity: sha512-NwX/wspnq4vYyMFsqbYvzums3ki/Tk8FZbMzMAovPDp3OfLeYKby/D+9osokadXuYEV3OvpeHlwnr/bG8QMixA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.3':
     resolution: {integrity: sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-x64-musl@1.1.1':
     resolution: {integrity: sha512-+n46LhDrJFQM+229y4oXtVpj1G50U/+XuHMlpnisFTEXhrg9f/YIjp/HymX+PVJjBEr7XHRs3CFLelV464pqwA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.3':
     resolution: {integrity: sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==}
@@ -1519,6 +1513,9 @@ packages:
   '@types/cli-progress@3.11.6':
     resolution: {integrity: sha512-cE3+jb9WRlu+uOSAugewNpITJDt1VF8dHOopPO4IABFc3SXYL5WE/+PTz/FCdZRRfIujiWW3n3aMbv1eIGVRWA==}
 
+  '@types/cross-spawn@6.0.6':
+    resolution: {integrity: sha512-fXRhhUkG4H3TQk5dBhQ7m/JDdSNHKwR2BBia62lhwEIq9xGiQKLxd6LymNhn47SjXhsUEPmxi+PKw2OkW4LLjA==}
+
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
@@ -1672,14 +1669,14 @@ packages:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
 
-  ai@5.0.210:
-    resolution: {integrity: sha512-HAYfzP0vMU3/1GzjQkpJT7/x7BqacIYimAMgm6wXZKjZfOHGv1458hLDqYcC7o9BuAr23sFijvL41MSx9KEnEQ==}
+  ai@5.0.213:
+    resolution: {integrity: sha512-QCPMxXxV/I+nXVYyQru62Izx8cU5UmPDkooJmYy1+kBvhT/hDH/n33th/SAE73A2kRXIUO1cFdvhZ0XCRPdWaw==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  ai@6.0.221:
-    resolution: {integrity: sha512-cB7qJbNTMuD5spdJEo+guejX0rkjhSQpc4PHITNB+iBFBnGYHLUZOM+uSeIkY4mS4sVVKBKm3kSQQoI5cUwU3g==}
+  ai@6.0.226:
+    resolution: {integrity: sha512-OMUrcW9hqwEXuMRowh3fprdUxKCIWCsRg84DUnBmXU9hhAOIw9It754oHDtYEjS/WrzgzUL8tf+J6V5HV+SzuQ==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -1796,14 +1793,12 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   chromadb-js-bindings-linux-x64-gnu@1.3.4:
     resolution: {integrity: sha512-HmTUe7PEIaBngCQ70Yyle81z2wYyg9OMgJYyRUNBYCBp4ED6zTmdaOro41Vs/c/h2UyQeBXFIKNmHDeD2Nr2fw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   chromadb-js-bindings-win32-x64-msvc@1.3.4:
     resolution: {integrity: sha512-punrofQRzKspNMxHmv24qoPeRycV2T3KfedekGV4lOuPPG14i6qggS4x/OWLSAK7ozPfBbrzCejvCa5wfvujhQ==}
@@ -2462,28 +2457,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -3299,17 +3290,17 @@ packages:
 
 snapshots:
 
-  '@ai-sdk/gateway@2.0.109(zod@4.4.3)':
+  '@ai-sdk/gateway@2.0.112(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 2.0.3
-      '@ai-sdk/provider-utils': 3.0.28(zod@4.4.3)
+      '@ai-sdk/provider-utils': 3.0.29(zod@4.4.3)
       '@vercel/oidc': 3.1.0
       zod: 4.4.3
 
-  '@ai-sdk/gateway@3.0.145(zod@4.4.3)':
+  '@ai-sdk/gateway@3.0.150(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/provider': 3.0.13
-      '@ai-sdk/provider-utils': 4.0.37(zod@4.4.3)
+      '@ai-sdk/provider': 3.0.14
+      '@ai-sdk/provider-utils': 4.0.39(zod@4.4.3)
       '@vercel/oidc': 3.2.0
       zod: 4.4.3
 
@@ -3326,16 +3317,16 @@ snapshots:
       '@ai-sdk/provider-utils': 5.0.5(zod@4.4.3)
       zod: 4.4.3
 
-  '@ai-sdk/provider-utils@3.0.28(zod@4.4.3)':
+  '@ai-sdk/provider-utils@3.0.29(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 2.0.3
       '@standard-schema/spec': 1.1.0
       eventsource-parser: 3.0.8
       zod: 4.4.3
 
-  '@ai-sdk/provider-utils@4.0.37(zod@4.4.3)':
+  '@ai-sdk/provider-utils@4.0.39(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/provider': 3.0.13
+      '@ai-sdk/provider': 3.0.14
       '@standard-schema/spec': 1.1.0
       eventsource-parser: 3.0.8
       zod: 4.4.3
@@ -3352,7 +3343,7 @@ snapshots:
     dependencies:
       json-schema: 0.4.0
 
-  '@ai-sdk/provider@3.0.13':
+  '@ai-sdk/provider@3.0.14':
     dependencies:
       json-schema: 0.4.0
 
@@ -4683,6 +4674,10 @@ snapshots:
     dependencies:
       '@types/node': 24.12.4
 
+  '@types/cross-spawn@6.0.6':
+    dependencies:
+      '@types/node': 24.12.4
+
   '@types/deep-eql@4.0.2': {}
 
   '@types/esrecurse@4.3.1': {}
@@ -4869,19 +4864,19 @@ snapshots:
 
   agent-base@7.1.4: {}
 
-  ai@5.0.210(zod@4.4.3):
+  ai@5.0.213(zod@4.4.3):
     dependencies:
-      '@ai-sdk/gateway': 2.0.109(zod@4.4.3)
+      '@ai-sdk/gateway': 2.0.112(zod@4.4.3)
       '@ai-sdk/provider': 2.0.3
-      '@ai-sdk/provider-utils': 3.0.28(zod@4.4.3)
+      '@ai-sdk/provider-utils': 3.0.29(zod@4.4.3)
       '@opentelemetry/api': 1.9.0
       zod: 4.4.3
 
-  ai@6.0.221(zod@4.4.3):
+  ai@6.0.226(zod@4.4.3):
     dependencies:
-      '@ai-sdk/gateway': 3.0.145(zod@4.4.3)
-      '@ai-sdk/provider': 3.0.13
-      '@ai-sdk/provider-utils': 4.0.37(zod@4.4.3)
+      '@ai-sdk/gateway': 3.0.150(zod@4.4.3)
+      '@ai-sdk/provider': 3.0.14
+      '@ai-sdk/provider-utils': 4.0.39(zod@4.4.3)
       '@opentelemetry/api': 1.9.1
       zod: 4.4.3
 


### PR DESCRIPTION
## What

Adds `lmnr-cli plugin add <agent>` — one-command onboarding for a coding-agent observability plugin (`claude-code` in V1).

The flow:
1. Log in via device flow if not already.
2. User picks the project that should receive **this agent's** traces.
3. Mint a project API key named `<Agent> plugin @ <hostname>` (recognizable + revocable in the dashboard).
4. Install via the host CLI — `claude plugin marketplace add …` + `claude plugin install laminar@laminar --config LMNR_PROJECT_API_KEY=<key> --scope user` — narrating each step with the key **masked** in the echo.
5. Or `--print-only` / auto-fallback: print the exact commands when `claude` is missing or too old.

## Design notes

- **Global, directory-independent.** Never reads/writes `.lmnr/project.json` or `.env` — agent traces go to a deliberately-chosen project, not the linked app project. The key lives only in the host CLI's keychain-backed config (via `--config`), so no plugin-repo change was needed.
- **Capability probe** (`claude plugin install --help` contains `--config`) instead of brittle version parsing; safe fallback to printing.
- **Lenient marketplace-add** (already-added is benign), **fatal install failure** (prints commands for manual recovery).
- **Agent registry** (`AGENTS` map) — adding `cursor`/`codex` later is a one-entry change.

## Known follow-ups (deliberately out of V1 scope)

- ⚠️ No idempotency: each run mints a **new** key → dashboard key sprawl. Reuse/`--rotate` is a V2 item.
- ~40 lines duplicated from `setup` (`listProjects` / project picker / mint) to keep blast radius off the working `setup` command — worth extracting to a shared util later.

## Test

`pnpm build` ✓, `pnpm lint` ✓ (0 errors), `pnpm test` ✓ (149 incl. 4 new), and end-to-end verified: installs the plugin into Claude Code against a real project + minted key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Each run mints a new project API key and writes it to disk; `--json` can expose the key, and the command shells out to third-party CLIs—acceptable for onboarding but worth noting for automation and key sprawl.
> 
> **Overview**
> Adds **`lmnr-cli plugin add <agent>`** (`claude-code`, `codex`) for global agent observability onboarding: device-flow login if needed, project selection (with nudge toward a dedicated traces project), mint of a labeled project API key, and writing **`projectApiKey` + `baseUrl`** to `~/.config/lmnr/<agent>-plugin.json` (mode `0600`). It does **not** touch `.lmnr/project.json` or `.env`.
> 
> When the host CLI supports plugins, the command runs marketplace add (lenient) plus install via **`cross-spawn`**; otherwise or with **`--print-only`**, it prints copy-paste install commands with **no secret on argv**. **`--json`** returns structured results (including recovery data on install failure).
> 
> **Refactor alongside the feature:** shared **`mintProjectApiKey`**, **`listProjects` / `promptProjectChoice`**, **`emitError`**, **`safeReadCredentials`**, **`firstNonEmpty`**, and **`errorMessage`** from `@lmnr-ai/types`; **`setup`** now wires Commander’s **`browser`** flag for `--no-browser`. Docs and version **0.3.2**; unit tests cover install argv shape and config writes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e547a48c4960c45388820b286e221fd299f295b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->