### PR TITLE
feat/lam-1999-debugger-improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@lmnr-ai/lmnr-ts",
   "private": true,
-  "version": "0.8.38",
+  "version": "0.8.39",
   "description": "Laminar AI TypeScript SDK",
   "scripts": {
     "build": "pnpm -r build",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lmnr-ai/client",
-  "version": "0.8.38",
+  "version": "0.8.39",
   "description": "HTTP client for Laminar AI API",
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",

--- a/packages/client/src/resources/cli.ts
+++ b/packages/client/src/resources/cli.ts
@@ -8,6 +8,22 @@ export interface CliProject {
 }
 
 /**
+ * Locale-aware, case-insensitive comparator for the project listing. Ordering
+ * lives here — the single choke point every CLI surface (the `project list`
+ * table + its `--json`, and the interactive picker used by `setup` / `plugin
+ * add`) reads from — so the order can't drift between surfaces.
+ */
+const projectCollator = new Intl.Collator(undefined, { sensitivity: "base" });
+
+/** Sort projects by workspace name, then project name (stable, human-scannable). */
+const sortProjects = (projects: CliProject[]): CliProject[] =>
+  [...projects].sort(
+    (a, b) =>
+      projectCollator.compare(a.workspaceName ?? "", b.workspaceName ?? "") ||
+      projectCollator.compare(a.name ?? "", b.name ?? ""),
+  );
+
+/**
  * Outcome of resolving which project a project API key belongs to via the
  * user-token CLI endpoint. The states are deliberately distinct so the caller
  * doesn't conflate "key is bad" with "couldn't reach the server":
@@ -50,8 +66,9 @@ export class CliResource extends BaseResource {
     }
     // Coerce a missing/non-array `projects` to [] so callers (.length/.map)
     // don't throw. A malformed body on a 2xx is exceptional — let it surface.
+    // Sort here so every consumer inherits one stable, alphabetical order.
     const body = (await response.json()) as { projects?: CliProject[] };
-    return Array.isArray(body?.projects) ? body.projects : [];
+    return Array.isArray(body?.projects) ? sortProjects(body.projects) : [];
   }
 
   /**

--- a/packages/client/src/resources/rollout-sessions.ts
+++ b/packages/client/src/resources/rollout-sessions.ts
@@ -142,11 +142,16 @@ export class RolloutSessionsResource extends BaseResource {
     type,
     content,
     failOnNotFound,
+    signal,
   }: {
     sessionId: string;
     type: SessionBlockType;
     content: SessionBlockContent;
     failOnNotFound?: boolean;
+    // Optional cancellation: aborting tears down the in-flight request so a
+    // best-effort caller (e.g. the CLI's command tracking) can bound its own
+    // deadline without a leaked socket keeping the process alive.
+    signal?: AbortSignal;
   }): Promise<string | null> {
     const response = await fetch(
       `${this.baseHttpUrl}${this.apiPrefix}/rollouts/${sessionId}/blocks`,
@@ -154,6 +159,7 @@ export class RolloutSessionsResource extends BaseResource {
         method: "POST",
         headers: this.headers(),
         body: JSON.stringify({ type, content }),
+        signal,
       },
     );
 

--- a/packages/client/test/cli-resource.test.ts
+++ b/packages/client/test/cli-resource.test.ts
@@ -1,0 +1,45 @@
+import * as assert from "node:assert";
+import { describe, it, mock } from "node:test";
+
+import { CliResource } from "../src/resources/cli";
+
+void describe("CliResource Tests", () => {
+  void it("listProjects sorts by workspace then project name, case-insensitively", async () => {
+    // Deliberately unsorted server order (mixed case) to prove the client sorts.
+    const serverProjects = [
+      { id: "3", name: "zebra", workspaceId: "wb", workspaceName: "Beta" },
+      { id: "1", name: "Apple", workspaceId: "wa", workspaceName: "alpha" },
+      { id: "2", name: "banana", workspaceId: "wa", workspaceName: "Alpha" },
+      { id: "4", name: "aardvark", workspaceId: "wb", workspaceName: "beta" },
+    ];
+    const mockFetch = mock.fn(() => ({
+      ok: true,
+      json: () => Promise.resolve({ projects: serverProjects }),
+    }));
+    global.fetch = mockFetch as any;
+
+    const resource = new CliResource(
+      "https://api.test.com:443",
+      { type: "userToken", token: "jwt", projectId: "" },
+    );
+    const projects = await resource.listProjects();
+
+    // Workspace alpha (case-insensitive) before beta; within a workspace,
+    // project name ascending, case-insensitive.
+    assert.deepStrictEqual(
+      projects.map((p) => p.id),
+      ["1", "2", "4", "3"],
+    );
+  });
+
+  void it("listProjects returns [] for a missing projects array", async () => {
+    const mockFetch = mock.fn(() => ({ ok: true, json: () => Promise.resolve({}) }));
+    global.fetch = mockFetch as any;
+
+    const resource = new CliResource(
+      "https://api.test.com:443",
+      { type: "userToken", token: "jwt", projectId: "" },
+    );
+    assert.deepStrictEqual(await resource.listProjects(), []);
+  });
+});

--- a/packages/client/test/rollout-sessions-resource.test.ts
+++ b/packages/client/test/rollout-sessions-resource.test.ts
@@ -142,6 +142,32 @@ void describe("RolloutSessions Resource Tests", () => {
     assert.deepStrictEqual(body, { type: "text", content: { text: "a note" } });
   });
 
+  void it("addBlock POSTs a `command` block (new block type)", async () => {
+    const mockFetch = mock.fn(() => ({
+      ok: true,
+      json: () => Promise.resolve({ id: "block-2" }),
+    }));
+    global.fetch = mockFetch as any;
+
+    const resource = new RolloutSessionsResource(
+      "https://api.test.com:443",
+      { type: "apiKey", key: "test-api-key" },
+    );
+    const id = await resource.addBlock({
+      sessionId: "sess-cmd",
+      type: "command",
+      content: { command: "sql query", args: ["SELECT 1"], exitCode: 0 },
+    });
+
+    assert.strictEqual(id, "block-2");
+    const requestOptions = (mockFetch.mock.calls[0].arguments as any)[1] as RequestInit;
+    const body = JSON.parse(requestOptions.body as string);
+    assert.deepStrictEqual(body, {
+      type: "command",
+      content: { command: "sql query", args: ["SELECT 1"], exitCode: 0 },
+    });
+  });
+
   void it("addBlock returns null and warns on 404 by default", async () => {
     const mockFetch = mock.fn(() => ({ ok: false, status: 404, text: () => "nope" }));
     global.fetch = mockFetch as any;

--- a/packages/lmnr-cli/package.json
+++ b/packages/lmnr-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lmnr-cli",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "description": "CLI for the Laminar agent observability platform",
   "main": "dist/index.cjs",
   "bin": {

--- a/packages/lmnr-cli/src/auth/resolve.ts
+++ b/packages/lmnr-cli/src/auth/resolve.ts
@@ -8,6 +8,15 @@ import { type AuthInputs, type ResolvedAuth } from "./types";
 const REFRESH_SKEW_MS = 30_000;
 
 /**
+ * The stored BetterAuth session's durable grant is no longer valid (the refresh
+ * endpoint answered `invalid_grant`), so a fresh access JWT can't be minted —
+ * the user must re-authenticate. A distinct type (not a bare `Error`) so callers
+ * can absorb an expiry (e.g. `setup` re-runs the device flow) without matching
+ * on the message string. Thrown by {@link refreshIfNeeded}.
+ */
+export class SessionExpiredError extends Error {}
+
+/**
  * HTTP port from `LMNR_HTTP_PORT`. The Laminar convention is that `baseUrl`
  * carries NO port and the port is supplied separately (mirrors the SDK's
  * `LMNR_HTTP_PORT` / `LMNR_GRPC_PORT`). Returns undefined when unset/invalid so
@@ -111,7 +120,7 @@ export async function refreshIfNeeded(creds: Credentials): Promise<Credentials> 
     next.accessTokenExpiresAt = decodeJwtExp(jwt) ?? new Date().toISOString();
   } catch (e) {
     if (e instanceof DeviceFlowError && e.code === "invalid_grant") {
-      throw new Error("Session expired — run `lmnr-cli login`.");
+      throw new SessionExpiredError("Session expired — run `lmnr-cli login`.");
     }
     throw e;
   }

--- a/packages/lmnr-cli/src/auth/resolve.ts
+++ b/packages/lmnr-cli/src/auth/resolve.ts
@@ -8,20 +8,17 @@ import { type AuthInputs, type ResolvedAuth } from "./types";
 const REFRESH_SKEW_MS = 30_000;
 
 /**
- * The stored BetterAuth session's durable grant is no longer valid (the refresh
- * endpoint answered `invalid_grant`), so a fresh access JWT can't be minted —
- * the user must re-authenticate. A distinct type (not a bare `Error`) so callers
- * can absorb an expiry (e.g. `setup` re-runs the device flow) without matching
- * on the message string. Thrown by {@link refreshIfNeeded}.
+ * The stored session grant is dead (`invalid_grant` from the refresh endpoint),
+ * so no fresh JWT can be minted — the user must re-authenticate. A distinct type
+ * so callers can absorb an expiry without matching on the message string.
  */
 export class SessionExpiredError extends Error {}
 
 /**
- * HTTP port from `LMNR_HTTP_PORT`. The Laminar convention is that `baseUrl`
- * carries NO port and the port is supplied separately (mirrors the SDK's
- * `LMNR_HTTP_PORT` / `LMNR_GRPC_PORT`). Returns undefined when unset/invalid so
- * the client keeps its 443 default for Cloud. An explicit `--port` flag still
- * wins (callers do `opts.port ?? envHttpPort()`).
+ * HTTP port from `LMNR_HTTP_PORT`. By convention `baseUrl` carries no port and
+ * the port is supplied separately. Returns undefined when unset/invalid so the
+ * client keeps its 443 Cloud default. An explicit `--port` still wins
+ * (`opts.port ?? envHttpPort()`).
  */
 export function envHttpPort(): number | undefined {
   const raw = process.env.LMNR_HTTP_PORT?.trim();
@@ -32,22 +29,19 @@ export function envHttpPort(): number | undefined {
 
 /**
  * Resolve the data-API base URL: `--base-url` flag → `LMNR_BASE_URL` env →
- * default. Intentionally NOT read from credentials.json — the endpoint is not
- * persisted at login, so a self-host `.env` change applies to every command
- * without re-logging-in (and base URL behaves symmetrically with the port).
+ * default. Not read from credentials.json — the endpoint isn't persisted at
+ * login, so a self-host `.env` change applies without re-logging-in.
  */
 export function resolveBaseUrl(optBaseUrl?: string): string {
   return optBaseUrl?.trim() || process.env.LMNR_BASE_URL?.trim() || DEFAULT_BASE_URL;
 }
 
 /**
- * CLI auth is **user-token only** — the CLI authenticates as the single
- * signed-in user via the stored BetterAuth session (refreshed access JWT),
- * never via a project API key.
+ * CLI auth is user-token only — authenticates as the signed-in user via the
+ * stored session (refreshed access JWT), never a project API key.
  *
- * Project precedence (directory-scoped): `--project-id` flag > the nearest
- * `.lmnr/project.json` (written by `setup`). The project is NOT stored in
- * credentials.json — that holds only user auth.
+ * Project precedence: `--project-id` flag > nearest `.lmnr/project.json`. The
+ * project is not stored in credentials.json (that holds only user auth).
  */
 export async function resolveAuth(opts: AuthInputs): Promise<ResolvedAuth> {
   const creds = await readCredentials();
@@ -77,7 +71,7 @@ export async function resolveAuth(opts: AuthInputs): Promise<ResolvedAuth> {
 
 /**
  * Resolve only the user-scoped access token (no project) — for discovery
- * endpoints like listing projects, which run BEFORE a project is selected.
+ * endpoints like listing projects, which run before a project is selected.
  */
 export async function resolveUserToken(opts: {
   baseUrl?: string;
@@ -96,15 +90,9 @@ export async function resolveUserToken(opts: {
 }
 
 /**
- * Re-mint the access JWT when it's near expiry and persist it. A 401 from the
- * token endpoint means the session is gone — surface a clear "run login" error.
- *
- * Logout race guard: we write credentials ONLY when we actually re-minted. The
- * old code unconditionally rewrote the file (just to bump lastUsedAt) on every
- * command, so a concurrent `logout` that deleted the file mid-flight could have
- * its delete clobbered by this in-flight atomic rename — logout would appear to
- * succeed while tokens remained on disk. For a fresh (not-near-expiry) token we
- * now do no write at all, eliminating that window for the common case.
+ * Re-mint the access token if it's about to expire, and save it.
+ * Only write when we actually re-mint — otherwise a concurrent `logout` deleting
+ * the file could race with our write and leave tokens on disk.
  */
 export async function refreshIfNeeded(creds: Credentials): Promise<Credentials> {
   const expMs = new Date(creds.accessTokenExpiresAt).getTime();

--- a/packages/lmnr-cli/src/auth/with-client.ts
+++ b/packages/lmnr-cli/src/auth/with-client.ts
@@ -4,6 +4,7 @@ import type { Command } from "commander";
 
 import { initializeLogger } from "../utils/logger";
 import { outputJsonError } from "../utils/output";
+import { maybeTrackCommand } from "../utils/track-command";
 import { buildLaminarClient } from "./client";
 import { resolveUserToken } from "./resolve";
 
@@ -46,24 +47,38 @@ function splitCommanderArgs(cmdArgs: unknown[]): {
 }
 
 /**
- * The error envelope shared by both wrappers: in `--json` mode emit a structured
+ * The error envelope shared by every wrapper: in `--json` mode emit a structured
  * error line and exit with the mapped code; otherwise log and exit. Owning this
  * here lets handlers stay pure `(client, ...args) => work` with no try/catch.
+ *
+ * It's also the one place that knows a command has finished AND its real exit
+ * code, so it records the command into the active debug session here (best-effort
+ * via `maybeTrackCommand`) — 0 on success, the mapped code on failure. Commander
+ * has no on-error hook, so this is the only spot that can track failures too.
  */
 function runWithEnvelope(
   work: () => Promise<void>,
   opts: GlobalOpts,
   exitCodeFor: ExitCodeMapper,
+  command: Command,
 ): Promise<void> {
-  return work().catch((error: unknown) => {
-    const code = exitCodeFor(error);
-    if (opts.json) {
-      // outputJsonError exits with `code` (never returns).
-      outputJsonError(error, code);
-    }
-    logger.error(errorMessage(error));
-    process.exit(code);
-  });
+  return work().then(
+    async () => {
+      // Success — record with exit 0 (swallows its own errors; never throws).
+      await maybeTrackCommand(command, 0);
+    },
+    async (error: unknown) => {
+      const code = exitCodeFor(error);
+      // Record the failure with its real exit code BEFORE we exit the process.
+      await maybeTrackCommand(command, code);
+      if (opts.json) {
+        // outputJsonError exits with `code` (never returns).
+        outputJsonError(error, code);
+      }
+      logger.error(errorMessage(error));
+      process.exit(code);
+    },
+  );
 }
 
 /**
@@ -97,11 +112,12 @@ export const withLocalOpts =
     exitCodeFor: ExitCodeMapper = defaultExitCode,
   ) =>
     async (...cmdArgs: unknown[]): Promise<void> => {
-      const { positionals, opts } = splitCommanderArgs(cmdArgs);
+      const { positionals, command, opts } = splitCommanderArgs(cmdArgs);
       await runWithEnvelope(
         () => action(...(positionals as A), opts),
         opts,
         exitCodeFor,
+        command,
       );
     };
 
@@ -122,7 +138,7 @@ export const withProjectClient =
     exitCodeFor: ExitCodeMapper = defaultExitCode,
   ) =>
     async (...cmdArgs: unknown[]): Promise<void> => {
-      const { positionals, opts } = splitCommanderArgs(cmdArgs);
+      const { positionals, command, opts } = splitCommanderArgs(cmdArgs);
       await runWithEnvelope(
         async () => {
           const client = await buildLaminarClient({
@@ -134,6 +150,7 @@ export const withProjectClient =
         },
         opts,
         exitCodeFor,
+        command,
       );
     };
 
@@ -149,7 +166,7 @@ export const withUserToken =
     exitCodeFor: ExitCodeMapper = defaultExitCode,
   ) =>
     async (...cmdArgs: unknown[]): Promise<void> => {
-      const { positionals, opts } = splitCommanderArgs(cmdArgs);
+      const { positionals, command, opts } = splitCommanderArgs(cmdArgs);
       await runWithEnvelope(
         async () => {
           const token = await resolveUserToken({
@@ -169,5 +186,6 @@ export const withUserToken =
         },
         opts,
         exitCodeFor,
+        command,
       );
     };

--- a/packages/lmnr-cli/src/auth/with-client.ts
+++ b/packages/lmnr-cli/src/auth/with-client.ts
@@ -69,8 +69,10 @@ function runWithEnvelope(
     },
     async (error: unknown) => {
       const code = exitCodeFor(error);
-      // Record the failure with its real exit code BEFORE we exit the process.
-      await maybeTrackCommand(command, code);
+      // Record the failure with its real exit code BEFORE we exit the process,
+      // passing the fatal error text so it lands in the block's stderr (the
+      // logger.error below runs after this, so the tee wouldn't capture it).
+      await maybeTrackCommand(command, code, errorMessage(error));
       if (opts.json) {
         // outputJsonError exits with `code` (never returns).
         outputJsonError(error, code);

--- a/packages/lmnr-cli/src/auth/with-client.ts
+++ b/packages/lmnr-cli/src/auth/with-client.ts
@@ -13,25 +13,22 @@ const logger = initializeLogger();
 
 /**
  * Global options every wrapped command shares (from `cmd.optsWithGlobals()`).
- * `projectId` is consumed by the project-client path; discovery commands ignore
- * it (the user-token surface has no project to scope at discovery time).
+ * `projectId` is used by the project-client path; discovery commands ignore it.
  */
 export interface GlobalOpts {
   projectId?: string;
   baseUrl?: string;
   port?: number;
   json?: boolean;
-  // `--pretty` selects the human table over the default CSV output. Only the
-  // `sql query` command wires this flag today; it lives on the shared type
-  // (like `json`) so pure handlers can read it without a per-command opts type.
+  // `--pretty` selects the human table over the default CSV output (only `sql
+  // query` wires it today). On the shared type so handlers read it without a
+  // per-command opts type.
   pretty?: boolean;
 }
 
 /**
- * Map a thrown error to a process exit code. Pass a custom mapper to a wrapper
- * to override; the default reads `CliError.exitCode` (so a wrapped handler can
- * `throw loginFailed(...)` and get exit 6) and falls back to 1 for anything
- * else — mirroring oclif's `err.oclif?.exit ?? 1`.
+ * Map a thrown error to a process exit code. The default reads
+ * `CliError.exitCode` and falls back to 1; pass a custom mapper to override.
  */
 export type ExitCodeMapper = (error: unknown) => number;
 
@@ -40,8 +37,8 @@ const defaultExitCode: ExitCodeMapper = (error) =>
 
 /**
  * Pull the commander positionals out of an `.action(...)` argument list.
- * Commander invokes the handler as `(arg1, ..., argN, options, command)`, so
- * the positionals are everything except the trailing `(options, command)`.
+ * Commander calls the handler as `(arg1, ..., argN, options, command)`, so the
+ * positionals are everything except the trailing `(options, command)`.
  */
 function splitCommanderArgs(cmdArgs: unknown[]): {
   positionals: unknown[];
@@ -56,13 +53,13 @@ function splitCommanderArgs(cmdArgs: unknown[]): {
 
 /**
  * The error envelope shared by every wrapper: in `--json` mode emit a structured
- * error line and exit with the mapped code; otherwise log and exit. Owning this
- * here lets handlers stay pure `(client, ...args) => work` with no try/catch.
+ * error line and exit with the mapped code, else log and exit. Keeps handlers
+ * pure `(client, ...args) => work` with no try/catch.
  *
- * It's also the one place that knows a command has finished AND its real exit
- * code, so it records the command into the active debug session here (best-effort
- * via `maybeTrackCommand`) — 0 on success, the mapped code on failure. Commander
- * has no on-error hook, so this is the only spot that can track failures too.
+ * Also the one place that knows a command finished AND its exit code, so it
+ * records the command into the active debug session (best-effort) — 0 on
+ * success, the mapped code on failure. Commander has no on-error hook, so this
+ * is the only spot that can track failures.
  */
 function runWithEnvelope(
   work: () => Promise<void>,
@@ -72,14 +69,13 @@ function runWithEnvelope(
 ): Promise<void> {
   return work().then(
     async () => {
-      // Success — record with exit 0 (swallows its own errors; never throws).
+      // Success — record with exit 0 (never throws).
       await maybeTrackCommand(command, 0);
     },
     async (error: unknown) => {
       const code = exitCodeFor(error);
-      // Record the failure with its real exit code BEFORE we exit the process,
-      // passing the fatal error text so it lands in the block's stderr (the
-      // logger.error below runs after this, so the tee wouldn't capture it).
+      // Record the failure BEFORE exiting, passing the error text so it lands in
+      // the block's stderr (the logger.error below runs after, too late to tee).
       await maybeTrackCommand(command, code, errorMessage(error));
       if (opts.json) {
         // outputJsonError exits with `code` (never returns).
@@ -92,10 +88,9 @@ function runWithEnvelope(
 }
 
 /**
- * The handler shape both wrappers accept: a pure function of the resolved
- * client, the commander positionals, and the parsed options (so it can read
- * `--json` for output mode). All auth resolution + the error envelope live in
- * the wrapper, so handlers contain only the work.
+ * The handler shape both client wrappers accept: a pure function of the resolved
+ * client, the commander positionals, and the parsed options. Auth resolution and
+ * the error envelope live in the wrapper.
  */
 export type ClientAction<A extends unknown[]> = (
   client: LaminarClient,
@@ -103,8 +98,7 @@ export type ClientAction<A extends unknown[]> = (
 ) => Promise<void>;
 
 /**
- * The handler shape {@link withLocalOpts} accepts: a pure function of the
- * commander positionals and the parsed options — no client, for commands that
+ * The handler shape {@link withLocalOpts} accepts — no client, for commands that
  * only touch local state (e.g. `.lmnr/*` files) and never call the API.
  */
 export type LocalAction<A extends unknown[]> = (
@@ -112,9 +106,8 @@ export type LocalAction<A extends unknown[]> = (
 ) => Promise<void>;
 
 /**
- * Wrap a local-only command handler. No auth resolution / client build (the
- * command must not call the API), but the same positionals + options threading
- * and error envelope as the client wrappers, so handlers stay pure.
+ * Wrap a local-only command handler: no auth/client build, but the same
+ * positionals + options threading and error envelope as the client wrappers.
  */
 export const withLocalOpts =
   <A extends unknown[]>(
@@ -134,8 +127,7 @@ export const withLocalOpts =
 /**
  * Wrap a project-scoped command handler. Resolves a user-token
  * {@link LaminarClient} (routes to `/v1/cli/*` with the resolved project),
- * threads the commander positionals + options through, and owns the error
- * envelope.
+ * threads positionals + options, and owns the error envelope.
  *
  * @example
  *   sqlCmd.command("query")
@@ -166,9 +158,8 @@ export const withProjectClient =
 
 /**
  * Wrap a discovery command handler. Resolves a user-token
- * {@link LaminarClient} with NO project (the discovery surface — e.g. listing
- * projects — runs before a project is selected), threads positionals +
- * options, and owns the error envelope.
+ * {@link LaminarClient} with NO project (discovery runs before a project is
+ * selected), threads positionals + options, and owns the error envelope.
  */
 export const withUserToken =
   <A extends unknown[]>(
@@ -185,11 +176,11 @@ export const withUserToken =
           });
           const client = new LaminarClient({
             baseUrl: token.baseUrl,
-            // token.port carries the --port flag OR the LMNR_HTTP_PORT fallback
-            // (resolveUserToken applies it); using opts.port here would drop it.
+            // token.port already folds in the LMNR_HTTP_PORT fallback; opts.port
+            // would drop it.
             port: token.port,
-            // Discovery: no project id yet. CliResource overrides its own
-            // URL/headers, so the empty projectId is never sent.
+            // No project id yet. CliResource overrides its own URL/headers, so
+            // the empty projectId is never sent.
             auth: { type: "userToken", token: token.bearer, projectId: "" },
           });
           await action(client, ...(positionals as A), opts);

--- a/packages/lmnr-cli/src/auth/with-client.ts
+++ b/packages/lmnr-cli/src/auth/with-client.ts
@@ -2,6 +2,7 @@ import { LaminarClient } from "@lmnr-ai/client";
 import { errorMessage } from "@lmnr-ai/types";
 import type { Command } from "commander";
 
+import { CliError } from "../errors";
 import { initializeLogger } from "../utils/logger";
 import { outputJsonError } from "../utils/output";
 import { maybeTrackCommand } from "../utils/track-command";
@@ -27,12 +28,15 @@ export interface GlobalOpts {
 }
 
 /**
- * Map a thrown error to a process exit code. The default is 1; pass a custom
- * mapper to a wrapper to surface distinct machine-readable codes (Phase 6).
+ * Map a thrown error to a process exit code. Pass a custom mapper to a wrapper
+ * to override; the default reads `CliError.exitCode` (so a wrapped handler can
+ * `throw loginFailed(...)` and get exit 6) and falls back to 1 for anything
+ * else — mirroring oclif's `err.oclif?.exit ?? 1`.
  */
 export type ExitCodeMapper = (error: unknown) => number;
 
-const defaultExitCode: ExitCodeMapper = () => 1;
+const defaultExitCode: ExitCodeMapper = (error) =>
+  error instanceof CliError ? error.exitCode : 1;
 
 /**
  * Pull the commander positionals out of an `.action(...)` argument list.

--- a/packages/lmnr-cli/src/auth/with-client.ts
+++ b/packages/lmnr-cli/src/auth/with-client.ts
@@ -20,6 +20,10 @@ export interface GlobalOpts {
   baseUrl?: string;
   port?: number;
   json?: boolean;
+  // `--pretty` selects the human table over the default CSV output. Only the
+  // `sql query` command wires this flag today; it lives on the shared type
+  // (like `json`) so pure handlers can read it without a per-command opts type.
+  pretty?: boolean;
 }
 
 /**

--- a/packages/lmnr-cli/src/commands/ask.ts
+++ b/packages/lmnr-cli/src/commands/ask.ts
@@ -1,7 +1,7 @@
 import { resolveAuth } from "../auth/resolve";
 import type { GlobalOpts } from "../auth/with-client";
 import { pc } from "../utils/colors";
-import { outputJson } from "../utils/output";
+import { emitData, emitErr, outputJson } from "../utils/output";
 
 /**
  * One SSE frame from the app-server agent stream (`AgentEvent`, camelCase). Only
@@ -94,13 +94,13 @@ export const handleAsk = async (query: string, opts: AskOpts): Promise<void> => 
         // flip `streamed`, suppressing the `message`-frame fallback that carries the full answer.
         if (typeof frame.text === "string" && frame.text.length > 0) {
           answer += frame.text;
-          process.stdout.write(frame.text);
+          emitData(frame.text);
           streamed = true;
         }
         break;
       case "thought":
         if (typeof frame.text === "string") {
-          process.stderr.write(pc.dim(frame.text));
+          emitErr(pc.dim(frame.text));
         }
         break;
       case "message": {
@@ -108,7 +108,7 @@ export const handleAsk = async (query: string, opts: AskOpts): Promise<void> => 
         if (frame.message?.role === "assistant") {
           for (const part of parts) {
             if (part.type === "toolCall" && part.name) {
-              process.stderr.write(pc.dim(`\n  → ${part.name}\n`));
+              emitErr(pc.dim(`\n  → ${part.name}\n`));
             }
           }
           // Final assistant text: only used if no deltas streamed it (defensive).
@@ -156,17 +156,17 @@ export const handleAsk = async (query: string, opts: AskOpts): Promise<void> => 
   if (failure) throw new Error(failure);
 
   if (streamed) {
-    process.stdout.write("\n");
+    emitData("\n");
   } else if (answer.trim()) {
-    process.stdout.write(`${answer.trim()}\n`);
+    emitData(`${answer.trim()}\n`);
   } else {
-    process.stderr.write(pc.dim("(the agent returned no answer)\n"));
+    emitErr(pc.dim("(the agent returned no answer)\n"));
   }
 
   // Echo a ready-to-run continuation hint (muted, on stderr so stdout stays the clean answer) —
   // copy it into the next turn's `--conversation`.
   if (conversationId) {
-    process.stderr.write(
+    emitErr(
       pc.dim(`\ncontinue with: lmnr-cli ask "<question>" --conversation ${conversationId}\n`),
     );
   }

--- a/packages/lmnr-cli/src/commands/ask.ts
+++ b/packages/lmnr-cli/src/commands/ask.ts
@@ -3,11 +3,7 @@ import type { GlobalOpts } from "../auth/with-client";
 import { pc } from "../utils/colors";
 import { emitData, emitErr, outputJson } from "../utils/output";
 
-/**
- * One SSE frame from the app-server agent stream (`AgentEvent`, camelCase). Only
- * the fields the CLI consumes are typed; unknown variants are ignored so the
- * stream stays forward-compatible.
- */
+/** One SSE frame from the agent stream; only the fields the CLI consumes are typed. */
 interface AgentFrame {
   type: "conversation" | "delta" | "thought" | "message" | "finish" | "error";
   conversationId?: string;
@@ -19,10 +15,9 @@ interface AgentFrame {
 type AskOpts = GlobalOpts & { conversation?: string };
 
 /**
- * `lmnr-cli ask "<question>"` — ask the Laminar agent a natural-language question.
- * User-token authed (like the rest of the CLI) against `/v1/cli/agent/chat`, project
- * in the `x-lmnr-project-id` header; streams the answer to stdout (activity to stderr).
- * `--conversation <id>` continues a prior session (its id is echoed on stderr).
+ * `lmnr-cli ask "<question>"` — ask the Laminar agent a question. Streams the
+ * answer to stdout (activity to stderr). `--conversation <id>` continues a prior
+ * session; its id is echoed on stderr.
  */
 export const handleAsk = async (query: string, opts: AskOpts): Promise<void> => {
   const question = query?.trim();
@@ -30,10 +25,10 @@ export const handleAsk = async (query: string, opts: AskOpts): Promise<void> => 
     throw new Error('Provide a question, e.g. lmnr-cli ask "why did my latest trace fail?"');
   }
 
-  // User-token auth (auto-refreshed) + resolved project — same resolution `withProjectClient` uses.
+  // User-token auth + resolved project — same resolution `withProjectClient` uses.
   const { bearer, baseUrl, port, projectId } = await resolveAuth(opts);
 
-  // baseUrl carries no port by convention; splice the resolved port onto the URL.
+  // baseUrl carries no port by convention; splice the resolved port on.
   const url = new URL(baseUrl.replace(/\/+$/, ""));
   if (port) url.port = String(port);
   url.pathname = "/v1/cli/agent/chat";
@@ -44,7 +39,7 @@ export const handleAsk = async (query: string, opts: AskOpts): Promise<void> => 
       Authorization: `Bearer ${bearer}`,
       "x-lmnr-project-id": projectId,
       "Content-Type": "application/json",
-      // Content negotiation: agents/scripts (`--json`) get one buffered JSON result; humans stream.
+      // --json gets one buffered JSON result; humans stream.
       Accept: opts.json ? "application/json" : "text/event-stream",
     },
     // `--conversation` continues a prior session; omitted → server mints a fresh one and echoes it.
@@ -60,22 +55,21 @@ export const handleAsk = async (query: string, opts: AskOpts): Promise<void> => 
     throw new Error(`Agent request failed (HTTP ${res.status})${suffix}`);
   }
 
-  // `--json`: the server buffered the run into `{ answer, conversationId, tools }` — no stream
-  // to parse. Emit it verbatim.
+  // --json: the server buffered the whole run; emit it verbatim.
   if (opts.json) {
     outputJson(await res.json());
     return;
   }
 
-  // Human mode: stream-parse the SSE frames — `delta` tokens form the answer (stdout), thoughts +
-  // tool calls surface as activity (stderr), a trailing `error` frame aborts.
+  // Human mode: stream-parse the SSE frames — `delta` tokens form the answer
+  // (stdout), thoughts + tool calls go to stderr, a trailing `error` aborts.
   const reader = res.body.getReader();
   const decoder = new TextDecoder();
   let buffer = "";
   let answer = "";
   let streamed = false;
   let failure: string | undefined;
-  // Resolved server-side; arrives on the leading `conversation` frame (or equals `--conversation`).
+  // Arrives on the leading `conversation` frame (or equals `--conversation`).
   let conversationId: string | undefined = opts.conversation;
 
   const onFrame = (data: string): void => {
@@ -90,8 +84,8 @@ export const handleAsk = async (query: string, opts: AskOpts): Promise<void> => 
         if (frame.conversationId) conversationId = frame.conversationId;
         break;
       case "delta":
-        // Only a NON-EMPTY delta counts as streamed: an empty token writes nothing but would still
-        // flip `streamed`, suppressing the `message`-frame fallback that carries the full answer.
+        // Only a non-empty delta counts as streamed, else it would flip
+        // `streamed` and suppress the `message`-frame fallback for empty tokens.
         if (typeof frame.text === "string" && frame.text.length > 0) {
           answer += frame.text;
           emitData(frame.text);
@@ -111,7 +105,7 @@ export const handleAsk = async (query: string, opts: AskOpts): Promise<void> => 
               emitErr(pc.dim(`\n  → ${part.name}\n`));
             }
           }
-          // Final assistant text: only used if no deltas streamed it (defensive).
+          // Fallback: only used if no deltas streamed the text.
           const text = parts
             .filter((p) => p.type === "text" && typeof p.text === "string")
             .map((p) => p.text)
@@ -121,8 +115,7 @@ export const handleAsk = async (query: string, opts: AskOpts): Promise<void> => 
         break;
       }
       case "error": {
-        // The `error` frame's `message` is a string (the `message` frame's is the
-        // ChatMessage object) — read it off the raw payload.
+        // Here `message` is a string (unlike the `message` frame's object).
         const raw = (frame as unknown as { message?: unknown }).message;
         failure = typeof raw === "string" && raw.length > 0 ? raw : "Agent error";
         break;
@@ -163,8 +156,7 @@ export const handleAsk = async (query: string, opts: AskOpts): Promise<void> => 
     emitErr(pc.dim("(the agent returned no answer)\n"));
   }
 
-  // Echo a ready-to-run continuation hint (muted, on stderr so stdout stays the clean answer) —
-  // copy it into the next turn's `--conversation`.
+  // Echo a ready-to-run continuation hint on stderr (stdout stays the clean answer).
   if (conversationId) {
     emitErr(
       pc.dim(`\ncontinue with: lmnr-cli ask "<question>" --conversation ${conversationId}\n`),

--- a/packages/lmnr-cli/src/commands/debug/index.test.ts
+++ b/packages/lmnr-cli/src/commands/debug/index.test.ts
@@ -73,7 +73,7 @@ describe('handleDebugSessionSummary', () => {
     );
   });
 
-  it('renders command blocks (invocation + exit code + thinking)', async () => {
+  it('renders command blocks (invocation + exit code + reasoning)', async () => {
     mockListBlocks.mockResolvedValue([
       commandBlock(
         'c1',
@@ -81,7 +81,7 @@ describe('handleDebugSessionSummary', () => {
           command: 'sql query',
           args: ['SELECT 1'],
           exitCode: 0,
-          thinking: 'checking error rate',
+          reasoning: 'checking error rate',
           output: 'ignored in human summary',
         },
         '2026-06-01T10:00:00.000Z',
@@ -96,7 +96,7 @@ describe('handleDebugSessionSummary', () => {
     await handleDebugSessionSummary(stubClient, { ...baseOpts, sessionId: SESSION_ID });
 
     expect(logSpy).toHaveBeenCalledWith(
-      '<command exitCode="0" thinking="checking error rate">sql query SELECT 1</command>' +
+      '<command exitCode="0" reasoning="checking error rate">sql query SELECT 1</command>' +
       '\n\n<command exitCode="9">ask why?</command>',
     );
   });

--- a/packages/lmnr-cli/src/commands/debug/index.test.ts
+++ b/packages/lmnr-cli/src/commands/debug/index.test.ts
@@ -73,7 +73,7 @@ describe('handleDebugSessionSummary', () => {
     );
   });
 
-  it('renders command blocks (invocation + exit code + reasoning)', async () => {
+  it('renders command blocks (invocation + exit code + thinking)', async () => {
     mockListBlocks.mockResolvedValue([
       commandBlock(
         'c1',
@@ -81,7 +81,7 @@ describe('handleDebugSessionSummary', () => {
           command: 'sql query',
           args: ['SELECT 1'],
           exitCode: 0,
-          reasoning: 'checking error rate',
+          thinking: 'checking error rate',
           output: 'ignored in human summary',
         },
         '2026-06-01T10:00:00.000Z',
@@ -96,7 +96,7 @@ describe('handleDebugSessionSummary', () => {
     await handleDebugSessionSummary(stubClient, { ...baseOpts, sessionId: SESSION_ID });
 
     expect(logSpy).toHaveBeenCalledWith(
-      '<command exitCode="0" reasoning="checking error rate">sql query SELECT 1</command>' +
+      '<command exitCode="0" thinking="checking error rate">sql query SELECT 1</command>' +
       '\n\n<command exitCode="9">ask why?</command>',
     );
   });

--- a/packages/lmnr-cli/src/commands/debug/index.test.ts
+++ b/packages/lmnr-cli/src/commands/debug/index.test.ts
@@ -41,6 +41,12 @@ const evalBlock = (id: string, evaluationId: string, createdAt: string) => ({
   content: { evaluationId },
 });
 
+const commandBlock = (
+  id: string,
+  content: Record<string, unknown>,
+  createdAt: string,
+) => ({ id, createdAt, type: 'command', content });
+
 let logSpy: ReturnType<typeof vi.spyOn>;
 
 beforeEach(() => {
@@ -64,6 +70,34 @@ describe('handleDebugSessionSummary', () => {
 
     expect(logSpy).toHaveBeenCalledWith(
       '<trace id="trace-1"/>\n\na finding\n\n<evaluation id="eval-9"/>',
+    );
+  });
+
+  it('renders command blocks (invocation + exit code + reasoning)', async () => {
+    mockListBlocks.mockResolvedValue([
+      commandBlock(
+        'c1',
+        {
+          command: 'sql query',
+          args: ['SELECT 1'],
+          exitCode: 0,
+          reasoning: 'checking error rate',
+          output: 'ignored in human summary',
+        },
+        '2026-06-01T10:00:00.000Z',
+      ),
+      commandBlock(
+        'c2',
+        { command: 'ask', args: ['why?'], exitCode: 9 },
+        '2026-06-01T10:05:00.000Z',
+      ),
+    ]);
+
+    await handleDebugSessionSummary(stubClient, { ...baseOpts, sessionId: SESSION_ID });
+
+    expect(logSpy).toHaveBeenCalledWith(
+      '<command exitCode="0" reasoning="checking error rate">sql query SELECT 1</command>' +
+      '\n\n<command exitCode="9">ask why?</command>',
     );
   });
 

--- a/packages/lmnr-cli/src/commands/debug/index.ts
+++ b/packages/lmnr-cli/src/commands/debug/index.ts
@@ -18,25 +18,16 @@ import { outputJson } from "../../utils/output";
 
 const logger = initializeLogger();
 
-/**
- * Options accepted by the session-scoped debug commands (`set-name`, `summary`,
- * `open`), extending the shared globals.
- */
+/** Options for the session-scoped debug commands (`set-name`, `summary`, `open`). */
 export interface DebugSessionScopedOpts extends GlobalOpts {
   /** Set by `--session-id`; omitted → the debug-session.json `session_id`. */
   sessionId?: string;
 }
 
 /**
- * Upsert the display name of a debug session. Update-only on the backend: a
- * session id unknown to the project 404s rather than creating a ghost session.
- *
- * The target session is the optional `--session-id` flag; when omitted the
- * session comes from `.lmnr/debug-session.json` (see `resolveSessionId`).
- *
- * Pure handler: the command wrapper (`withProjectClient`) resolves a user-token
- * {@link LaminarClient} (routes to `/v1/cli/*` with the resolved project) and
- * owns the error envelope.
+ * Upsert a debug session's display name. Update-only on the backend: an unknown
+ * session id 404s rather than creating a ghost session. Session id defaults from
+ * `.lmnr/debug-session.json` when `--session-id` is omitted.
  */
 export const handleDebugSessionSetName = async (
   client: LaminarClient,
@@ -61,23 +52,11 @@ export interface DebugSessionAddNoteOpts extends GlobalOpts {
 }
 
 /**
- * Attach a free-text note to a debug session as a standalone `text` block.
- *
- * The note is written to the session's block list (`debugger_session_blocks`)
- * keyed by session id — NOT to any trace / evaluation metadata. Each call
- * appends a new block, interleaved by time with the session's trace / evaluation
- * blocks in the debugger UI (and in `debug session summary`). This is the
- * unified note path for both debug runs and evals: `rollout.session_id` links
- * traces / evals to the session; the note only needs the session id.
- *
- * The target session is the optional `--session-id` flag; when omitted the
- * session comes from `.lmnr/debug-session.json` (see `resolveSessionId`) — which
- * every LMNR_DEBUG=1 run (agents and evals alike) keeps pointed at the current
- * session via the SDK's shutdown pointer write.
- *
- * Pure handler: the command wrapper (`withProjectClient`) resolves a user-token
- * {@link LaminarClient} (routes to `/v1/cli/*` with the resolved project) and
- * owns the error envelope.
+ * Attach a free-text note to a debug session as a standalone `text` block,
+ * keyed by session id — not to any trace / evaluation metadata. Notes interleave
+ * by time with the session's trace / evaluation blocks in the UI and in
+ * `debug session summary`. Session id defaults from `.lmnr/debug-session.json`
+ * when `--session-id` is omitted.
  */
 export const handleDebugSessionAddNote = async (
   client: LaminarClient,
@@ -85,7 +64,7 @@ export const handleDebugSessionAddNote = async (
   opts: DebugSessionAddNoteOpts,
 ): Promise<void> => {
   const sessionId = resolveSessionId(opts.sessionId);
-  // failOnNotFound: a CLI exit 0 must mean the note actually landed.
+  // failOnNotFound: exit 0 must mean the note actually landed.
   const blockId = await client.rolloutSessions.addBlock({
     sessionId,
     type: "text",
@@ -119,9 +98,8 @@ const renderBlock = (block: SessionBlock): string | null => {
       return text || null;
     }
     case "command": {
-      // One digest line per recorded command: what ran + how it exited (+ the
-      // agent's thinking, when supplied). Full stdout/stderr stay in `--json` —
-      // dumping them here would bury the chronology under command output.
+      // One digest line per command: what ran + how it exited (+ thinking, when
+      // supplied). Full stdout/stderr stay in `--json`.
       const command = typeof content.command === "string" ? content.command : "";
       if (!command) return null;
       const args = Array.isArray(content.args)
@@ -142,15 +120,8 @@ const renderBlock = (block: SessionBlock): string | null => {
 
 /**
  * Print a chronological digest of a debug session: every block (trace /
- * evaluation / text note) on the session, oldest first — the same data the
- * debugger UI renders.
- *
- * The target session is the optional `--session-id` flag; when omitted the
- * session comes from `.lmnr/debug-session.json` (see `resolveSessionId`).
- *
- * Pure handler: the command wrapper (`withProjectClient`) resolves a user-token
- * {@link LaminarClient} (routes to `/v1/cli/*` with the resolved project) and
- * owns the error envelope.
+ * evaluation / text note), oldest first. Session id defaults from
+ * `.lmnr/debug-session.json` when `--session-id` is omitted.
  */
 export const handleDebugSessionSummary = async (
   client: LaminarClient,
@@ -158,8 +129,7 @@ export const handleDebugSessionSummary = async (
 ): Promise<void> => {
   const sessionId = resolveSessionId(opts.sessionId);
   const blocks = await client.rolloutSessions.listBlocks({ sessionId });
-  // Sort oldest-first defensively — the backend returns creation order, but the
-  // summary's contract is chronological regardless.
+  // Sort oldest-first defensively; the summary's contract is chronological.
   const ordered = [...blocks].sort((a, b) =>
     String(a.createdAt).localeCompare(String(b.createdAt)),
   );
@@ -180,10 +150,7 @@ export const handleDebugSessionSummary = async (
   console.log(rendered.join("\n\n"));
 };
 
-/**
- * Build the frontend debugger-session URL. The frontend URL is its own env var
- * (LMNR_FRONTEND_URL) with a cloud default; self-host/local sets it explicitly.
- */
+/** Build the frontend debugger-session URL (LMNR_FRONTEND_URL, else cloud default). */
 const buildDebuggerUrl = (projectId: string, sessionId: string): string => {
   const frontend =
     process.env.LMNR_FRONTEND_URL?.trim().replace(/\/+$/, "") || DEFAULT_FRONTEND_URL;
@@ -191,17 +158,12 @@ const buildDebuggerUrl = (projectId: string, sessionId: string): string => {
 };
 
 /**
- * Open a debug session's debugger page in the browser.
+ * Open a debug session's debugger page in the browser. The URL is the file's
+ * stored `debugger_url` when it matches the resolved session, else it is rebuilt
+ * from the resolved project + LMNR_FRONTEND_URL. Session id defaults from
+ * `.lmnr/debug-session.json` when `--session-id` is omitted.
  *
- * The target session is the optional `--session-id` flag; when omitted the
- * session comes from `.lmnr/debug-session.json` (see `resolveSessionId`).
- * The URL is the file's stored `debugger_url` when it belongs to the resolved
- * session, else it is rebuilt from the resolved project (`--project-id` or the
- * linked `.lmnr/project.json`) + LMNR_FRONTEND_URL.
- *
- * Local-only handler (registered via `withLocalOpts`, NOT `withProjectClient`):
- * everything needed lives on disk, so no auth resolution / API call — `open`
- * works offline and before login.
+ * Local-only: everything lives on disk, so `open` works offline and before login.
  */
 export const handleDebugSessionOpen = async (
   opts: DebugSessionScopedOpts,
@@ -242,21 +204,12 @@ export interface DebugSessionNewOpts extends GlobalOpts {
 }
 
 /**
- * Mint a fresh debug session and reset `.lmnr/debug-session.json` to it.
+ * Mint a fresh debug session and reset `.lmnr/debug-session.json` to it. The next
+ * `LMNR_DEBUG=1 <run>` reads that file and rejoins the session silently.
  *
- * The next `LMNR_DEBUG=1 <run>` in this directory reads that file and rejoins the
- * minted session silently (no browser) — "new session" is owned by this command;
- * the SDK only mints when no file exists.
- *
- * Ordering matters: the local file is written FIRST (so the minted session is
- * usable for `LMNR_DEBUG=1` continuation even if the network is down / the
- * backend endpoint isn't deployed yet), THEN the session is best-effort
- * registered with the backend. A registration failure WARNS but does not fail
- * the command (exit 0) — the file is already written.
- *
- * Pure handler: the command wrapper (`withProjectClient`) resolves a user-token
- * {@link LaminarClient} (routes `register()` to `POST /v1/cli/rollouts/{id}` with
- * the resolved project) and owns the error envelope.
+ * Ordering matters: the local file is written FIRST (so the session is usable
+ * even if the backend is unreachable), THEN best-effort registered. A
+ * registration failure warns but does not fail the command (exit 0).
  */
 export const handleDebugSessionNew = async (
   client: LaminarClient,
@@ -264,14 +217,12 @@ export const handleDebugSessionNew = async (
 ): Promise<void> => {
   const sessionId = randomUUID();
 
-  // The session file is project-scoped: reset the NEAREST existing
-  // .lmnr/debug-session.json (walking up from cwd) rather than shadowing it
-  // with a nested copy; only when none exists anywhere up the tree is a fresh
-  // one created in cwd. Resolved once — both writes must hit the same file.
+  // Project-scoped: reset the nearest existing .lmnr/debug-session.json (walking
+  // up from cwd), only creating one in cwd if none exists up the tree. Resolved
+  // once — both writes must hit the same file.
   const sessionDir = resolveDebugSessionDir();
 
-  // 1. Write the file FIRST (nulls for trace/replay/cache, fresh started_at).
-  // The debugger_url is filled in once we learn the project id from register().
+  // 1. Write the file FIRST. debugger_url is filled in after register().
   writeDebugSessionFile({
     session_id: sessionId,
     trace_id: null,
@@ -281,9 +232,8 @@ export const handleDebugSessionNew = async (
     started_at: new Date().toISOString(),
   }, sessionDir);
 
-  // 2. Best-effort register. Routes to POST /v1/cli/rollouts/{id} (userToken
-  // auth). A failure (endpoint missing / offline) warns but never fails — the
-  // file is already usable for continuation.
+  // 2. Best-effort register. A failure warns but never fails — the file is
+  // already usable for continuation.
   let projectId: string | null = null;
   try {
     projectId = await client.rolloutSessions.register({ sessionId });
@@ -294,8 +244,7 @@ export const handleDebugSessionNew = async (
     );
   }
 
-  // 3. Build the per-session debugger URL once the project id is known and
-  // rewrite the file with it filled in.
+  // 3. Once the project id is known, rewrite the file with the debugger URL.
   const debuggerUrl = projectId ? buildDebuggerUrl(projectId, sessionId) : null;
   if (debuggerUrl) {
     writeDebugSessionFile({

--- a/packages/lmnr-cli/src/commands/debug/index.ts
+++ b/packages/lmnr-cli/src/commands/debug/index.ts
@@ -120,7 +120,7 @@ const renderBlock = (block: SessionBlock): string | null => {
     }
     case "command": {
       // One digest line per recorded command: what ran + how it exited (+ the
-      // agent's reasoning, when supplied). Full stdout/stderr stay in `--json` —
+      // agent's thinking, when supplied). Full stdout/stderr stay in `--json` —
       // dumping them here would bury the chronology under command output.
       const command = typeof content.command === "string" ? content.command : "";
       if (!command) return null;
@@ -128,12 +128,12 @@ const renderBlock = (block: SessionBlock): string | null => {
         ? content.args.map((a) => (typeof a === "string" ? a : String(a)))
         : [];
       const exitCode = typeof content.exitCode === "number" ? content.exitCode : 0;
-      const reasoning =
-        typeof content.reasoning === "string" && content.reasoning
-          ? ` reasoning="${content.reasoning}"`
+      const thinking =
+        typeof content.thinking === "string" && content.thinking
+          ? ` thinking="${content.thinking}"`
           : "";
       const invocation = args.length ? `${command} ${args.join(" ")}` : command;
-      return `<command exitCode="${exitCode}"${reasoning}>${invocation}</command>`;
+      return `<command exitCode="${exitCode}"${thinking}>${invocation}</command>`;
     }
     default:
       return null;

--- a/packages/lmnr-cli/src/commands/debug/index.ts
+++ b/packages/lmnr-cli/src/commands/debug/index.ts
@@ -80,6 +80,16 @@ export const handleDebugSessionAddNote = async (
   logger.info(`Added note to session ${sessionId}.`);
 };
 
+// Escape the five XML entities so user-controlled reasoning / invocation text
+// can't break the `<command …>` digest that agents and reviewers parse.
+const escapeXml = (s: string): string =>
+  s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+
 /** Render one session block into the summary's text form. */
 const renderBlock = (block: SessionBlock): string | null => {
   const content = block.content ?? {};
@@ -108,10 +118,10 @@ const renderBlock = (block: SessionBlock): string | null => {
       const exitCode = typeof content.exitCode === "number" ? content.exitCode : 0;
       const reasoning =
         typeof content.reasoning === "string" && content.reasoning
-          ? ` reasoning="${content.reasoning}"`
+          ? ` reasoning="${escapeXml(content.reasoning)}"`
           : "";
       const invocation = args.length ? `${command} ${args.join(" ")}` : command;
-      return `<command exitCode="${exitCode}"${reasoning}>${invocation}</command>`;
+      return `<command exitCode="${exitCode}"${reasoning}>${escapeXml(invocation)}</command>`;
     }
     default:
       return null;

--- a/packages/lmnr-cli/src/commands/debug/index.ts
+++ b/packages/lmnr-cli/src/commands/debug/index.ts
@@ -118,6 +118,23 @@ const renderBlock = (block: SessionBlock): string | null => {
       const text = typeof content.text === "string" ? content.text : "";
       return text || null;
     }
+    case "command": {
+      // One digest line per recorded command: what ran + how it exited (+ the
+      // agent's reasoning, when supplied). Full stdout/stderr stay in `--json` —
+      // dumping them here would bury the chronology under command output.
+      const command = typeof content.command === "string" ? content.command : "";
+      if (!command) return null;
+      const args = Array.isArray(content.args)
+        ? content.args.map((a) => (typeof a === "string" ? a : String(a)))
+        : [];
+      const exitCode = typeof content.exitCode === "number" ? content.exitCode : 0;
+      const reasoning =
+        typeof content.reasoning === "string" && content.reasoning
+          ? ` reasoning="${content.reasoning}"`
+          : "";
+      const invocation = args.length ? `${command} ${args.join(" ")}` : command;
+      return `<command exitCode="${exitCode}"${reasoning}>${invocation}</command>`;
+    }
     default:
       return null;
   }

--- a/packages/lmnr-cli/src/commands/debug/index.ts
+++ b/packages/lmnr-cli/src/commands/debug/index.ts
@@ -98,7 +98,7 @@ const renderBlock = (block: SessionBlock): string | null => {
       return text || null;
     }
     case "command": {
-      // One digest line per command: what ran + how it exited (+ thinking, when
+      // One digest line per command: what ran + how it exited (+ reasoning, when
       // supplied). Full stdout/stderr stay in `--json`.
       const command = typeof content.command === "string" ? content.command : "";
       if (!command) return null;
@@ -106,12 +106,12 @@ const renderBlock = (block: SessionBlock): string | null => {
         ? content.args.map((a) => (typeof a === "string" ? a : String(a)))
         : [];
       const exitCode = typeof content.exitCode === "number" ? content.exitCode : 0;
-      const thinking =
-        typeof content.thinking === "string" && content.thinking
-          ? ` thinking="${content.thinking}"`
+      const reasoning =
+        typeof content.reasoning === "string" && content.reasoning
+          ? ` reasoning="${content.reasoning}"`
           : "";
       const invocation = args.length ? `${command} ${args.join(" ")}` : command;
-      return `<command exitCode="${exitCode}"${thinking}>${invocation}</command>`;
+      return `<command exitCode="${exitCode}"${reasoning}>${invocation}</command>`;
     }
     default:
       return null;

--- a/packages/lmnr-cli/src/commands/plugin/index.ts
+++ b/packages/lmnr-cli/src/commands/plugin/index.ts
@@ -15,6 +15,7 @@ import { SessionExpiredError } from "../../auth/resolve";
 import { DEFAULT_BASE_URL, DEFAULT_FRONTEND_URL } from "../../constants";
 import {
   configWriteFailed,
+  EXIT_INSTALL_FAILED,
   failWith,
   listProjectsFailed,
   loginFailed,
@@ -31,12 +32,6 @@ import { emitError } from "../../utils/output";
 import { listProjects, promptProjectChoice } from "../../utils/projects";
 import { firstNonEmpty } from "../../utils/text";
 import { handleLogin } from "../login";
-
-// The onboarding exit-code contract now lives in ../../errors (one factory per
-// code). The install failure is the one site that stays a manual exit — in
-// --json it emits a bespoke full result payload (see makeResult) that failWith's
-// generic `{error, detail}` envelope can't carry — so its code (14) is kept here.
-const EXIT_INSTALL_FAILED = 14;
 
 /**
  * Registry of agents `plugin add <agent>` can wire up, keyed by the CLI argument

--- a/packages/lmnr-cli/src/commands/plugin/index.ts
+++ b/packages/lmnr-cli/src/commands/plugin/index.ts
@@ -12,30 +12,29 @@ import { version } from "../../../package.json";
 import { mintProjectApiKey } from "../../auth/api-key";
 import { type Credentials, globalLmnrDirectory, safeReadCredentials } from "../../auth/credentials";
 import { DEFAULT_BASE_URL, DEFAULT_FRONTEND_URL } from "../../constants";
+import {
+  configWriteFailed,
+  failWith,
+  listProjectsFailed,
+  loginFailed,
+  mintFailed,
+  noAccess,
+  noProject,
+  projectAmbiguous,
+  unsupportedAgent,
+} from "../../errors";
 import { orange, pc } from "../../utils/colors";
+// emitError is still used by the one bespoke install-failure site (below), which
+// emits a full result JSON rather than the generic failWith envelope.
 import { emitError } from "../../utils/output";
 import { listProjects, promptProjectChoice } from "../../utils/projects";
 import { firstNonEmpty } from "../../utils/text";
 import { handleLogin } from "../login";
 
-// Exit codes (machine-readable; distinct so automation can branch on the mode):
-//   4  no_access          — user lacks access to the requested --project-id
-//   6  login_failed       — device-flow login failed / no creds after login
-//   7  no_project         — no project to select, or (as `project_ambiguous`)
-//                            more than one matched in --json mode
-
-//   8  config_write_failed — minted a key but couldn't write the plugin config file
-//   9  mint_failed        — POST /api/cli/api-key failed
-//   10 list_projects_failed — GET /v1/cli/projects (discovery) failed
-//   13 unsupported_agent  — unknown <agent> argument
-//   14 install_failed     — a host `plugin` command exited non-zero
-const EXIT_NO_ACCESS = 4;
-const EXIT_LOGIN_FAILED = 6;
-const EXIT_NO_PROJECT = 7;
-const EXIT_CONFIG_WRITE_FAILED = 8;
-const EXIT_MINT_FAILED = 9;
-const EXIT_LIST_PROJECTS_FAILED = 10;
-const EXIT_UNSUPPORTED_AGENT = 13;
+// The onboarding exit-code contract now lives in ../../errors (one factory per
+// code). The install failure is the one site that stays a manual exit — in
+// --json it emits a bespoke full result payload (see makeResult) that failWith's
+// generic `{error, detail}` envelope can't carry — so its code (14) is kept here.
 const EXIT_INSTALL_FAILED = 14;
 
 /**
@@ -131,12 +130,10 @@ export const handlePluginAdd = async (agent: string, options: PluginAddOptions):
   const isJson = options.json === true;
   const spec = AGENTS[agent];
   if (!spec) {
-    emitError(
+    failWith(
       isJson,
-      "unsupported_agent",
-      `Unknown agent "${agent}". Supported: ${Object.keys(AGENTS).join(", ")}.`,
+      unsupportedAgent(`Unknown agent "${agent}". Supported: ${Object.keys(AGENTS).join(", ")}.`),
     );
-    process.exit(EXIT_UNSUPPORTED_AGENT);
   }
 
   const frontendUrl = firstNonEmpty(
@@ -159,14 +156,12 @@ export const handlePluginAdd = async (agent: string, options: PluginAddOptions):
     try {
       login = await handleLogin({ frontendUrl, noBrowser: options.browser === false });
     } catch (err) {
-      emitError(isJson, "login_failed", errorMessage(err));
-      process.exit(EXIT_LOGIN_FAILED);
+      failWith(isJson, loginFailed(errorMessage(err)));
     }
     loginProjectId = login.projectId;
     creds = await safeReadCredentials();
     if (!creds) {
-      emitError(isJson, "login_failed", "credentials missing after login");
-      process.exit(EXIT_LOGIN_FAILED);
+      failWith(isJson, loginFailed("credentials missing after login"));
     }
   }
 
@@ -191,8 +186,7 @@ export const handlePluginAdd = async (agent: string, options: PluginAddOptions):
   try {
     key = await mintProjectApiKey(issuer, creds.sessionToken, project.id, keyName);
   } catch (err) {
-    emitError(isJson, "mint_failed", errorMessage(err));
-    process.exit(EXIT_MINT_FAILED);
+    failWith(isJson, mintFailed(errorMessage(err)));
   }
   if (!isJson) {
     process.stderr.write(`${pc.green("✓")} Minted a project API key named "${pc.bold(keyName)}"\n`);
@@ -203,8 +197,7 @@ export const handlePluginAdd = async (agent: string, options: PluginAddOptions):
   try {
     configPath = writeAgentConfig(spec, key.apiKey, baseUrl);
   } catch (err) {
-    emitError(isJson, "config_write_failed", errorMessage(err));
-    process.exit(EXIT_CONFIG_WRITE_FAILED);
+    failWith(isJson, configWriteFailed(errorMessage(err)));
   }
   if (!isJson) {
     process.stderr.write(`${pc.green("✓")} Wrote ${configPath}\n`);
@@ -300,20 +293,19 @@ const resolveProject = async (
   try {
     projects = await listProjects(creds, baseUrl);
   } catch (err) {
-    emitError(isJson, "list_projects_failed", errorMessage(err));
-    process.exit(EXIT_LIST_PROJECTS_FAILED);
+    failWith(isJson, listProjectsFailed(errorMessage(err)));
   }
 
   if (options.projectId) {
     const match = projects.find((p) => p.id === options.projectId);
     if (!match) {
-      emitError(
+      failWith(
         isJson,
-        "no_access",
-        `You don't have access to project ${options.projectId}. Accessible: ` +
-          projects.map((p) => `${p.id} (${p.workspaceName}/${p.name})`).join(", "),
+        noAccess(
+          `You don't have access to project ${options.projectId}. Accessible: ` +
+            projects.map((p) => `${p.id} (${p.workspaceName}/${p.name})`).join(", "),
+        ),
       );
-      process.exit(EXIT_NO_ACCESS);
     }
     return match;
   }
@@ -327,24 +319,24 @@ const resolveProject = async (
   }
 
   if (projects.length === 0) {
-    emitError(
+    failWith(
       isJson,
-      "no_project",
-      `No projects found. Create one in the dashboard, then re-run \`lmnr-cli plugin add\`.`,
+      noProject(
+        `No projects found. Create one in the dashboard, then re-run \`lmnr-cli plugin add\`.`,
+      ),
     );
-    process.exit(EXIT_NO_PROJECT);
   }
   if (projects.length === 1) {
     return projects[0];
   }
   if (isJson) {
-    emitError(
+    failWith(
       isJson,
-      "project_ambiguous",
-      `Multiple projects: pass --project-id <id>. ` +
-        projects.map((p) => `${p.id} (${p.workspaceName}/${p.name})`).join(", "),
+      projectAmbiguous(
+        `Multiple projects: pass --project-id <id>. ` +
+          projects.map((p) => `${p.id} (${p.workspaceName}/${p.name})`).join(", "),
+      ),
     );
-    process.exit(EXIT_NO_PROJECT);
   }
   return promptProjectChoice(
     projects,

--- a/packages/lmnr-cli/src/commands/plugin/index.ts
+++ b/packages/lmnr-cli/src/commands/plugin/index.ts
@@ -11,6 +11,7 @@ import spawn from "cross-spawn";
 import { version } from "../../../package.json";
 import { mintProjectApiKey } from "../../auth/api-key";
 import { type Credentials, globalLmnrDirectory, safeReadCredentials } from "../../auth/credentials";
+import { SessionExpiredError } from "../../auth/resolve";
 import { DEFAULT_BASE_URL, DEFAULT_FRONTEND_URL } from "../../constants";
 import {
   configWriteFailed,
@@ -293,6 +294,11 @@ const resolveProject = async (
   try {
     projects = await listProjects(creds, baseUrl);
   } catch (err) {
+    // An expired grant surfaces here via listProjects → refreshIfNeeded. Map it
+    // to login_failed (6), like setup / project link — not a discovery failure.
+    if (err instanceof SessionExpiredError) {
+      failWith(isJson, loginFailed("Session expired. Run `lmnr-cli login` first."));
+    }
     failWith(isJson, listProjectsFailed(errorMessage(err)));
   }
 

--- a/packages/lmnr-cli/src/commands/project/link-core.test.ts
+++ b/packages/lmnr-cli/src/commands/project/link-core.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const h = vi.hoisted(() => ({ refreshIfNeeded: vi.fn() }));
+
+// Keep the real SessionExpiredError (so `instanceof` works); stub only the probe
+// so refreshIfNeeded throws before any network call.
+vi.mock("../../auth/resolve", async (orig) => {
+  const actual = await orig<typeof import("../../auth/resolve")>();
+  return { ...actual, refreshIfNeeded: h.refreshIfNeeded };
+});
+
+import { SessionExpiredError } from "../../auth/resolve";
+import { ensureProjectKey } from "./link-core";
+
+const CREDS = {
+  issuer: "https://laminar.sh",
+  sessionToken: "sess",
+  accessToken: "jwt",
+} as unknown as Parameters<typeof ensureProjectKey>[0]["creds"];
+
+class ExitError extends Error {
+  constructor(public code: number) {
+    super(`exit ${code}`);
+  }
+}
+
+let exitSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+    throw new ExitError(code ?? 0);
+  }) as never);
+  vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+  vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("ensureProjectKey — session expiry during the key probe", () => {
+  it("maps an expired grant to login_failed (6), not an uncoded exit 1", async () => {
+    // The existing-key probe calls refreshIfNeeded, which reports expiry.
+    h.refreshIfNeeded.mockRejectedValue(new SessionExpiredError("Session expired"));
+
+    await expect(
+      ensureProjectKey({
+        creds: CREDS,
+        link: { projectId: "p1" },
+        existingKey: { value: "lmnr-old", source: { type: "process-env" } },
+        cwd: "/repo",
+        issuer: "https://laminar.sh",
+        userBaseUrl: "https://api.lmnr.ai",
+        writeEnv: false,
+        isJson: true,
+      }),
+    ).rejects.toMatchObject({ code: 6 });
+    expect(exitSpy).toHaveBeenCalledWith(6);
+  });
+});

--- a/packages/lmnr-cli/src/commands/project/link-core.ts
+++ b/packages/lmnr-cli/src/commands/project/link-core.ts
@@ -1,0 +1,232 @@
+import { hostname } from "node:os";
+import { relative } from "node:path";
+
+import { LaminarClient, type ProjectKeyProbe } from "@lmnr-ai/client";
+import { errorMessage } from "@lmnr-ai/types";
+
+import { type MintedApiKey, mintProjectApiKey } from "../../auth/api-key";
+import { type Credentials } from "../../auth/credentials";
+import { envHttpPort, refreshIfNeeded } from "../../auth/resolve";
+import { pc } from "../../utils/colors";
+import {
+  type EnvKeyLocation,
+  isPathGitIgnored,
+  resolveEnvWriteTarget,
+  writeEnvFile,
+} from "../../utils/env-file";
+import { type LocalProjectFile } from "../../utils/local-project-file";
+import { emitError } from "../../utils/output";
+
+/**
+ * Onboarding exit codes (machine-readable contract — each distinct so
+ * automation can branch on the failure mode). Shared by `setup` and
+ * `project link` so both commands report identical codes for the same failures.
+ *
+ *   4  no_access            — user lacks access to the target project
+ *   6  login_failed         — device-flow login failed / no creds after login
+ *   7  no_project           — no project to select (and none could be created)
+ *   8  env_write_failed     — minted a key but couldn't write ./.env
+ *   9  setup_key_failed     — POST /api/cli/api-key failed
+ *   10 list_projects_failed — GET /v1/cli/projects (discovery) failed
+ *   11 key_probe_failed     — couldn't verify the existing key (network/server)
+ *   12 key_mismatch         — existing key belongs to a different project
+ */
+export const EXIT_NO_ACCESS = 4;
+export const EXIT_LOGIN_FAILED = 6;
+export const EXIT_NO_PROJECT = 7;
+export const EXIT_ENV_WRITE_FAILED = 8;
+export const EXIT_SETUP_KEY_FAILED = 9;
+export const EXIT_LIST_PROJECTS_FAILED = 10;
+export const EXIT_KEY_PROBE_FAILED = 11;
+export const EXIT_KEY_MISMATCH = 12;
+
+/**
+ * Resolve which project an existing project API key belongs to, via the
+ * user-token CLI endpoint (`POST /v1/cli/project`, key in body). By this point
+ * the CLI is already logged in, so we authenticate as the user (JWT bearer)
+ * rather than re-deriving auth from the project key itself. The server also
+ * confirms the user is a member of the resolved project.
+ */
+export async function probeProjectKey(
+  creds: Credentials,
+  apiKey: string,
+  baseUrl: string,
+): Promise<ProjectKeyProbe> {
+  const updated = await refreshIfNeeded(creds);
+  const client = new LaminarClient({
+    baseUrl,
+    port: envHttpPort(),
+    auth: { type: "userToken", token: updated.accessToken, projectId: "" },
+  });
+  return client.cli.resolveProjectByApiKey(apiKey);
+}
+
+/** Outcome of {@link ensureProjectKey}: what (if anything) was minted / written. */
+export interface EnsureKeyResult {
+  /** The key written to .env, or null when an existing matching key was reused. */
+  apiKey: string | null;
+  /** The .env(.local) path written, or null when nothing was written. */
+  envFileUpdated: string | null;
+  /** Full mint metadata when a key was minted, else null. */
+  keyMeta: MintedApiKey | null;
+  /**
+   * When `onKeyMismatch: "warn"` and the existing key belongs to a DIFFERENT
+   * project: that project's id (so the caller can surface it in `--json`). Null
+   * otherwise. Only ever set on the "warn" path — "fail" exits instead.
+   */
+  mismatchProjectId: string | null;
+}
+
+/**
+ * Ensure a usable Project API Key for the directory-linked project (SPEC 36-42),
+ * the shared key-handling primitive for `setup` and `project link`:
+ *  - probe an existing `LMNR_PROJECT_API_KEY` (process.env → .env.local → .env),
+ *  - reuse it untouched when it already points at THIS project,
+ *  - refuse to clobber a valid key that belongs to a DIFFERENT project,
+ *  - abort (don't mint) when the key can't be verified (network/server blip),
+ *  - otherwise mint a fresh key and (when `writeEnv`) write it to .env(.local).
+ *
+ * `link` is mutated in place to backfill display details learned while minting.
+ * On a hard failure it emits a coded error and exits — the SAME exit codes for
+ * both callers. Returns what was minted/written on success.
+ *
+ * `onKeyMismatch` controls the one place the two callers differ: a valid key
+ * that belongs to a DIFFERENT project. `"fail"` (default, `setup`) refuses to
+ * clobber and exits `key_mismatch` (12). `"warn"` (`project link`) instead warns
+ * and returns — the user asked to re-point here, so we let the re-link proceed
+ * and point them at `lmnr-cli project mint-key` to replace the stale key themselves.
+ */
+export async function ensureProjectKey(params: {
+  creds: Credentials;
+  link: LocalProjectFile;
+  existingKey: EnvKeyLocation | null;
+  cwd: string;
+  issuer: string;
+  userBaseUrl: string;
+  writeEnv: boolean;
+  isJson: boolean;
+  onKeyMismatch?: "fail" | "warn";
+}): Promise<EnsureKeyResult> {
+  const { creds, link, existingKey, cwd, issuer, userBaseUrl, writeEnv, isJson } = params;
+  const onKeyMismatch = params.onKeyMismatch ?? "fail";
+
+  let apiKey: string | null = null;
+  let envFileUpdated: string | null = null;
+  let keyMeta: MintedApiKey | null = null;
+  let mismatchProjectId: string | null = null;
+
+  let needMint = true;
+  if (existingKey) {
+    const probe = await probeProjectKey(creds, existingKey.value, userBaseUrl);
+    const where =
+      existingKey.source.type === "process-env"
+        ? "your environment"
+        : relative(cwd, existingKey.source.path);
+
+    if (probe.status === "unverifiable") {
+      // Couldn't verify the key (network/server error). Do NOT mint — that would
+      // clobber a possibly-valid key on a transient blip. Abort so the user retries.
+      emitError(
+        isJson,
+        "key_probe_failed",
+        `Couldn't verify the existing Project API Key in ${where} (network or server error). ` +
+        "Check your connection and re-run.",
+      );
+      process.exit(EXIT_KEY_PROBE_FAILED);
+    } else if (probe.status === "ok" && probe.projectId === link.projectId) {
+      // Already configured for this project. Respect the user's setup: no mint,
+      // no write (option a) — including when the key only lives in process.env.
+      needMint = false;
+      if (!isJson) {
+        process.stderr.write(`${pc.green("✓")} Project API Key already set in ${where}\n`);
+      }
+    } else if (probe.status === "ok" && onKeyMismatch === "warn") {
+      // Valid key for a DIFFERENT project, but the caller (`project link`) asked
+      // to re-point here anyway. Don't clobber the key — warn and let the re-link
+      // proceed; the user replaces the key themselves via `lmnr-cli project mint-key`.
+      needMint = false;
+      mismatchProjectId = probe.projectId;
+      if (!isJson) {
+        process.stderr.write(
+          `${pc.yellow("⚠")} The Project API Key in ${where} belongs to a different ` +
+          `project (${probe.projectId}), not the one you're linking here (${link.projectId}). ` +
+          `Mint one for this project with \`lmnr-cli project mint-key\` and replace it ` +
+          `in ${where}.\n`,
+        );
+      }
+    } else if (probe.status === "ok") {
+      // Valid key, but for a DIFFERENT project. Refuse to clobber it — abort so the
+      // user resolves the conflict deliberately rather than silently overwriting.
+      emitError(
+        isJson,
+        "key_mismatch",
+        `The Project API Key in ${where} belongs to a different project (${probe.projectId}), ` +
+        `not the one linked here (${link.projectId}). Remove or update it, then re-run.`,
+      );
+      process.exit(EXIT_KEY_MISMATCH);
+    } else if (!isJson) {
+      // invalid / revoked (401) — minting a fresh key is the correct recovery.
+      process.stderr.write(
+        `${pc.yellow("⚠")} Existing Project API Key in ${where} is invalid or revoked, ` +
+        `minting a new one\n`,
+      );
+    }
+  }
+
+  if (needMint) {
+    try {
+      keyMeta = await mintProjectApiKey(issuer, creds.sessionToken, link.projectId, hostname());
+    } catch (err) {
+      emitError(isJson, "setup_key_failed", errorMessage(err));
+      process.exit(EXIT_SETUP_KEY_FAILED);
+    }
+    apiKey = keyMeta.apiKey;
+
+    // Backfill display details onto the link if we learned them while minting.
+    if (!link.projectName && keyMeta.projectName) link.projectName = keyMeta.projectName;
+    if (!link.workspaceName && keyMeta.workspaceName) link.workspaceName = keyMeta.workspaceName;
+    if (!link.workspaceId && keyMeta.workspaceId) link.workspaceId = keyMeta.workspaceId;
+
+    if (writeEnv) {
+      const target = await resolveEnvWriteTarget(cwd, existingKey);
+      try {
+        const result = await writeEnvFile(target, apiKey);
+        envFileUpdated = result.path;
+        if (!isJson) {
+          const rel = relative(cwd, result.path);
+          const verb = result.created
+            ? "Created"
+            : result.replaced
+              ? "Updated LMNR_PROJECT_API_KEY in"
+              : "Added LMNR_PROJECT_API_KEY to";
+          process.stderr.write(`${pc.green("✓")} ${verb} ${rel}\n`);
+          // The key is a secret; nudge if it landed in a tracked file.
+          if ((await isPathGitIgnored(result.path)) === false) {
+            process.stderr.write(
+              `${pc.yellow("⚠")} ${rel} isn't gitignored; add it so the key isn't committed\n`,
+            );
+          }
+        }
+      } catch (err) {
+        process.stderr.write(
+          `\n${pc.red("ERROR")}: failed to write ${target}: ${errorMessage(err)}\n` +
+          pc.dim("Your API key (set it manually):") +
+          `\n  LMNR_PROJECT_API_KEY=${apiKey}\n\n`,
+        );
+        if (isJson) {
+          process.stdout.write(
+            JSON.stringify({
+              error: "env_write_failed",
+              apiKey,
+              projectId: link.projectId,
+              message: errorMessage(err),
+            }) + "\n",
+          );
+        }
+        process.exit(EXIT_ENV_WRITE_FAILED);
+      }
+    }
+  }
+
+  return { apiKey, envFileUpdated, keyMeta, mismatchProjectId };
+}

--- a/packages/lmnr-cli/src/commands/project/link-core.ts
+++ b/packages/lmnr-cli/src/commands/project/link-core.ts
@@ -17,18 +17,14 @@ import {
 } from "../../utils/env-file";
 import { type LocalProjectFile } from "../../utils/local-project-file";
 
-// The onboarding exit-code contract now lives in ../../errors (one factory per
-// code). The env-write failure is the one site that stays a manual exit — it
-// emits a bespoke JSON payload (the minted key + projectId) that `failWith`'s
-// generic `{error, detail}` envelope can't carry — so its code (8) is kept here.
+// Manual exit code because this path emits a bespoke JSON payload (minted key +
+// projectId) that `failWith`'s generic `{error, detail}` envelope can't carry.
 const EXIT_ENV_WRITE_FAILED = 8;
 
 /**
- * Resolve which project an existing project API key belongs to, via the
- * user-token CLI endpoint (`POST /v1/cli/project`, key in body). By this point
- * the CLI is already logged in, so we authenticate as the user (JWT bearer)
- * rather than re-deriving auth from the project key itself. The server also
- * confirms the user is a member of the resolved project.
+ * Resolve which project a project API key belongs to (`POST /v1/cli/project`).
+ * Auth is the user's JWT, not the project key — the server also checks the user
+ * is a member of the resolved project.
  */
 export async function probeProjectKey(
   creds: Credentials,
@@ -52,32 +48,21 @@ export interface EnsureKeyResult {
   envFileUpdated: string | null;
   /** Full mint metadata when a key was minted, else null. */
   keyMeta: MintedApiKey | null;
-  /**
-   * When `onKeyMismatch: "warn"` and the existing key belongs to a DIFFERENT
-   * project: that project's id (so the caller can surface it in `--json`). Null
-   * otherwise. Only ever set on the "warn" path — "fail" exits instead.
-   */
+  /** On the "warn" path, the different project's id (for `--json`); null otherwise. */
   mismatchProjectId: string | null;
 }
 
 /**
- * Ensure a usable Project API Key for the directory-linked project (SPEC 36-42),
- * the shared key-handling primitive for `setup` and `project link`:
- *  - probe an existing `LMNR_PROJECT_API_KEY` (process.env → .env.local → .env),
- *  - reuse it untouched when it already points at THIS project,
- *  - refuse to clobber a valid key that belongs to a DIFFERENT project,
- *  - abort (don't mint) when the key can't be verified (network/server blip),
- *  - otherwise mint a fresh key and (when `writeEnv`) write it to .env(.local).
+ * Ensure a usable Project API Key for the linked project — shared by `setup` and
+ * `project link`. Probes an existing `LMNR_PROJECT_API_KEY`, reuses it if it
+ * already points here, and otherwise mints (and writes, when `writeEnv`). Never
+ * clobbers a valid key for a different project, and aborts rather than minting
+ * when the key can't be verified (transient blip). `link` is mutated in place to
+ * backfill display details learned while minting.
  *
- * `link` is mutated in place to backfill display details learned while minting.
- * On a hard failure it emits a coded error and exits — the SAME exit codes for
- * both callers. Returns what was minted/written on success.
- *
- * `onKeyMismatch` controls the one place the two callers differ: a valid key
- * that belongs to a DIFFERENT project. `"fail"` (default, `setup`) refuses to
- * clobber and exits `key_mismatch` (12). `"warn"` (`project link`) instead warns
- * and returns — the user asked to re-point here, so we let the re-link proceed
- * and point them at `lmnr-cli project mint-key` to replace the stale key themselves.
+ * `onKeyMismatch` is the only caller difference: for a valid key on a DIFFERENT
+ * project, `"fail"` (setup) exits `key_mismatch`; `"warn"` (`project link`) warns
+ * and proceeds so the re-link goes through.
  */
 export async function ensureProjectKey(params: {
   creds: Credentials;
@@ -104,10 +89,8 @@ export async function ensureProjectKey(params: {
     try {
       probe = await probeProjectKey(creds, existingKey.value, userBaseUrl);
     } catch (err) {
-      // probeProjectKey → refreshIfNeeded can surface an expired grant here.
-      // Map it to login_failed (6) instead of letting it fall through to the
-      // top-level handler as an uncoded exit 1 — same 6-vs-10 contract the
-      // callers (setup / project link / mint-key) already follow.
+      // An expired grant from refreshIfNeeded maps to login_failed (6), not an
+      // uncoded exit 1 — same contract the callers follow.
       if (err instanceof SessionExpiredError) {
         failWith(isJson, loginFailed("Session expired. Run `lmnr-cli login` first."));
       }
@@ -119,8 +102,7 @@ export async function ensureProjectKey(params: {
         : relative(cwd, existingKey.source.path);
 
     if (probe.status === "unverifiable") {
-      // Couldn't verify the key (network/server error). Do NOT mint — that would
-      // clobber a possibly-valid key on a transient blip. Abort so the user retries.
+      // Couldn't verify the key — abort rather than mint over a possibly-valid key.
       failWith(
         isJson,
         keyProbeFailed(
@@ -129,16 +111,14 @@ export async function ensureProjectKey(params: {
         ),
       );
     } else if (probe.status === "ok" && probe.projectId === link.projectId) {
-      // Already configured for this project. Respect the user's setup: no mint,
-      // no write (option a) — including when the key only lives in process.env.
+      // Already set for this project — no mint, no write.
       needMint = false;
       if (!isJson) {
         process.stderr.write(`${pc.green("✓")} Project API Key already set in ${where}\n`);
       }
     } else if (probe.status === "ok" && onKeyMismatch === "warn") {
-      // Valid key for a DIFFERENT project, but the caller (`project link`) asked
-      // to re-point here anyway. Don't clobber the key — warn and let the re-link
-      // proceed; the user replaces the key themselves via `lmnr-cli project mint-key`.
+      // Valid key for a different project — warn instead of clobbering and let the
+      // re-link proceed; the user replaces it via `lmnr-cli project mint-key`.
       needMint = false;
       mismatchProjectId = probe.projectId;
       if (!isJson) {
@@ -150,8 +130,7 @@ export async function ensureProjectKey(params: {
         );
       }
     } else if (probe.status === "ok") {
-      // Valid key, but for a DIFFERENT project. Refuse to clobber it — abort so the
-      // user resolves the conflict deliberately rather than silently overwriting.
+      // Valid key for a different project — abort so the user resolves it deliberately.
       failWith(
         isJson,
         keyMismatch(
@@ -176,7 +155,7 @@ export async function ensureProjectKey(params: {
     }
     apiKey = keyMeta.apiKey;
 
-    // Backfill display details onto the link if we learned them while minting.
+    // Backfill display details learned while minting.
     if (!link.projectName && keyMeta.projectName) link.projectName = keyMeta.projectName;
     if (!link.workspaceName && keyMeta.workspaceName) link.workspaceName = keyMeta.workspaceName;
     if (!link.workspaceId && keyMeta.workspaceId) link.workspaceId = keyMeta.workspaceId;

--- a/packages/lmnr-cli/src/commands/project/link-core.ts
+++ b/packages/lmnr-cli/src/commands/project/link-core.ts
@@ -7,6 +7,7 @@ import { errorMessage } from "@lmnr-ai/types";
 import { type MintedApiKey, mintProjectApiKey } from "../../auth/api-key";
 import { type Credentials } from "../../auth/credentials";
 import { envHttpPort, refreshIfNeeded } from "../../auth/resolve";
+import { failWith, keyMismatch, keyProbeFailed, setupKeyFailed } from "../../errors";
 import { pc } from "../../utils/colors";
 import {
   type EnvKeyLocation,
@@ -15,30 +16,12 @@ import {
   writeEnvFile,
 } from "../../utils/env-file";
 import { type LocalProjectFile } from "../../utils/local-project-file";
-import { emitError } from "../../utils/output";
 
-/**
- * Onboarding exit codes (machine-readable contract — each distinct so
- * automation can branch on the failure mode). Shared by `setup` and
- * `project link` so both commands report identical codes for the same failures.
- *
- *   4  no_access            — user lacks access to the target project
- *   6  login_failed         — device-flow login failed / no creds after login
- *   7  no_project           — no project to select (and none could be created)
- *   8  env_write_failed     — minted a key but couldn't write ./.env
- *   9  setup_key_failed     — POST /api/cli/api-key failed
- *   10 list_projects_failed — GET /v1/cli/projects (discovery) failed
- *   11 key_probe_failed     — couldn't verify the existing key (network/server)
- *   12 key_mismatch         — existing key belongs to a different project
- */
-export const EXIT_NO_ACCESS = 4;
-export const EXIT_LOGIN_FAILED = 6;
-export const EXIT_NO_PROJECT = 7;
-export const EXIT_ENV_WRITE_FAILED = 8;
-export const EXIT_SETUP_KEY_FAILED = 9;
-export const EXIT_LIST_PROJECTS_FAILED = 10;
-export const EXIT_KEY_PROBE_FAILED = 11;
-export const EXIT_KEY_MISMATCH = 12;
+// The onboarding exit-code contract now lives in ../../errors (one factory per
+// code). The env-write failure is the one site that stays a manual exit — it
+// emits a bespoke JSON payload (the minted key + projectId) that `failWith`'s
+// generic `{error, detail}` envelope can't carry — so its code (8) is kept here.
+const EXIT_ENV_WRITE_FAILED = 8;
 
 /**
  * Resolve which project an existing project API key belongs to, via the
@@ -126,13 +109,13 @@ export async function ensureProjectKey(params: {
     if (probe.status === "unverifiable") {
       // Couldn't verify the key (network/server error). Do NOT mint — that would
       // clobber a possibly-valid key on a transient blip. Abort so the user retries.
-      emitError(
+      failWith(
         isJson,
-        "key_probe_failed",
-        `Couldn't verify the existing Project API Key in ${where} (network or server error). ` +
-        "Check your connection and re-run.",
+        keyProbeFailed(
+          `Couldn't verify the existing Project API Key in ${where} (network or server error). ` +
+          "Check your connection and re-run.",
+        ),
       );
-      process.exit(EXIT_KEY_PROBE_FAILED);
     } else if (probe.status === "ok" && probe.projectId === link.projectId) {
       // Already configured for this project. Respect the user's setup: no mint,
       // no write (option a) — including when the key only lives in process.env.
@@ -157,13 +140,13 @@ export async function ensureProjectKey(params: {
     } else if (probe.status === "ok") {
       // Valid key, but for a DIFFERENT project. Refuse to clobber it — abort so the
       // user resolves the conflict deliberately rather than silently overwriting.
-      emitError(
+      failWith(
         isJson,
-        "key_mismatch",
-        `The Project API Key in ${where} belongs to a different project (${probe.projectId}), ` +
-        `not the one linked here (${link.projectId}). Remove or update it, then re-run.`,
+        keyMismatch(
+          `The Project API Key in ${where} belongs to a different project (${probe.projectId}), ` +
+          `not the one linked here (${link.projectId}). Remove or update it, then re-run.`,
+        ),
       );
-      process.exit(EXIT_KEY_MISMATCH);
     } else if (!isJson) {
       // invalid / revoked (401) — minting a fresh key is the correct recovery.
       process.stderr.write(
@@ -177,8 +160,7 @@ export async function ensureProjectKey(params: {
     try {
       keyMeta = await mintProjectApiKey(issuer, creds.sessionToken, link.projectId, hostname());
     } catch (err) {
-      emitError(isJson, "setup_key_failed", errorMessage(err));
-      process.exit(EXIT_SETUP_KEY_FAILED);
+      failWith(isJson, setupKeyFailed(errorMessage(err)));
     }
     apiKey = keyMeta.apiKey;
 

--- a/packages/lmnr-cli/src/commands/project/link-core.ts
+++ b/packages/lmnr-cli/src/commands/project/link-core.ts
@@ -7,7 +7,14 @@ import { errorMessage } from "@lmnr-ai/types";
 import { type MintedApiKey, mintProjectApiKey } from "../../auth/api-key";
 import { type Credentials } from "../../auth/credentials";
 import { envHttpPort, refreshIfNeeded, SessionExpiredError } from "../../auth/resolve";
-import { failWith, keyMismatch, keyProbeFailed, loginFailed, setupKeyFailed } from "../../errors";
+import {
+  EXIT_ENV_WRITE_FAILED,
+  failWith,
+  keyMismatch,
+  keyProbeFailed,
+  loginFailed,
+  setupKeyFailed,
+} from "../../errors";
 import { pc } from "../../utils/colors";
 import {
   type EnvKeyLocation,
@@ -16,10 +23,6 @@ import {
   writeEnvFile,
 } from "../../utils/env-file";
 import { type LocalProjectFile } from "../../utils/local-project-file";
-
-// Manual exit code because this path emits a bespoke JSON payload (minted key +
-// projectId) that `failWith`'s generic `{error, detail}` envelope can't carry.
-const EXIT_ENV_WRITE_FAILED = 8;
 
 /**
  * Resolve which project a project API key belongs to (`POST /v1/cli/project`).

--- a/packages/lmnr-cli/src/commands/project/link-core.ts
+++ b/packages/lmnr-cli/src/commands/project/link-core.ts
@@ -6,8 +6,8 @@ import { errorMessage } from "@lmnr-ai/types";
 
 import { type MintedApiKey, mintProjectApiKey } from "../../auth/api-key";
 import { type Credentials } from "../../auth/credentials";
-import { envHttpPort, refreshIfNeeded } from "../../auth/resolve";
-import { failWith, keyMismatch, keyProbeFailed, setupKeyFailed } from "../../errors";
+import { envHttpPort, refreshIfNeeded, SessionExpiredError } from "../../auth/resolve";
+import { failWith, keyMismatch, keyProbeFailed, loginFailed, setupKeyFailed } from "../../errors";
 import { pc } from "../../utils/colors";
 import {
   type EnvKeyLocation,
@@ -100,7 +100,19 @@ export async function ensureProjectKey(params: {
 
   let needMint = true;
   if (existingKey) {
-    const probe = await probeProjectKey(creds, existingKey.value, userBaseUrl);
+    let probe: ProjectKeyProbe;
+    try {
+      probe = await probeProjectKey(creds, existingKey.value, userBaseUrl);
+    } catch (err) {
+      // probeProjectKey → refreshIfNeeded can surface an expired grant here.
+      // Map it to login_failed (6) instead of letting it fall through to the
+      // top-level handler as an uncoded exit 1 — same 6-vs-10 contract the
+      // callers (setup / project link / mint-key) already follow.
+      if (err instanceof SessionExpiredError) {
+        failWith(isJson, loginFailed("Session expired. Run `lmnr-cli login` first."));
+      }
+      throw err;
+    }
     const where =
       existingKey.source.type === "process-env"
         ? "your environment"

--- a/packages/lmnr-cli/src/commands/project/link.test.ts
+++ b/packages/lmnr-cli/src/commands/project/link.test.ts
@@ -1,0 +1,151 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const h = vi.hoisted(() => ({
+  safeReadCredentials: vi.fn(),
+  listProjects: vi.fn(),
+  promptProjectChoice: vi.fn(),
+  writeLocalProjectFile: vi.fn(),
+  findEnvKey: vi.fn(),
+  ensureProjectKey: vi.fn(),
+}));
+
+vi.mock("../../auth/credentials", () => ({ safeReadCredentials: h.safeReadCredentials }));
+vi.mock("../../utils/projects", () => ({
+  listProjects: h.listProjects,
+  promptProjectChoice: h.promptProjectChoice,
+}));
+vi.mock("../../utils/local-project-file", () => ({
+  writeLocalProjectFile: h.writeLocalProjectFile,
+}));
+vi.mock("../../utils/env-file", () => ({ findEnvKey: h.findEnvKey }));
+// Keep the real EXIT_* constants; only stub the key-handling primitive.
+vi.mock("./link-core", async (importActual) => {
+  const actual = await importActual<typeof import("./link-core")>();
+  return { ...actual, ensureProjectKey: h.ensureProjectKey };
+});
+
+import { handleProjectLink } from "./link";
+
+const CREDS = { issuer: "https://laminar.sh", sessionToken: "s", userEmail: "u@x.io" };
+const PROJECTS = [
+  { id: "p1", name: "Alpha", workspaceId: "w1", workspaceName: "Acme" },
+  { id: "p2", name: "Beta", workspaceId: "w1", workspaceName: "Acme" },
+];
+
+let exitSpy: ReturnType<typeof vi.spyOn>;
+let stdoutSpy: ReturnType<typeof vi.spyOn>;
+
+// process.exit is a hard failure in these flows — make it throw a tagged error
+// so tests can assert the exit code without the process actually dying.
+class ExitError extends Error {
+  constructor(public code: number) {
+    super(`exit ${code}`);
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+    throw new ExitError(code ?? 0);
+  }) as never);
+  stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+  vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+  h.safeReadCredentials.mockResolvedValue(CREDS);
+  h.listProjects.mockResolvedValue(PROJECTS);
+  h.writeLocalProjectFile.mockResolvedValue("/repo/.lmnr/project.json");
+  h.findEnvKey.mockResolvedValue(null);
+  h.ensureProjectKey.mockResolvedValue({
+    apiKey: "lmnr-new",
+    envFileUpdated: "/repo/.env",
+    keyMeta: null,
+    mismatchProjectId: null,
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("handleProjectLink", () => {
+  it("--project-id writes the link + ensures the key, emitting JSON", async () => {
+    await handleProjectLink({ projectId: "p2", json: true });
+
+    expect(h.writeLocalProjectFile).toHaveBeenCalledWith(
+      expect.objectContaining({ projectId: "p2", projectName: "Beta" }),
+    );
+    // The key handling ran against the newly-linked project, in warn-on-mismatch mode.
+    expect(h.ensureProjectKey).toHaveBeenCalledWith(
+      expect.objectContaining({
+        link: expect.objectContaining({ projectId: "p2" }),
+        onKeyMismatch: "warn",
+      }),
+    );
+    const out = stdoutSpy.mock.calls.map((c: unknown[]) => String(c[0])).join("");
+    expect(out).toContain('"projectId":"p2"');
+    expect(out).toContain('"apiKey":"lmnr-new"');
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it("still re-links (and surfaces the mismatch) when the key is for another project", async () => {
+    // ensureProjectKey warns instead of exiting; it reports the other project id.
+    h.ensureProjectKey.mockResolvedValue({
+      apiKey: null,
+      envFileUpdated: null,
+      keyMeta: null,
+      mismatchProjectId: "other-proj",
+    });
+
+    await handleProjectLink({ projectId: "p2", json: true });
+
+    // The re-link went through despite the mismatch...
+    expect(h.writeLocalProjectFile).toHaveBeenCalledWith(
+      expect.objectContaining({ projectId: "p2" }),
+    );
+    // ...and the mismatch is surfaced (not a hard failure).
+    expect(exitSpy).not.toHaveBeenCalled();
+    const out = stdoutSpy.mock.calls.map((c: unknown[]) => String(c[0])).join("");
+    expect(out).toContain('"keyMismatchProjectId":"other-proj"');
+  });
+
+  it("--project-id the user can't access exits no_access (4)", async () => {
+    await expect(handleProjectLink({ projectId: "nope", json: true })).rejects.toMatchObject({
+      code: 4,
+    });
+    expect(h.writeLocalProjectFile).not.toHaveBeenCalled();
+    expect(h.ensureProjectKey).not.toHaveBeenCalled();
+  });
+
+  it("no arg with a single accessible project auto-selects it", async () => {
+    h.listProjects.mockResolvedValue([PROJECTS[0]]);
+
+    await handleProjectLink({});
+
+    expect(h.promptProjectChoice).not.toHaveBeenCalled();
+    expect(h.writeLocalProjectFile).toHaveBeenCalledWith(
+      expect.objectContaining({ projectId: "p1" }),
+    );
+  });
+
+  it("no arg with multiple projects opens the picker", async () => {
+    h.promptProjectChoice.mockResolvedValue(PROJECTS[1]);
+
+    await handleProjectLink({});
+
+    expect(h.promptProjectChoice).toHaveBeenCalledOnce();
+    expect(h.writeLocalProjectFile).toHaveBeenCalledWith(
+      expect.objectContaining({ projectId: "p2" }),
+    );
+  });
+
+  it("not logged in exits login_failed (6)", async () => {
+    h.safeReadCredentials.mockResolvedValue(null);
+
+    await expect(handleProjectLink({ json: true })).rejects.toMatchObject({ code: 6 });
+    expect(h.listProjects).not.toHaveBeenCalled();
+  });
+
+  it("--json with multiple projects and no id exits (project_ambiguous)", async () => {
+    await expect(handleProjectLink({ json: true })).rejects.toBeInstanceOf(Error);
+    expect(h.promptProjectChoice).not.toHaveBeenCalled();
+  });
+});

--- a/packages/lmnr-cli/src/commands/project/link.test.ts
+++ b/packages/lmnr-cli/src/commands/project/link.test.ts
@@ -24,6 +24,7 @@ vi.mock("./link-core", async (importActual) => {
   return { ...actual, ensureProjectKey: h.ensureProjectKey };
 });
 
+import { SessionExpiredError } from "../../auth/resolve";
 import { handleProjectLink } from "./link";
 
 const CREDS = { issuer: "https://laminar.sh", sessionToken: "s", userEmail: "u@x.io" };
@@ -142,6 +143,18 @@ describe("handleProjectLink", () => {
 
     await expect(handleProjectLink({ json: true })).rejects.toMatchObject({ code: 6 });
     expect(h.listProjects).not.toHaveBeenCalled();
+  });
+
+  it("an expired session during discovery exits login_failed (6), not (10)", async () => {
+    h.listProjects.mockRejectedValue(new SessionExpiredError("expired"));
+
+    await expect(handleProjectLink({ json: true })).rejects.toMatchObject({ code: 6 });
+  });
+
+  it("a non-expiry discovery error still exits list_projects_failed (10)", async () => {
+    h.listProjects.mockRejectedValue(new Error("network down"));
+
+    await expect(handleProjectLink({ json: true })).rejects.toMatchObject({ code: 10 });
   });
 
   it("--json with multiple projects and no id exits (project_ambiguous)", async () => {

--- a/packages/lmnr-cli/src/commands/project/link.ts
+++ b/packages/lmnr-cli/src/commands/project/link.ts
@@ -1,0 +1,177 @@
+import { type CliProject } from "@lmnr-ai/client";
+import { errorMessage } from "@lmnr-ai/types";
+
+import { safeReadCredentials } from "../../auth/credentials";
+import { DEFAULT_BASE_URL, DEFAULT_FRONTEND_URL } from "../../constants";
+import { pc } from "../../utils/colors";
+import { findEnvKey } from "../../utils/env-file";
+import { type LocalProjectFile, writeLocalProjectFile } from "../../utils/local-project-file";
+import { emitError } from "../../utils/output";
+import { listProjects, promptProjectChoice } from "../../utils/projects";
+import { firstNonEmpty, trimSlash } from "../../utils/text";
+import {
+  ensureProjectKey,
+  EXIT_LIST_PROJECTS_FAILED,
+  EXIT_LOGIN_FAILED,
+  EXIT_NO_ACCESS,
+  EXIT_NO_PROJECT,
+} from "./link-core";
+
+export interface ProjectLinkOptions {
+  /** Explicit target project id — skips the interactive picker. */
+  projectId?: string;
+  baseUrl?: string;
+  json?: boolean;
+  /** Set by commander's `--no-write-env`; false suppresses the ./.env write. */
+  writeEnv?: boolean;
+}
+
+export interface ProjectLinkResult {
+  projectId: string;
+  projectName: string | null;
+  workspaceId: string | null;
+  workspaceName: string | null;
+  /** The key written to .env, or null when an existing matching key was reused. */
+  apiKey: string | null;
+  envFileUpdated: string | null;
+  linkPath: string;
+  /**
+   * Set when the existing LMNR_PROJECT_API_KEY belongs to a DIFFERENT project:
+   * that project's id. The re-link still succeeds; mint a key for the new project
+   * with `lmnr-cli project mint-key` and replace the stale one. Null when the key
+   * matched (or none was present).
+   */
+  keyMismatchProjectId: string | null;
+}
+
+/**
+ * `lmnr-cli project link` — (re)bind the current directory to a project by
+ * rewriting `.lmnr/project.json`, then ensure a usable Project API Key for the
+ * NEW project (the same probe/mint/write `setup` runs, via `ensureProjectKey`).
+ *
+ * With no `--project-id` it opens the (already alphabetically-sorted) picker;
+ * `--project-id <id>` sets it directly, validated against the user's accessible
+ * projects. Requires an existing login (no device flow here) — manages its own
+ * exit codes / `--json` contract like `setup`, so it is registered with a bare
+ * `.action(...)` rather than a with-client wrapper.
+ */
+export async function handleProjectLink(options: ProjectLinkOptions): Promise<void> {
+  const isJson = options.json === true;
+  const writeEnv = options.writeEnv !== false;
+  const baseUrl = firstNonEmpty(options.baseUrl, process.env.LMNR_BASE_URL, DEFAULT_BASE_URL);
+
+  const creds = await safeReadCredentials();
+  if (!creds) {
+    emitError(isJson, "login_failed", "Not authenticated. Run `lmnr-cli login` first.");
+    process.exit(EXIT_LOGIN_FAILED);
+  }
+  const issuer = creds.issuer || DEFAULT_FRONTEND_URL;
+
+  // Discovery (user JWT). Sorted at the client choke point, so the picker below
+  // is already alphabetical.
+  let projects: CliProject[];
+  try {
+    projects = await listProjects(creds, baseUrl);
+  } catch (err) {
+    emitError(isJson, "list_projects_failed", errorMessage(err));
+    process.exit(EXIT_LIST_PROJECTS_FAILED);
+  }
+
+  if (projects.length === 0) {
+    emitError(
+      isJson,
+      "no_project",
+      `No projects to link. Create one at ${trimSlash(issuer)}/onboarding, then re-run.`,
+    );
+    process.exit(EXIT_NO_PROJECT);
+  }
+
+  // Choose the target project (mirrors setup's resolution semantics).
+  let chosen: CliProject;
+  if (options.projectId) {
+    const match = projects.find((p) => p.id === options.projectId);
+    if (!match) {
+      emitError(
+        isJson,
+        "no_access",
+        `You don't have access to project ${options.projectId}. Accessible: ` +
+        projects.map((p) => `${p.id} (${p.workspaceName}/${p.name})`).join(", "),
+      );
+      process.exit(EXIT_NO_ACCESS);
+    }
+    chosen = match;
+  } else if (projects.length === 1) {
+    chosen = projects[0];
+  } else if (isJson) {
+    // No id and >1 project: can't prompt in --json mode.
+    emitError(
+      isJson,
+      "project_ambiguous",
+      `Multiple projects: pass --project-id <id>. ` +
+      projects.map((p) => `${p.id} (${p.workspaceName}/${p.name})`).join(", "),
+    );
+    process.exit(EXIT_NO_PROJECT);
+  } else {
+    chosen = await promptProjectChoice(
+      projects,
+      "\nSelect a project to link to this directory:\n",
+    );
+  }
+
+  // Rewrite .lmnr/project.json to the chosen project.
+  const link: LocalProjectFile = {
+    projectId: chosen.id,
+    projectName: chosen.name,
+    workspaceId: chosen.workspaceId,
+    workspaceName: chosen.workspaceName,
+  };
+
+  // Ensure a key for the NEW project FIRST — shared verbatim with `setup`. It
+  // can hard-exit (key mismatch / unverifiable / mint or env-write failure), so
+  // we commit the re-link to disk only AFTER it succeeds: a failed
+  // `project link` must not leave the directory silently re-pointed. (On mint,
+  // ensureProjectKey also backfills display details onto `link`, so writing
+  // afterwards captures them.)
+  const cwd = process.cwd();
+  const existingKey = await findEnvKey(cwd);
+  const { apiKey, envFileUpdated, mismatchProjectId } = await ensureProjectKey({
+    creds,
+    link,
+    existingKey,
+    cwd,
+    issuer,
+    userBaseUrl: baseUrl,
+    writeEnv,
+    // Re-pointing is intentional: a key for a different project warns (and points
+    // at `project mint-key`) instead of hard-failing, so the re-link still goes through.
+    onKeyMismatch: "warn",
+    isJson,
+  });
+
+  const linkPath = await writeLocalProjectFile(link);
+  if (!isJson) process.stderr.write(`${pc.green("✓")} Linked ${linkPath}\n`);
+
+  const result: ProjectLinkResult = {
+    projectId: link.projectId,
+    projectName: link.projectName ?? null,
+    workspaceId: link.workspaceId ?? null,
+    workspaceName: link.workspaceName ?? null,
+    apiKey,
+    envFileUpdated,
+    linkPath,
+    keyMismatchProjectId: mismatchProjectId,
+  };
+
+  if (isJson) {
+    process.stdout.write(JSON.stringify(result) + "\n");
+    return;
+  }
+
+  // Human confirmation is a message, not data — stderr (matches the ✓ lines above).
+  process.stderr.write(
+    `\n${pc.green("✓")} This directory is now linked to ` +
+    `${link.projectName ?? link.projectId}` +
+    (link.workspaceName ? pc.dim(` (${link.workspaceName})`) : "") +
+    "\n",
+  );
+}

--- a/packages/lmnr-cli/src/commands/project/link.ts
+++ b/packages/lmnr-cli/src/commands/project/link.ts
@@ -38,24 +38,18 @@ export interface ProjectLinkResult {
   envFileUpdated: string | null;
   linkPath: string;
   /**
-   * Set when the existing LMNR_PROJECT_API_KEY belongs to a DIFFERENT project:
-   * that project's id. The re-link still succeeds; mint a key for the new project
-   * with `lmnr-cli project mint-key` and replace the stale one. Null when the key
-   * matched (or none was present).
+   * Id of the different project the existing key belongs to; null if it matched
+   * (or none present). The re-link still succeeds — replace the stale key via
+   * `lmnr-cli project mint-key`.
    */
   keyMismatchProjectId: string | null;
 }
 
 /**
  * `lmnr-cli project link` — (re)bind the current directory to a project by
- * rewriting `.lmnr/project.json`, then ensure a usable Project API Key for the
- * NEW project (the same probe/mint/write `setup` runs, via `ensureProjectKey`).
- *
- * With no `--project-id` it opens the (already alphabetically-sorted) picker;
- * `--project-id <id>` sets it directly, validated against the user's accessible
- * projects. Requires an existing login (no device flow here) — manages its own
- * exit codes / `--json` contract like `setup`, so it is registered with a bare
- * `.action(...)` rather than a with-client wrapper.
+ * rewriting `.lmnr/project.json`, then ensure a Project API Key for it via
+ * `ensureProjectKey` (same as `setup`). No `--project-id` opens the picker;
+ * `--project-id <id>` is validated against accessible projects. Requires login.
  */
 export async function handleProjectLink(options: ProjectLinkOptions): Promise<void> {
   const isJson = options.json === true;
@@ -68,15 +62,12 @@ export async function handleProjectLink(options: ProjectLinkOptions): Promise<vo
   }
   const issuer = creds.issuer || DEFAULT_FRONTEND_URL;
 
-  // Discovery (user JWT). Sorted at the client choke point, so the picker below
-  // is already alphabetical.
+  // Sorted at the client choke point, so the picker is already alphabetical.
   let projects: CliProject[];
   try {
     projects = await listProjects(creds, baseUrl);
   } catch (err) {
-    // An expired grant surfaces here via listProjects → refreshIfNeeded. Keep it
-    // distinct from a discovery failure: it's an auth problem (exit 6), not a
-    // list_projects_failed (exit 10) — same distinction setup makes.
+    // Expired grant is an auth problem (exit 6), not a discovery failure (exit 10).
     if (err instanceof SessionExpiredError) {
       failWith(isJson, loginFailed("Session expired. Run `lmnr-cli login` first."));
     }
@@ -132,12 +123,9 @@ export async function handleProjectLink(options: ProjectLinkOptions): Promise<vo
     workspaceName: chosen.workspaceName,
   };
 
-  // Ensure a key for the NEW project FIRST — shared verbatim with `setup`. It
-  // can hard-exit (key mismatch / unverifiable / mint or env-write failure), so
-  // we commit the re-link to disk only AFTER it succeeds: a failed
-  // `project link` must not leave the directory silently re-pointed. (On mint,
-  // ensureProjectKey also backfills display details onto `link`, so writing
-  // afterwards captures them.)
+  // Ensure the key BEFORE writing the link: it can hard-exit, and a failed
+  // `project link` must not leave the directory silently re-pointed. It also
+  // backfills display details onto `link`, so writing afterwards captures them.
   const cwd = process.cwd();
   const existingKey = await findEnvKey(cwd);
   const { apiKey, envFileUpdated, mismatchProjectId } = await ensureProjectKey({
@@ -148,8 +136,7 @@ export async function handleProjectLink(options: ProjectLinkOptions): Promise<vo
     issuer,
     userBaseUrl: baseUrl,
     writeEnv,
-    // Re-pointing is intentional: a key for a different project warns (and points
-    // at `project mint-key`) instead of hard-failing, so the re-link still goes through.
+    // Warn (don't fail) on a mismatched key so the intentional re-link goes through.
     onKeyMismatch: "warn",
     isJson,
   });

--- a/packages/lmnr-cli/src/commands/project/link.ts
+++ b/packages/lmnr-cli/src/commands/project/link.ts
@@ -4,19 +4,20 @@ import { errorMessage } from "@lmnr-ai/types";
 import { safeReadCredentials } from "../../auth/credentials";
 import { SessionExpiredError } from "../../auth/resolve";
 import { DEFAULT_BASE_URL, DEFAULT_FRONTEND_URL } from "../../constants";
+import {
+  failWith,
+  listProjectsFailed,
+  loginFailed,
+  noAccess,
+  noProject,
+  projectAmbiguous,
+} from "../../errors";
 import { pc } from "../../utils/colors";
 import { findEnvKey } from "../../utils/env-file";
 import { type LocalProjectFile, writeLocalProjectFile } from "../../utils/local-project-file";
-import { emitError } from "../../utils/output";
 import { listProjects, promptProjectChoice } from "../../utils/projects";
 import { firstNonEmpty, trimSlash } from "../../utils/text";
-import {
-  ensureProjectKey,
-  EXIT_LIST_PROJECTS_FAILED,
-  EXIT_LOGIN_FAILED,
-  EXIT_NO_ACCESS,
-  EXIT_NO_PROJECT,
-} from "./link-core";
+import { ensureProjectKey } from "./link-core";
 
 export interface ProjectLinkOptions {
   /** Explicit target project id — skips the interactive picker. */
@@ -63,8 +64,7 @@ export async function handleProjectLink(options: ProjectLinkOptions): Promise<vo
 
   const creds = await safeReadCredentials();
   if (!creds) {
-    emitError(isJson, "login_failed", "Not authenticated. Run `lmnr-cli login` first.");
-    process.exit(EXIT_LOGIN_FAILED);
+    failWith(isJson, loginFailed("Not authenticated. Run `lmnr-cli login` first."));
   }
   const issuer = creds.issuer || DEFAULT_FRONTEND_URL;
 
@@ -78,20 +78,18 @@ export async function handleProjectLink(options: ProjectLinkOptions): Promise<vo
     // distinct from a discovery failure: it's an auth problem (exit 6), not a
     // list_projects_failed (exit 10) — same distinction setup makes.
     if (err instanceof SessionExpiredError) {
-      emitError(isJson, "login_failed", "Session expired. Run `lmnr-cli login` first.");
-      process.exit(EXIT_LOGIN_FAILED);
+      failWith(isJson, loginFailed("Session expired. Run `lmnr-cli login` first."));
     }
-    emitError(isJson, "list_projects_failed", errorMessage(err));
-    process.exit(EXIT_LIST_PROJECTS_FAILED);
+    failWith(isJson, listProjectsFailed(errorMessage(err)));
   }
 
   if (projects.length === 0) {
-    emitError(
+    failWith(
       isJson,
-      "no_project",
-      `No projects to link. Create one at ${trimSlash(issuer)}/onboarding, then re-run.`,
+      noProject(
+        `No projects to link. Create one at ${trimSlash(issuer)}/onboarding, then re-run.`,
+      ),
     );
-    process.exit(EXIT_NO_PROJECT);
   }
 
   // Choose the target project (mirrors setup's resolution semantics).
@@ -99,26 +97,26 @@ export async function handleProjectLink(options: ProjectLinkOptions): Promise<vo
   if (options.projectId) {
     const match = projects.find((p) => p.id === options.projectId);
     if (!match) {
-      emitError(
+      failWith(
         isJson,
-        "no_access",
-        `You don't have access to project ${options.projectId}. Accessible: ` +
-        projects.map((p) => `${p.id} (${p.workspaceName}/${p.name})`).join(", "),
+        noAccess(
+          `You don't have access to project ${options.projectId}. Accessible: ` +
+          projects.map((p) => `${p.id} (${p.workspaceName}/${p.name})`).join(", "),
+        ),
       );
-      process.exit(EXIT_NO_ACCESS);
     }
     chosen = match;
   } else if (projects.length === 1) {
     chosen = projects[0];
   } else if (isJson) {
     // No id and >1 project: can't prompt in --json mode.
-    emitError(
+    failWith(
       isJson,
-      "project_ambiguous",
-      `Multiple projects: pass --project-id <id>. ` +
-      projects.map((p) => `${p.id} (${p.workspaceName}/${p.name})`).join(", "),
+      projectAmbiguous(
+        `Multiple projects: pass --project-id <id>. ` +
+        projects.map((p) => `${p.id} (${p.workspaceName}/${p.name})`).join(", "),
+      ),
     );
-    process.exit(EXIT_NO_PROJECT);
   } else {
     chosen = await promptProjectChoice(
       projects,

--- a/packages/lmnr-cli/src/commands/project/link.ts
+++ b/packages/lmnr-cli/src/commands/project/link.ts
@@ -2,6 +2,7 @@ import { type CliProject } from "@lmnr-ai/client";
 import { errorMessage } from "@lmnr-ai/types";
 
 import { safeReadCredentials } from "../../auth/credentials";
+import { SessionExpiredError } from "../../auth/resolve";
 import { DEFAULT_BASE_URL, DEFAULT_FRONTEND_URL } from "../../constants";
 import { pc } from "../../utils/colors";
 import { findEnvKey } from "../../utils/env-file";
@@ -73,6 +74,13 @@ export async function handleProjectLink(options: ProjectLinkOptions): Promise<vo
   try {
     projects = await listProjects(creds, baseUrl);
   } catch (err) {
+    // An expired grant surfaces here via listProjects → refreshIfNeeded. Keep it
+    // distinct from a discovery failure: it's an auth problem (exit 6), not a
+    // list_projects_failed (exit 10) — same distinction setup makes.
+    if (err instanceof SessionExpiredError) {
+      emitError(isJson, "login_failed", "Session expired. Run `lmnr-cli login` first.");
+      process.exit(EXIT_LOGIN_FAILED);
+    }
     emitError(isJson, "list_projects_failed", errorMessage(err));
     process.exit(EXIT_LIST_PROJECTS_FAILED);
   }

--- a/packages/lmnr-cli/src/commands/project/mint-key.test.ts
+++ b/packages/lmnr-cli/src/commands/project/mint-key.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const h = vi.hoisted(() => ({
+  safeReadCredentials: vi.fn(),
+  readLocalProjectFile: vi.fn(),
+  mintProjectApiKey: vi.fn(),
+}));
+
+vi.mock("../../auth/credentials", () => ({ safeReadCredentials: h.safeReadCredentials }));
+vi.mock("../../utils/local-project-file", () => ({ readLocalProjectFile: h.readLocalProjectFile }));
+vi.mock("../../auth/api-key", () => ({ mintProjectApiKey: h.mintProjectApiKey }));
+
+import { handleProjectMintKey } from "./mint-key";
+
+const CREDS = { issuer: "https://laminar.sh", sessionToken: "sess", userEmail: "u@x.io" };
+
+class ExitError extends Error {
+  constructor(public code: number) {
+    super(`exit ${code}`);
+  }
+}
+
+let exitSpy: ReturnType<typeof vi.spyOn>;
+let stdoutSpy: ReturnType<typeof vi.spyOn>;
+const out = (): string =>
+  (stdoutSpy.mock.calls as unknown[][]).map((c) => String(c[0])).join("");
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+    throw new ExitError(code ?? 0);
+  }) as never);
+  stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+  vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+  h.safeReadCredentials.mockResolvedValue(CREDS);
+  h.readLocalProjectFile.mockResolvedValue({ projectId: "p1" });
+  h.mintProjectApiKey.mockResolvedValue({ apiKey: "lmnr-minted", apiKeyId: "k1" });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("handleProjectMintKey", () => {
+  it("mints via the shared minter for the linked project and prints the bare key", async () => {
+    await handleProjectMintKey({});
+
+    expect(h.mintProjectApiKey).toHaveBeenCalledWith(
+      "https://laminar.sh",
+      "sess",
+      "p1",
+      expect.any(String),
+    );
+    // Bare key on stdout (pipe/copy friendly), nothing else.
+    expect(out()).toBe("lmnr-minted\n");
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it("--project-id overrides the linked project", async () => {
+    await handleProjectMintKey({ projectId: "p9" });
+
+    expect(h.mintProjectApiKey).toHaveBeenCalledWith(
+      "https://laminar.sh",
+      "sess",
+      "p9",
+      expect.any(String),
+    );
+  });
+
+  it("--json emits { projectId, apiKey, apiKeyId } and never writes .env", async () => {
+    await handleProjectMintKey({ json: true });
+
+    const parsed = JSON.parse(out().trim());
+    expect(parsed).toEqual({ projectId: "p1", apiKey: "lmnr-minted", apiKeyId: "k1" });
+  });
+
+  it("not logged in exits login_failed (6)", async () => {
+    h.safeReadCredentials.mockResolvedValue(null);
+
+    await expect(handleProjectMintKey({ json: true })).rejects.toMatchObject({ code: 6 });
+    expect(h.mintProjectApiKey).not.toHaveBeenCalled();
+  });
+
+  it("no project (no link, no --project-id) exits no_project (7)", async () => {
+    h.readLocalProjectFile.mockResolvedValue(null);
+
+    await expect(handleProjectMintKey({ json: true })).rejects.toMatchObject({ code: 7 });
+    expect(h.mintProjectApiKey).not.toHaveBeenCalled();
+  });
+
+  it("mint failure exits setup_key_failed (9)", async () => {
+    h.mintProjectApiKey.mockRejectedValue(new Error("api-key request failed (500)"));
+
+    await expect(handleProjectMintKey({ json: true })).rejects.toMatchObject({ code: 9 });
+  });
+});

--- a/packages/lmnr-cli/src/commands/project/mint-key.test.ts
+++ b/packages/lmnr-cli/src/commands/project/mint-key.test.ts
@@ -4,12 +4,19 @@ const h = vi.hoisted(() => ({
   safeReadCredentials: vi.fn(),
   readLocalProjectFile: vi.fn(),
   mintProjectApiKey: vi.fn(),
+  refreshIfNeeded: vi.fn(),
 }));
 
 vi.mock("../../auth/credentials", () => ({ safeReadCredentials: h.safeReadCredentials }));
 vi.mock("../../utils/local-project-file", () => ({ readLocalProjectFile: h.readLocalProjectFile }));
 vi.mock("../../auth/api-key", () => ({ mintProjectApiKey: h.mintProjectApiKey }));
+// Keep the real SessionExpiredError (so `instanceof` works); stub only the probe.
+vi.mock("../../auth/resolve", async (orig) => {
+  const actual = await orig<typeof import("../../auth/resolve")>();
+  return { ...actual, refreshIfNeeded: h.refreshIfNeeded };
+});
 
+import { SessionExpiredError } from "../../auth/resolve";
 import { handleProjectMintKey } from "./mint-key";
 
 const CREDS = { issuer: "https://laminar.sh", sessionToken: "sess", userEmail: "u@x.io" };
@@ -35,6 +42,7 @@ beforeEach(() => {
   h.safeReadCredentials.mockResolvedValue(CREDS);
   h.readLocalProjectFile.mockResolvedValue({ projectId: "p1" });
   h.mintProjectApiKey.mockResolvedValue({ apiKey: "lmnr-minted", apiKeyId: "k1" });
+  h.refreshIfNeeded.mockResolvedValue(CREDS); // session live by default
 });
 
 afterEach(() => {
@@ -92,5 +100,12 @@ describe("handleProjectMintKey", () => {
     h.mintProjectApiKey.mockRejectedValue(new Error("api-key request failed (500)"));
 
     await expect(handleProjectMintKey({ json: true })).rejects.toMatchObject({ code: 9 });
+  });
+
+  it("expired session exits login_failed (6), not setup_key_failed (9)", async () => {
+    h.refreshIfNeeded.mockRejectedValue(new SessionExpiredError("expired"));
+
+    await expect(handleProjectMintKey({ json: true })).rejects.toMatchObject({ code: 6 });
+    expect(h.mintProjectApiKey).not.toHaveBeenCalled();
   });
 });

--- a/packages/lmnr-cli/src/commands/project/mint-key.ts
+++ b/packages/lmnr-cli/src/commands/project/mint-key.ts
@@ -1,0 +1,83 @@
+import { hostname } from "node:os";
+
+import { errorMessage } from "@lmnr-ai/types";
+
+import { mintProjectApiKey } from "../../auth/api-key";
+import { safeReadCredentials } from "../../auth/credentials";
+import { DEFAULT_FRONTEND_URL } from "../../constants";
+import { pc } from "../../utils/colors";
+import { readLocalProjectFile } from "../../utils/local-project-file";
+import { emitError } from "../../utils/output";
+import { EXIT_LOGIN_FAILED, EXIT_NO_PROJECT, EXIT_SETUP_KEY_FAILED } from "./link-core";
+
+export interface ProjectMintKeyOptions {
+  /** Project to mint for. Defaults to the linked `.lmnr/project.json`. */
+  projectId?: string;
+  json?: boolean;
+}
+
+export interface ProjectMintKeyResult {
+  projectId: string;
+  apiKey: string;
+  apiKeyId: string | null;
+}
+
+/**
+ * `lmnr-cli project mint-key` — mint a fresh Project API Key for the linked
+ * project (or `--project-id`) and PRINT it, so the user can paste it into their
+ * `.env` (or wherever). Unlike `setup` / `project link`, it deliberately does NOT
+ * write `.env` — it hands you the key and stays out of your files.
+ *
+ * Minting goes through the shared `mintProjectApiKey` (the same call `setup` and
+ * `plugin add` use). Requires an existing login. Manages its own exit codes /
+ * `--json` contract like the other onboarding commands. The bare key goes to
+ * stdout (pipe / copy-paste friendly); everything else is on stderr.
+ */
+export async function handleProjectMintKey(options: ProjectMintKeyOptions): Promise<void> {
+  const isJson = options.json === true;
+
+  const creds = await safeReadCredentials();
+  if (!creds) {
+    emitError(isJson, "login_failed", "Not authenticated. Run `lmnr-cli login` first.");
+    process.exit(EXIT_LOGIN_FAILED);
+  }
+
+  const projectId = options.projectId || (await readLocalProjectFile())?.projectId;
+  if (!projectId) {
+    emitError(
+      isJson,
+      "no_project",
+      "No project for this directory. Run `lmnr-cli project link` here, or pass --project-id <id>.",
+    );
+    process.exit(EXIT_NO_PROJECT);
+  }
+
+  const issuer = creds.issuer || DEFAULT_FRONTEND_URL;
+
+  let minted;
+  try {
+    minted = await mintProjectApiKey(issuer, creds.sessionToken, projectId, hostname());
+  } catch (err) {
+    emitError(isJson, "setup_key_failed", errorMessage(err));
+    process.exit(EXIT_SETUP_KEY_FAILED);
+  }
+
+  const result: ProjectMintKeyResult = {
+    projectId,
+    apiKey: minted.apiKey,
+    apiKeyId: minted.apiKeyId ?? null,
+  };
+
+  if (isJson) {
+    process.stdout.write(JSON.stringify(result) + "\n");
+    return;
+  }
+
+  // The bare key is the data — stdout, so it pipes / copies cleanly. The hint
+  // for what to do with it is a message — stderr, keeping stdout just the key.
+  process.stdout.write(minted.apiKey + "\n");
+  process.stderr.write(
+    `\n${pc.dim(`Set it in your environment (it is NOT written for you):`)}\n` +
+    `  LMNR_PROJECT_API_KEY=${minted.apiKey}\n`,
+  );
+}

--- a/packages/lmnr-cli/src/commands/project/mint-key.ts
+++ b/packages/lmnr-cli/src/commands/project/mint-key.ts
@@ -24,14 +24,9 @@ export interface ProjectMintKeyResult {
 
 /**
  * `lmnr-cli project mint-key` — mint a fresh Project API Key for the linked
- * project (or `--project-id`) and PRINT it, so the user can paste it into their
- * `.env` (or wherever). Unlike `setup` / `project link`, it deliberately does NOT
- * write `.env` — it hands you the key and stays out of your files.
- *
- * Minting goes through the shared `mintProjectApiKey` (the same call `setup` and
- * `plugin add` use). Requires an existing login. Manages its own exit codes /
- * `--json` contract like the other onboarding commands. The bare key goes to
- * stdout (pipe / copy-paste friendly); everything else is on stderr.
+ * project (or `--project-id`) and PRINT it. Unlike `setup` / `project link`, it
+ * deliberately does NOT write `.env` — the bare key goes to stdout (pipe-friendly),
+ * everything else to stderr. Requires an existing login.
  */
 export async function handleProjectMintKey(options: ProjectMintKeyOptions): Promise<void> {
   const isJson = options.json === true;
@@ -54,9 +49,8 @@ export async function handleProjectMintKey(options: ProjectMintKeyOptions): Prom
 
   const issuer = creds.issuer || DEFAULT_FRONTEND_URL;
 
-  // Validate the session up-front (no-op unless the access token is near expiry).
-  // An expired grant maps to login_failed (6) — the same code setup / project
-  // link report — instead of surfacing as setup_key_failed (9) from a doomed mint.
+  // Validate the session up-front so an expired grant maps to login_failed (6)
+  // rather than a doomed mint's setup_key_failed (9).
   try {
     await refreshIfNeeded(creds);
   } catch (err) {
@@ -84,8 +78,7 @@ export async function handleProjectMintKey(options: ProjectMintKeyOptions): Prom
     return;
   }
 
-  // The bare key is the data — stdout, so it pipes / copies cleanly. The hint
-  // for what to do with it is a message — stderr, keeping stdout just the key.
+  // Bare key to stdout (pipe-friendly); the hint goes to stderr.
   process.stdout.write(minted.apiKey + "\n");
   process.stderr.write(
     `\n${pc.dim(`Set it in your environment (it is NOT written for you):`)}\n` +

--- a/packages/lmnr-cli/src/commands/project/mint-key.ts
+++ b/packages/lmnr-cli/src/commands/project/mint-key.ts
@@ -4,6 +4,7 @@ import { errorMessage } from "@lmnr-ai/types";
 
 import { mintProjectApiKey } from "../../auth/api-key";
 import { safeReadCredentials } from "../../auth/credentials";
+import { refreshIfNeeded, SessionExpiredError } from "../../auth/resolve";
 import { DEFAULT_FRONTEND_URL } from "../../constants";
 import { failWith, loginFailed, noProject, setupKeyFailed } from "../../errors";
 import { pc } from "../../utils/colors";
@@ -52,6 +53,18 @@ export async function handleProjectMintKey(options: ProjectMintKeyOptions): Prom
   }
 
   const issuer = creds.issuer || DEFAULT_FRONTEND_URL;
+
+  // Validate the session up-front (no-op unless the access token is near expiry).
+  // An expired grant maps to login_failed (6) — the same code setup / project
+  // link report — instead of surfacing as setup_key_failed (9) from a doomed mint.
+  try {
+    await refreshIfNeeded(creds);
+  } catch (err) {
+    if (err instanceof SessionExpiredError) {
+      failWith(isJson, loginFailed("Session expired. Run `lmnr-cli login` first."));
+    }
+    throw err;
+  }
 
   let minted;
   try {

--- a/packages/lmnr-cli/src/commands/project/mint-key.ts
+++ b/packages/lmnr-cli/src/commands/project/mint-key.ts
@@ -5,10 +5,9 @@ import { errorMessage } from "@lmnr-ai/types";
 import { mintProjectApiKey } from "../../auth/api-key";
 import { safeReadCredentials } from "../../auth/credentials";
 import { DEFAULT_FRONTEND_URL } from "../../constants";
+import { failWith, loginFailed, noProject, setupKeyFailed } from "../../errors";
 import { pc } from "../../utils/colors";
 import { readLocalProjectFile } from "../../utils/local-project-file";
-import { emitError } from "../../utils/output";
-import { EXIT_LOGIN_FAILED, EXIT_NO_PROJECT, EXIT_SETUP_KEY_FAILED } from "./link-core";
 
 export interface ProjectMintKeyOptions {
   /** Project to mint for. Defaults to the linked `.lmnr/project.json`. */
@@ -38,18 +37,18 @@ export async function handleProjectMintKey(options: ProjectMintKeyOptions): Prom
 
   const creds = await safeReadCredentials();
   if (!creds) {
-    emitError(isJson, "login_failed", "Not authenticated. Run `lmnr-cli login` first.");
-    process.exit(EXIT_LOGIN_FAILED);
+    failWith(isJson, loginFailed("Not authenticated. Run `lmnr-cli login` first."));
   }
 
   const projectId = options.projectId || (await readLocalProjectFile())?.projectId;
   if (!projectId) {
-    emitError(
+    failWith(
       isJson,
-      "no_project",
-      "No project for this directory. Run `lmnr-cli project link` here, or pass --project-id <id>.",
+      noProject(
+        "No project for this directory. Run `lmnr-cli project link` here, " +
+        "or pass --project-id <id>.",
+      ),
     );
-    process.exit(EXIT_NO_PROJECT);
   }
 
   const issuer = creds.issuer || DEFAULT_FRONTEND_URL;
@@ -58,8 +57,7 @@ export async function handleProjectMintKey(options: ProjectMintKeyOptions): Prom
   try {
     minted = await mintProjectApiKey(issuer, creds.sessionToken, projectId, hostname());
   } catch (err) {
-    emitError(isJson, "setup_key_failed", errorMessage(err));
-    process.exit(EXIT_SETUP_KEY_FAILED);
+    failWith(isJson, setupKeyFailed(errorMessage(err)));
   }
 
   const result: ProjectMintKeyResult = {

--- a/packages/lmnr-cli/src/commands/setup/index.test.ts
+++ b/packages/lmnr-cli/src/commands/setup/index.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// handleSetup wires together login, credentials, project discovery, key
+// minting, env writing and skill install. We mock those seams and focus this
+// suite on ONE behavior: an expired-but-valid-shaped session must be absorbed
+// into the device-flow login, never surfaced as list_projects_failed (exit 10).
+
+// vi.mock factories are hoisted above the module body, so the mock fns they
+// reference must be created in a hoisted block too.
+const h = vi.hoisted(() => ({
+  handleLogin: vi.fn(),
+  safeReadCredentials: vi.fn(),
+  refreshIfNeeded: vi.fn(),
+  readLocalProjectFile: vi.fn(),
+  writeLocalProjectFile: vi.fn(),
+  listProjects: vi.fn(),
+  promptProjectChoice: vi.fn(),
+  findEnvKey: vi.fn(),
+  resolveEnvWriteTarget: vi.fn(),
+  writeEnvFile: vi.fn(),
+  isPathGitIgnored: vi.fn(),
+  mintProjectApiKey: vi.fn(),
+  installSkill: vi.fn(),
+}));
+
+vi.mock("../login", () => ({ handleLogin: h.handleLogin }));
+vi.mock("../../auth/credentials", () => ({ safeReadCredentials: h.safeReadCredentials }));
+vi.mock("../../auth/resolve", async (importActual) => {
+  const actual = await importActual<typeof import("../../auth/resolve")>();
+  return { ...actual, refreshIfNeeded: h.refreshIfNeeded, envHttpPort: () => undefined };
+});
+vi.mock("../../utils/local-project-file", () => ({
+  readLocalProjectFile: h.readLocalProjectFile,
+  writeLocalProjectFile: h.writeLocalProjectFile,
+}));
+vi.mock("../../utils/projects", () => ({
+  listProjects: h.listProjects,
+  promptProjectChoice: h.promptProjectChoice,
+}));
+vi.mock("../../utils/env-file", () => ({
+  findEnvKey: h.findEnvKey,
+  resolveEnvWriteTarget: h.resolveEnvWriteTarget,
+  writeEnvFile: h.writeEnvFile,
+  isPathGitIgnored: h.isPathGitIgnored,
+}));
+vi.mock("../../auth/api-key", () => ({ mintProjectApiKey: h.mintProjectApiKey }));
+vi.mock("../../utils/install-skill", () => ({ installSkill: h.installSkill }));
+
+import { SessionExpiredError } from "../../auth/resolve";
+import { handleSetup } from "./index";
+
+const VALID_CREDS = {
+  version: 1,
+  issuer: "https://laminar.sh",
+  sessionToken: "sess",
+  accessToken: "jwt",
+  accessTokenExpiresAt: "2099-01-01T00:00:00.000Z",
+  userId: "u1",
+  userEmail: "dev@example.com",
+  createdAt: "2026-01-01T00:00:00.000Z",
+};
+
+let exitSpy: ReturnType<typeof vi.spyOn>;
+let stdoutSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // process.exit must never be reached on the happy expiry-recovery path — make
+  // it throw so an unexpected exit fails the test loudly instead of hanging.
+  exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+    throw new Error(`process.exit(${code})`);
+  }) as never);
+  stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+  vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("handleSetup — expired session recovery", () => {
+  it("re-runs login (does not error) when refresh returns invalid_grant", async () => {
+    // Valid-shaped creds on disk both before the gate and after re-login.
+    h.safeReadCredentials.mockResolvedValue(VALID_CREDS);
+    // The gate's refresh throws SessionExpiredError → the expiry is absorbed.
+    h.refreshIfNeeded.mockRejectedValue(new SessionExpiredError("Session expired"));
+    // No directory link yet; the browser hands back the chosen project.
+    h.readLocalProjectFile.mockResolvedValue(null);
+    h.handleLogin.mockResolvedValue({
+      userId: "u1",
+      userEmail: "dev@example.com",
+      projectId: "proj-1",
+    });
+    h.listProjects.mockResolvedValue([
+      { id: "proj-1", name: "Proj", workspaceId: "w1", workspaceName: "WS" },
+    ]);
+    h.writeLocalProjectFile.mockResolvedValue("/tmp/.lmnr/project.json");
+    // No existing key → mint a fresh one; skip env write via writeEnv:false.
+    h.findEnvKey.mockResolvedValue(null);
+    h.mintProjectApiKey.mockResolvedValue({
+      apiKey: "lmnr-key",
+      projectName: "Proj",
+      workspaceName: "WS",
+      workspaceId: "w1",
+    });
+    h.installSkill.mockResolvedValue({ written: [], skipped: true });
+
+    await handleSetup({ json: true, writeEnv: false, browser: false });
+
+    // The expiry was absorbed into the device-flow login...
+    expect(h.handleLogin).toHaveBeenCalledTimes(1);
+    expect(h.handleLogin).toHaveBeenCalledWith(
+      expect.objectContaining({ noBrowser: true }),
+    );
+    // ...and onboarding completed: a JSON result on stdout, no error exit.
+    expect(exitSpy).not.toHaveBeenCalled();
+    const out = stdoutSpy.mock.calls.map((c: unknown[]) => String(c[0])).join("");
+    expect(out).toContain('"projectId":"proj-1"');
+    expect(out).not.toContain("list_projects_failed");
+  });
+});

--- a/packages/lmnr-cli/src/commands/setup/index.test.ts
+++ b/packages/lmnr-cli/src/commands/setup/index.test.ts
@@ -118,4 +118,18 @@ describe("handleSetup — expired session recovery", () => {
     expect(out).toContain('"projectId":"proj-1"');
     expect(out).not.toContain("list_projects_failed");
   });
+
+  it("maps a late listProjects expiry to login_failed (6), not (10)", async () => {
+    // Gate refresh SUCCEEDS (session live here), so expiry isn't absorbed...
+    h.safeReadCredentials.mockResolvedValue(VALID_CREDS);
+    h.refreshIfNeeded.mockResolvedValue(VALID_CREDS);
+    h.readLocalProjectFile.mockResolvedValue(null); // no link → resolve via CLI
+    // ...it only surfaces on the later discovery call.
+    h.listProjects.mockRejectedValue(new SessionExpiredError("Session expired"));
+
+    await expect(
+      handleSetup({ json: true, writeEnv: false, browser: false }),
+    ).rejects.toThrow("process.exit(6)");
+    expect(h.handleLogin).not.toHaveBeenCalled();
+  });
 });

--- a/packages/lmnr-cli/src/commands/setup/index.ts
+++ b/packages/lmnr-cli/src/commands/setup/index.ts
@@ -1,21 +1,14 @@
-import { hostname } from "node:os";
 import { relative } from "node:path";
 
-import { type CliProject, LaminarClient, type ProjectKeyProbe } from "@lmnr-ai/client";
+import { type CliProject } from "@lmnr-ai/client";
 import { errorMessage } from "@lmnr-ai/types";
 
 import { version } from "../../../package.json";
-import { type MintedApiKey, mintProjectApiKey } from "../../auth/api-key";
 import { type Credentials, safeReadCredentials } from "../../auth/credentials";
-import { envHttpPort, refreshIfNeeded } from "../../auth/resolve";
+import { refreshIfNeeded, SessionExpiredError } from "../../auth/resolve";
+import { DEFAULT_BASE_URL, DEFAULT_FRONTEND_URL } from "../../constants";
 import { orange, pc, pcOut } from "../../utils/colors";
-import {
-  type EnvKeyLocation,
-  findEnvKey,
-  isPathGitIgnored,
-  resolveEnvWriteTarget,
-  writeEnvFile,
-} from "../../utils/env-file";
+import { type EnvKeyLocation, findEnvKey } from "../../utils/env-file";
 import { installSkill } from "../../utils/install-skill";
 import {
   type LocalProjectFile,
@@ -24,30 +17,15 @@ import {
 } from "../../utils/local-project-file";
 import { emitError } from "../../utils/output";
 import { listProjects, promptProjectChoice } from "../../utils/projects";
-import { firstNonEmpty } from "../../utils/text";
+import { firstNonEmpty, trimSlash } from "../../utils/text";
 import { handleLogin } from "../login";
-
-const DEFAULT_FRONTEND_URL = "https://laminar.sh";
-const DEFAULT_BASE_URL = "https://api.lmnr.ai";
-
-// Exit codes (machine-readable contract — each distinct so automation can
-// branch on the failure mode):
-//   4  no_access            — user lacks access to the linked project
-//   6  login_failed         — device-flow login failed / no creds after login
-//   7  no_project           — no project to select (and none could be created)
-//   8  env_write_failed     — minted a key but couldn't write ./.env
-//   9  setup_key_failed     — POST /api/cli/api-key failed
-//   10 list_projects_failed — GET /v1/cli/projects (discovery) failed
-//   11 key_probe_failed     — couldn't verify the existing key (network/server error)
-//   12 key_mismatch         — existing key belongs to a different project
-const EXIT_NO_ACCESS = 4;
-const EXIT_LOGIN_FAILED = 6;
-const EXIT_NO_PROJECT = 7;
-const EXIT_ENV_WRITE_FAILED = 8;
-const EXIT_SETUP_KEY_FAILED = 9;
-const EXIT_LIST_PROJECTS_FAILED = 10;
-const EXIT_KEY_PROBE_FAILED = 11;
-const EXIT_KEY_MISMATCH = 12;
+import {
+  ensureProjectKey,
+  EXIT_LIST_PROJECTS_FAILED,
+  EXIT_LOGIN_FAILED,
+  EXIT_NO_ACCESS,
+  EXIT_NO_PROJECT,
+} from "../project/link-core";
 
 export interface SetupOptions {
   writeEnv?: boolean;
@@ -114,6 +92,25 @@ export async function handleSetup(options: SetupOptions): Promise<void> {
   let creds: Credentials | null = await safeReadCredentials();
   let link = await readLocalProjectFile();
 
+  // Expiry gate: an expired session still leaves a valid-shaped credentials.json
+  // on disk, so without this setup would take the "already logged in" branch and
+  // then dead-end on the first authed call (list_projects → list_projects_failed).
+  // Validate the session now; an expired grant is ABSORBED — we drop the creds so
+  // the not-logged-in branch below re-runs the device flow (honoring --no-browser)
+  // and onboarding continues. A non-expiry error (network/5xx / server blip) is
+  // deliberately left for the downstream authed call to surface through its coded
+  // path (list_projects_failed, exit 10) so a transient failure is never
+  // conflated with an expiry.
+  if (creds) {
+    try {
+      creds = await refreshIfNeeded(creds);
+    } catch (err) {
+      if (err instanceof SessionExpiredError) {
+        creds = null;
+      }
+    }
+  }
+
   // --- 1. Login + project resolution ---------------------------------------
 
   if (!creds) {
@@ -179,109 +176,17 @@ export async function handleSetup(options: SetupOptions): Promise<void> {
   const userBaseUrl = baseUrl;
 
   // --- 3. Key handling (SPEC 36-42) -----------------------------------------
-
-  let apiKey: string | null = null;
-  let envPath: string | null = null;
-  let keyMeta: MintedApiKey | null = null;
-
-  let needMint = true;
-  if (existingKey) {
-    const probe = await probeProjectKey(creds, existingKey.value, userBaseUrl);
-    const where =
-      existingKey.source.type === "process-env"
-        ? "your environment"
-        : relative(cwd, existingKey.source.path);
-
-    if (probe.status === "unverifiable") {
-      // Couldn't verify the key (network/server error). Do NOT mint — that would
-      // clobber a possibly-valid key on a transient blip. Abort so the user retries.
-      emitError(
-        isJson,
-        "key_probe_failed",
-        `Couldn't verify the existing Project API Key in ${where} (network or server error). ` +
-        "Check your connection and re-run.",
-      );
-      process.exit(EXIT_KEY_PROBE_FAILED);
-    } else if (probe.status === "ok" && probe.projectId === link.projectId) {
-      // Already configured for this project. Respect the user's setup: no mint,
-      // no write (option a) — including when the key only lives in process.env.
-      needMint = false;
-      if (!isJson) {
-        process.stderr.write(`${pc.green("✓")} Project API Key already set in ${where}\n`);
-      }
-    } else if (probe.status === "ok") {
-      // Valid key, but for a DIFFERENT project. Refuse to clobber it — abort so the
-      // user resolves the conflict deliberately rather than silently overwriting.
-      emitError(
-        isJson,
-        "key_mismatch",
-        `The Project API Key in ${where} belongs to a different project (${probe.projectId}), ` +
-        `not the one linked here (${link.projectId}). Remove or update it, then re-run.`,
-      );
-      process.exit(EXIT_KEY_MISMATCH);
-    } else if (!isJson) {
-      // invalid / revoked (401) — minting a fresh key is the correct recovery.
-      process.stderr.write(
-        `${pc.yellow("⚠")} Existing Project API Key in ${where} is invalid or revoked, ` +
-        `minting a new one\n`,
-      );
-    }
-  }
-
-  if (needMint) {
-    try {
-      keyMeta = await mintProjectApiKey(issuer, creds.sessionToken, link.projectId, hostname());
-    } catch (err) {
-      emitError(isJson, "setup_key_failed", errorMessage(err));
-      process.exit(EXIT_SETUP_KEY_FAILED);
-    }
-    apiKey = keyMeta.apiKey;
-
-    // Backfill display details onto the link if we learned them while minting.
-    if (!link.projectName && keyMeta.projectName) link.projectName = keyMeta.projectName;
-    if (!link.workspaceName && keyMeta.workspaceName) link.workspaceName = keyMeta.workspaceName;
-    if (!link.workspaceId && keyMeta.workspaceId) link.workspaceId = keyMeta.workspaceId;
-
-    if (writeEnv) {
-      const target = await resolveEnvWriteTarget(cwd, existingKey);
-      try {
-        const result = await writeEnvFile(target, apiKey);
-        envPath = result.path;
-        if (!isJson) {
-          const rel = relative(cwd, result.path);
-          const verb = result.created
-            ? "Created"
-            : result.replaced
-              ? "Updated LMNR_PROJECT_API_KEY in"
-              : "Added LMNR_PROJECT_API_KEY to";
-          process.stderr.write(`${pc.green("✓")} ${verb} ${rel}\n`);
-          // The key is a secret; nudge if it landed in a tracked file.
-          if ((await isPathGitIgnored(result.path)) === false) {
-            process.stderr.write(
-              `${pc.yellow("⚠")} ${rel} isn't gitignored; add it so the key isn't committed\n`,
-            );
-          }
-        }
-      } catch (err) {
-        process.stderr.write(
-          `\n${pc.red("ERROR")}: failed to write ${target}: ${errorMessage(err)}\n` +
-          pc.dim("Your API key (set it manually):") +
-          `\n  LMNR_PROJECT_API_KEY=${apiKey}\n\n`,
-        );
-        if (isJson) {
-          process.stdout.write(
-            JSON.stringify({
-              error: "env_write_failed",
-              apiKey,
-              projectId: link.projectId,
-              message: errorMessage(err),
-            }) + "\n",
-          );
-        }
-        process.exit(EXIT_ENV_WRITE_FAILED);
-      }
-    }
-  }
+  // Shared with `project link` — the whole probe/mint/write is `ensureProjectKey`.
+  const { apiKey, envFileUpdated: envPath } = await ensureProjectKey({
+    creds,
+    link,
+    existingKey,
+    cwd,
+    issuer,
+    userBaseUrl,
+    writeEnv,
+    isJson,
+  });
 
   // --- 4. Skill install -----------------------------------------------------
 
@@ -556,32 +461,7 @@ function buildNoAccessDetail(
     `It's linked (.lmnr/project.json) to project ${project}${workspace}. ${accessLine}\n\n` +
     `To fix, pick one:\n` +
     `  • Wrong account? Run \`lmnr-cli login\` as someone with access, then re-run setup.\n` +
-    `  • Want a different project here? Remove the link and re-run setup: ` +
-    `\`rm .lmnr/project.json && lmnr-cli setup\`.${envHint}`
+    `  • Want a different project here? Re-point this directory: ` +
+    `\`lmnr-cli project link\`.${envHint}`
   );
-}
-
-/**
- * Resolve which project an existing project API key belongs to, via the
- * user-token CLI endpoint (`POST /v1/cli/project`, key in body). By setup time
- * the CLI is already logged in, so we authenticate as the user (JWT bearer)
- * rather than re-deriving auth from the project key itself. The server also
- * confirms the user is a member of the resolved project.
- */
-async function probeProjectKey(
-  creds: Credentials,
-  apiKey: string,
-  baseUrl: string,
-): Promise<ProjectKeyProbe> {
-  const updated = await refreshIfNeeded(creds);
-  const client = new LaminarClient({
-    baseUrl,
-    port: envHttpPort(),
-    auth: { type: "userToken", token: updated.accessToken, projectId: "" },
-  });
-  return client.cli.resolveProjectByApiKey(apiKey);
-}
-
-function trimSlash(url: string): string {
-  return url.replace(/\/+$/, "");
 }

--- a/packages/lmnr-cli/src/commands/setup/index.ts
+++ b/packages/lmnr-cli/src/commands/setup/index.ts
@@ -36,11 +36,7 @@ export interface SetupOptions {
   browser?: boolean;
   frontendUrl?: string;
   baseUrl?: string;
-  /**
-   * Explicit project id. Disambiguates when the user can access >1 project
-   * (otherwise --json setup errors `project_ambiguous`). Validated against the
-   * user's accessible projects before linking.
-   */
+  /** Explicit project id; disambiguates when >1 is accessible. Validated before linking. */
   projectId?: string;
 }
 
@@ -59,19 +55,11 @@ export interface SetupResult {
 }
 
 /**
- * Directory-scoped onboarding (SPEC decision tree):
- *  - log in if needed (browser picks/creates the project; its id rides back on
- *    the device-token metadata, see parseProjectFromMetadata),
- *  - resolve a project for this directory (`.lmnr/project.json`), enforcing
- *    access,
- *  - mint a project API key only when one isn't already configured for this
- *    project (checked across process.env → .env.local → .env), then write it to
- *    an existing .env.local or else .env,
- *  - install the Laminar skill into present agent dirs,
- *  - print a summary.
- *
- * The minted key goes ONLY into the project's env file, never into
- * credentials.json (which stores user-scoped BetterAuth tokens).
+ * Directory-scoped onboarding: log in if needed, resolve the project for this
+ * directory (`.lmnr/project.json`) and enforce access, mint a project API key
+ * only when one isn't already configured, install the Laminar skill, print a
+ * summary. The minted key goes only into the project's env file, never into
+ * credentials.json (which stores user-scoped tokens).
  */
 export async function handleSetup(options: SetupOptions): Promise<void> {
   const writeEnv = options.writeEnv !== false;
@@ -88,21 +76,16 @@ export async function handleSetup(options: SetupOptions): Promise<void> {
   }
 
   const cwd = process.cwd();
-  // Detect an already-configured key across process.env → .env.local → .env.
+  // Already-configured key across process.env, .env.local, .env.
   const existingKey = await findEnvKey(cwd);
 
   let creds: Credentials | null = await safeReadCredentials();
   let link = await readLocalProjectFile();
 
-  // Expiry gate: an expired session still leaves a valid-shaped credentials.json
-  // on disk, so without this setup would take the "already logged in" branch and
-  // then dead-end on the first authed call (list_projects → list_projects_failed).
-  // Validate the session now; an expired grant is ABSORBED — we drop the creds so
-  // the not-logged-in branch below re-runs the device flow (honoring --no-browser)
-  // and onboarding continues. A non-expiry error (network/5xx / server blip) is
-  // deliberately left for the downstream authed call to surface through its coded
-  // path (list_projects_failed, exit 10) so a transient failure is never
-  // conflated with an expiry.
+  // An expired session leaves a valid-shaped credentials.json on disk. Validate
+  // now: an expired grant is absorbed (drop creds so the login branch re-runs
+  // the device flow); a non-expiry error is left for the downstream authed call
+  // to surface, so a transient blip is never conflated with an expiry.
   if (creds) {
     try {
       creds = await refreshIfNeeded(creds);
@@ -116,9 +99,8 @@ export async function handleSetup(options: SetupOptions): Promise<void> {
   // --- 1. Login + project resolution ---------------------------------------
 
   if (!creds) {
-    // Not logged in: run the device flow. The browser is where the project is
-    // chosen/created (when there's no link), and the chosen id rides back on
-    // the device-token metadata (parseProjectFromMetadata).
+    // Not logged in: run the device flow. The browser picks/creates the project
+    // (when there's no link) and its id rides back on the device-token metadata.
     let login;
     try {
       login = await handleLogin({ frontendUrl, noBrowser: options.browser === false });
@@ -134,15 +116,14 @@ export async function handleSetup(options: SetupOptions): Promise<void> {
     const userBaseUrl = baseUrl;
 
     if (link) {
-      // Directory already declares the project — ignore the metadata-borne id
-      // and assert the freshly-authenticated user can access the linked project.
+      // Directory already declares the project — ignore the metadata id and
+      // check the user can access the linked project.
       await assertAccess(creds, userBaseUrl, link, existingKey, isJson);
     } else if (login.projectId) {
       // Browser-selected (or just-created) project. Trust it and write the link.
       link = await writeLink(userBaseUrl, login.projectId, isJson);
     } else {
-      // Defensive: fall back to the CLI picker if the browser didn't attach a
-      // project via metadata.
+      // Defensive: fall back to the CLI picker if the browser attached no project.
       link = await resolveProjectViaCli(creds, userBaseUrl, issuer, isJson, options);
     }
   } else {
@@ -174,8 +155,8 @@ export async function handleSetup(options: SetupOptions): Promise<void> {
   const issuer = creds.issuer || frontendUrl;
   const userBaseUrl = baseUrl;
 
-  // --- 3. Key handling (SPEC 36-42) -----------------------------------------
-  // Shared with `project link` — the whole probe/mint/write is `ensureProjectKey`.
+  // --- 3. Key handling ------------------------------------------------------
+  // Shared with `project link` — probe/mint/write is `ensureProjectKey`.
   const { apiKey, envFileUpdated: envPath } = await ensureProjectKey({
     creds,
     link,
@@ -191,16 +172,15 @@ export async function handleSetup(options: SetupOptions): Promise<void> {
 
   let skillsInstalled: string[] = [];
   try {
-    // installSkill fetches the skill from the lmnr-skills repo and is
-    // best-effort: it logs + returns `skipped: true` on network/codeload
-    // failure rather than throwing, so setup never breaks here.
+    // Best-effort: returns skipped: true on failure rather than throwing, so
+    // setup never breaks here.
     const skillResult = await installSkill(process.cwd());
     skillsInstalled = skillResult.written;
     if (!isJson) {
       if (skillResult.skipped) {
         process.stderr.write(pc.dim("  Laminar skill install skipped\n"));
       } else if (skillResult.written.length > 0) {
-        // One mark for the whole skill, not one per file (SKILL.md + references).
+        // One mark for the whole skill, not one per file.
         const note = skillResult.defaulted
           ? pc.dim(" (no agent dir found; defaulted to .claude and .agents)")
           : "";
@@ -255,10 +235,8 @@ export async function handleSetup(options: SetupOptions): Promise<void> {
 // ---------------------------------------------------------------------------
 
 /**
- * Resolve a project via the CLI (logged-in, no link). 0 projects routes to the
- * browser create flow (gap A): we re-run the device flow, which lands on the
- * /device picker → first-project create UI, and the new project's id rides back
- * on the device-token metadata. >1 prompts a CLI choice; ==1 auto-selects.
+ * Resolve a project via the CLI (logged-in, no link). 0 projects re-runs the
+ * device flow (browser create UI); >1 prompts a CLI choice; ==1 auto-selects.
  */
 async function resolveProjectViaCli(
   creds: Credentials,
@@ -271,9 +249,8 @@ async function resolveProjectViaCli(
   try {
     projects = await listProjects(creds, userBaseUrl);
   } catch (err) {
-    // Expiry can surface here (listProjects → refreshIfNeeded) if the up-front
-    // gate hit a transient error and swallowed it: keep it login_failed (6), not
-    // list_projects_failed (10) — same 6-vs-10 contract as link / plugin.
+    // Expiry can surface here if the up-front gate swallowed a transient error:
+    // keep it login_failed (6), not list_projects_failed (10).
     if (err instanceof SessionExpiredError) {
       failWith(isJson, loginFailed("Session expired. Run `lmnr-cli login` first."));
     }
@@ -281,9 +258,8 @@ async function resolveProjectViaCli(
   }
 
   if (projects.length === 0) {
-    // Gap A: no project to select and the CLI can't create one. Drive the
-    // browser create flow — same path the not-logged-in 0-project user takes —
-    // so project creation lives in ONE place (the /device picker).
+    // No project to select and the CLI can't create one. Drive the browser
+    // create flow so project creation lives in one place (the /device picker).
     if (isJson) {
       failWith(
         isJson,
@@ -319,7 +295,7 @@ async function resolveProjectViaCli(
 
   let chosen: CliProject;
   if (options.projectId) {
-    // Explicit --project-id disambiguates. Validate against the accessible set.
+    // --project-id disambiguates. Validate against the accessible set.
     const match = projects.find((p) => p.id === options.projectId);
     if (!match) {
       failWith(
@@ -400,12 +376,8 @@ async function writeLink(
 }
 
 /**
- * Access check: the logged-in user must be a member of the directory-linked
- * project (`link.projectId`). Calls GET /v1/cli/projects (user JWT) and asserts
- * the id is present; aborts otherwise (SPEC: "You don't have access to the
- * project in this directory"). On failure, names the actual mismatch (linked
- * project vs. logged-in account) and the two things that pin a stale project —
- * `.lmnr/project.json` and any `LMNR_PROJECT_API_KEY` in the environment.
+ * Assert the logged-in user is a member of the directory-linked project.
+ * Aborts with an actionable error otherwise.
  */
 async function assertAccess(
   creds: Credentials,
@@ -418,14 +390,12 @@ async function assertAccess(
   try {
     projects = await listProjects(creds, userBaseUrl);
   } catch (err) {
-    // An expired grant (listProjects → refreshIfNeeded) is an auth failure, not a
-    // transient one: login_failed (6), consistent with the resolve path above.
+    // An expired grant is an auth failure: login_failed (6).
     if (err instanceof SessionExpiredError) {
       failWith(isJson, loginFailed("Session expired. Run `lmnr-cli login` first."));
     }
-    // Discovery FAILED (network/5xx) — we couldn't determine access. Report it
-    // as a transient list failure (exit 10), NOT no_access (exit 4): automation
-    // must be able to retry instead of concluding the user lacks access.
+    // Discovery failed (network/5xx) — report as a transient list failure
+    // (exit 10), NOT no_access (exit 4), so automation can retry.
     failWith(isJson, listProjectsFailed(errorMessage(err)));
   }
   if (!projects.some((p) => p.id === link.projectId)) {
@@ -434,9 +404,8 @@ async function assertAccess(
 }
 
 /**
- * Build the `no_access` detail: lead with the SPEC sentence (so substring
- * matchers keep working), then explain the linked-project-vs-account mismatch
- * and the concrete remediation steps.
+ * Build the `no_access` detail. Leads with the SPEC sentence (so substring
+ * matchers keep working), then explains the mismatch and remediation steps.
  */
 function buildNoAccessDetail(
   link: LocalProjectFile,

--- a/packages/lmnr-cli/src/commands/setup/index.ts
+++ b/packages/lmnr-cli/src/commands/setup/index.ts
@@ -86,11 +86,13 @@ export async function handleSetup(options: SetupOptions): Promise<void> {
   // now: an expired grant is absorbed (drop creds so the login branch re-runs
   // the device flow); a non-expiry error is left for the downstream authed call
   // to surface, so a transient blip is never conflated with an expiry.
+  let expiredIssuer: string | undefined;
   if (creds) {
     try {
       creds = await refreshIfNeeded(creds);
     } catch (err) {
       if (err instanceof SessionExpiredError) {
+        expiredIssuer = creds.issuer;
         creds = null;
       }
     }
@@ -102,8 +104,14 @@ export async function handleSetup(options: SetupOptions): Promise<void> {
     // Not logged in: run the device flow. The browser picks/creates the project
     // (when there's no link) and its id rides back on the device-token metadata.
     let login;
+    // On expiry recovery, fall back to the expired creds' issuer over the cloud
+    // default — an explicit --frontend-url / LMNR_FRONTEND_URL still wins.
+    const loginUrl =
+      !options.frontendUrl && !process.env.LMNR_FRONTEND_URL && expiredIssuer
+        ? expiredIssuer
+        : frontendUrl;
     try {
-      login = await handleLogin({ frontendUrl, noBrowser: options.browser === false });
+      login = await handleLogin({ frontendUrl: loginUrl, noBrowser: options.browser === false });
     } catch (err) {
       failWith(isJson, loginFailed(errorMessage(err)));
     }

--- a/packages/lmnr-cli/src/commands/setup/index.ts
+++ b/packages/lmnr-cli/src/commands/setup/index.ts
@@ -7,6 +7,15 @@ import { version } from "../../../package.json";
 import { type Credentials, safeReadCredentials } from "../../auth/credentials";
 import { refreshIfNeeded, SessionExpiredError } from "../../auth/resolve";
 import { DEFAULT_BASE_URL, DEFAULT_FRONTEND_URL } from "../../constants";
+import {
+  failWith,
+  listProjectsFailed,
+  loginFailed,
+  noAccess,
+  noProjects,
+  projectAmbiguous,
+  setupInvariant,
+} from "../../errors";
 import { orange, pc, pcOut } from "../../utils/colors";
 import { type EnvKeyLocation, findEnvKey } from "../../utils/env-file";
 import { installSkill } from "../../utils/install-skill";
@@ -15,17 +24,10 @@ import {
   readLocalProjectFile,
   writeLocalProjectFile,
 } from "../../utils/local-project-file";
-import { emitError } from "../../utils/output";
 import { listProjects, promptProjectChoice } from "../../utils/projects";
 import { firstNonEmpty, trimSlash } from "../../utils/text";
 import { handleLogin } from "../login";
-import {
-  ensureProjectKey,
-  EXIT_LIST_PROJECTS_FAILED,
-  EXIT_LOGIN_FAILED,
-  EXIT_NO_ACCESS,
-  EXIT_NO_PROJECT,
-} from "../project/link-core";
+import { ensureProjectKey } from "../project/link-core";
 
 export interface SetupOptions {
   writeEnv?: boolean;
@@ -121,13 +123,11 @@ export async function handleSetup(options: SetupOptions): Promise<void> {
     try {
       login = await handleLogin({ frontendUrl, noBrowser: options.browser === false });
     } catch (err) {
-      emitError(isJson, "login_failed", errorMessage(err));
-      process.exit(EXIT_LOGIN_FAILED);
+      failWith(isJson, loginFailed(errorMessage(err)));
     }
     creds = await safeReadCredentials();
     if (!creds) {
-      emitError(isJson, "login_failed", "credentials missing after login");
-      process.exit(EXIT_LOGIN_FAILED);
+      failWith(isJson, loginFailed("credentials missing after login"));
     }
 
     const issuer = creds.issuer || frontendUrl;
@@ -168,8 +168,7 @@ export async function handleSetup(options: SetupOptions): Promise<void> {
   // --- 2. Assert invariants -------------------------------------------------
 
   if (!creds || !link.projectId) {
-    emitError(isJson, "setup_invariant", "missing credentials or project after resolution");
-    process.exit(EXIT_NO_PROJECT);
+    failWith(isJson, setupInvariant("missing credentials or project after resolution"));
   }
 
   const issuer = creds.issuer || frontendUrl;
@@ -272,8 +271,7 @@ async function resolveProjectViaCli(
   try {
     projects = await listProjects(creds, userBaseUrl);
   } catch (err) {
-    emitError(isJson, "list_projects_failed", errorMessage(err));
-    process.exit(EXIT_LIST_PROJECTS_FAILED);
+    failWith(isJson, listProjectsFailed(errorMessage(err)));
   }
 
   if (projects.length === 0) {
@@ -281,13 +279,13 @@ async function resolveProjectViaCli(
     // browser create flow — same path the not-logged-in 0-project user takes —
     // so project creation lives in ONE place (the /device picker).
     if (isJson) {
-      emitError(
+      failWith(
         isJson,
-        "no_projects",
-        `No projects found. Run \`lmnr-cli setup\` interactively (it opens the browser ` +
-        `to create your first project) or create one at ${trimSlash(issuer)}/onboarding.`,
+        noProjects(
+          `No projects found. Run \`lmnr-cli setup\` interactively (it opens the browser ` +
+          `to create your first project) or create one at ${trimSlash(issuer)}/onboarding.`,
+        ),
       );
-      process.exit(EXIT_NO_PROJECT);
     }
     process.stderr.write(
       "\nYou have no projects yet. Opening the browser to create your first one...\n",
@@ -299,16 +297,16 @@ async function resolveProjectViaCli(
         noBrowser: options.browser === false,
       });
     } catch (err) {
-      emitError(isJson, "login_failed", errorMessage(err));
-      process.exit(EXIT_LOGIN_FAILED);
+      failWith(isJson, loginFailed(errorMessage(err)));
     }
     if (!login.projectId) {
-      emitError(
+      failWith(
         isJson,
-        "no_projects",
-        `No project was created. Create one at ${trimSlash(issuer)}/onboarding then re-run setup.`,
+        noProjects(
+          `No project was created. Create one at ${trimSlash(issuer)}/onboarding ` +
+          `then re-run setup.`,
+        ),
       );
-      process.exit(EXIT_NO_PROJECT);
     }
     return writeLink(userBaseUrl, login.projectId, isJson);
   }
@@ -318,26 +316,26 @@ async function resolveProjectViaCli(
     // Explicit --project-id disambiguates. Validate against the accessible set.
     const match = projects.find((p) => p.id === options.projectId);
     if (!match) {
-      emitError(
+      failWith(
         isJson,
-        "no_access",
-        `You don't have access to project ${options.projectId}. Accessible: ` +
-        projects.map((p) => `${p.id} (${p.workspaceName}/${p.name})`).join(", "),
+        noAccess(
+          `You don't have access to project ${options.projectId}. Accessible: ` +
+          projects.map((p) => `${p.id} (${p.workspaceName}/${p.name})`).join(", "),
+        ),
       );
-      process.exit(EXIT_NO_ACCESS);
     }
     chosen = match;
   } else if (projects.length === 1) {
     chosen = projects[0];
   } else {
     if (isJson) {
-      emitError(
+      failWith(
         isJson,
-        "project_ambiguous",
-        `Multiple projects: pass --project-id <id>, or run setup interactively. ` +
-        projects.map((p) => `${p.id} (${p.workspaceName}/${p.name})`).join(", "),
+        projectAmbiguous(
+          `Multiple projects: pass --project-id <id>, or run setup interactively. ` +
+          projects.map((p) => `${p.id} (${p.workspaceName}/${p.name})`).join(", "),
+        ),
       );
-      process.exit(EXIT_NO_PROJECT);
     }
     chosen = await promptProjectChoice(projects, "\nMultiple projects available. Choose one:\n");
   }
@@ -417,12 +415,10 @@ async function assertAccess(
     // Discovery FAILED (network/5xx) — we couldn't determine access. Report it
     // as a transient list failure (exit 10), NOT no_access (exit 4): automation
     // must be able to retry instead of concluding the user lacks access.
-    emitError(isJson, "list_projects_failed", errorMessage(err));
-    process.exit(EXIT_LIST_PROJECTS_FAILED);
+    failWith(isJson, listProjectsFailed(errorMessage(err)));
   }
   if (!projects.some((p) => p.id === link.projectId)) {
-    emitError(isJson, "no_access", buildNoAccessDetail(link, creds, existingKey, projects));
-    process.exit(EXIT_NO_ACCESS);
+    failWith(isJson, noAccess(buildNoAccessDetail(link, creds, existingKey, projects)));
   }
 }
 

--- a/packages/lmnr-cli/src/commands/setup/index.ts
+++ b/packages/lmnr-cli/src/commands/setup/index.ts
@@ -271,6 +271,12 @@ async function resolveProjectViaCli(
   try {
     projects = await listProjects(creds, userBaseUrl);
   } catch (err) {
+    // Expiry can surface here (listProjects → refreshIfNeeded) if the up-front
+    // gate hit a transient error and swallowed it: keep it login_failed (6), not
+    // list_projects_failed (10) — same 6-vs-10 contract as link / plugin.
+    if (err instanceof SessionExpiredError) {
+      failWith(isJson, loginFailed("Session expired. Run `lmnr-cli login` first."));
+    }
     failWith(isJson, listProjectsFailed(errorMessage(err)));
   }
 
@@ -412,6 +418,11 @@ async function assertAccess(
   try {
     projects = await listProjects(creds, userBaseUrl);
   } catch (err) {
+    // An expired grant (listProjects → refreshIfNeeded) is an auth failure, not a
+    // transient one: login_failed (6), consistent with the resolve path above.
+    if (err instanceof SessionExpiredError) {
+      failWith(isJson, loginFailed("Session expired. Run `lmnr-cli login` first."));
+    }
     // Discovery FAILED (network/5xx) — we couldn't determine access. Report it
     // as a transient list failure (exit 10), NOT no_access (exit 4): automation
     // must be able to retry instead of concluding the user lacks access.

--- a/packages/lmnr-cli/src/commands/sql/README.md
+++ b/packages/lmnr-cli/src/commands/sql/README.md
@@ -16,6 +16,18 @@ These options apply to all sql subcommands:
 - `--base-url <url>` - Base URL for the Laminar API (default: https://api.lmnr.ai)
 - `--port <port>` - Port for the Laminar API (default: 443)
 - `--json` - Output structured JSON to stdout
+- `--pretty` - Render results as a human-readable table (default output is CSV)
+
+## Output format
+
+By default `sql query` prints **CSV** to stdout: a header row of column names
+followed by one record per line, so results pipe cleanly into other tools and
+are easy for agents to parse. Cells containing commas, quotes, or newlines are
+quoted per RFC 4180; object/jsonb columns are emitted as a JSON string in a
+single cell. The row-count summary is written to stderr, keeping stdout pure CSV.
+
+- `--json` emits a JSON array of row objects instead.
+- `--pretty` renders the borderless human-readable table.
 
 ## Commands
 

--- a/packages/lmnr-cli/src/commands/sql/index.test.ts
+++ b/packages/lmnr-cli/src/commands/sql/index.test.ts
@@ -13,6 +13,9 @@ const baseOpts = { projectId: 'fake-project', baseUrl: 'http://localhost', port:
 
 let logSpy: ReturnType<typeof vi.spyOn>;
 
+const stdout = (): string =>
+  (logSpy.mock.calls as unknown[][]).map((c) => c[0]).join('\n');
+
 beforeEach(() => {
   logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
   vi.clearAllMocks();
@@ -42,31 +45,9 @@ describe('handleSqlQuery', () => {
     expect(logSpy).toHaveBeenCalledWith('[]');
   });
 
-  // --- Human mode ---
+  // --- Default (CSV) mode ---
 
-  it('prints column headers', async () => {
-    mockQuery.mockResolvedValue([{ id: '1', name: 'alice' }]);
-
-    await handleSqlQuery(stubClient, 'SELECT * FROM spans', baseOpts);
-
-    const output = logSpy.mock.calls.map((c: unknown[]) => c[0]).join('\n');
-    expect(output).toContain('id');
-    expect(output).toContain('name');
-  });
-
-  it('separates columns with spacing', async () => {
-    mockQuery.mockResolvedValue([{ id: '1', name: 'alice' }]);
-
-    await handleSqlQuery(stubClient, 'SELECT * FROM spans', baseOpts);
-
-    const output = logSpy.mock.calls.map((c: unknown[]) => c[0]).join('\n');
-    // Strip ANSI codes then check column spacing
-    // eslint-disable-next-line no-control-regex
-    const plain = output.replace(/\x1b\[[0-9;]*m/g, '');
-    expect(plain).toMatch(/id\s+name/);
-  });
-
-  it('prints each row', async () => {
+  it('outputs a CSV header row and one line per record by default', async () => {
     mockQuery.mockResolvedValue([
       { id: '1', name: 'alice' },
       { id: '2', name: 'bob' },
@@ -74,24 +55,109 @@ describe('handleSqlQuery', () => {
 
     await handleSqlQuery(stubClient, 'SELECT * FROM spans', baseOpts);
 
-    const output = logSpy.mock.calls.map((c: unknown[]) => c[0]).join('\n');
-    expect(output).toContain('alice');
-    expect(output).toContain('bob');
+    // Single stdout write: the whole CSV block (row count goes to stderr).
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(logSpy).toHaveBeenCalledWith('id,name\n1,alice\n2,bob');
   });
 
-  it('prints row count summary', async () => {
+  it('quotes cells containing commas, quotes, or newlines', async () => {
+    mockQuery.mockResolvedValue([
+      { id: '1', text: 'hello, world' },
+      { id: '2', text: 'say "hi"' },
+      { id: '3', text: 'line1\nline2' },
+    ]);
+
+    await handleSqlQuery(stubClient, 'SELECT * FROM spans', baseOpts);
+
+    expect(stdout()).toBe(
+      'id,text\n1,"hello, world"\n2,"say ""hi"""\n3,"line1\nline2"',
+    );
+  });
+
+  it('serializes object/jsonb cells as a single JSON string cell', async () => {
+    mockQuery.mockResolvedValue([
+      { id: '1', attributes: { model: 'gpt-4', nested: { a: 1 } } },
+    ]);
+
+    await handleSqlQuery(stubClient, 'SELECT * FROM spans', baseOpts);
+
+    expect(stdout()).toBe(
+      'id,attributes\n1,"{""model"":""gpt-4"",""nested"":{""a"":1}}"',
+    );
+  });
+
+  it('renders null/undefined cells as empty fields', async () => {
+    mockQuery.mockResolvedValue([{ id: '1', name: null }]);
+
+    await handleSqlQuery(stubClient, 'SELECT * FROM spans', baseOpts);
+
+    expect(stdout()).toBe('id,name\n1,');
+  });
+
+  it('does not write a row-count summary to stdout in CSV mode', async () => {
     mockQuery.mockResolvedValue([{ id: '1' }, { id: '2' }]);
 
     await handleSqlQuery(stubClient, 'SELECT * FROM spans', baseOpts);
 
-    const output = logSpy.mock.calls.map((c: unknown[]) => c[0]).join('\n');
-    expect(output).toContain('2 row(s)');
+    expect(stdout()).not.toContain('row(s)');
   });
 
-  it('prints "No rows returned." when result is empty', async () => {
+  it('writes nothing to stdout when no rows are returned (CSV mode)', async () => {
     mockQuery.mockResolvedValue([]);
 
     await handleSqlQuery(stubClient, 'SELECT * FROM spans', baseOpts);
+
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  // --- --pretty (table) mode ---
+
+  it('prints column headers in pretty mode', async () => {
+    mockQuery.mockResolvedValue([{ id: '1', name: 'alice' }]);
+
+    await handleSqlQuery(stubClient, 'SELECT * FROM spans', { ...baseOpts, pretty: true });
+
+    const output = stdout();
+    expect(output).toContain('id');
+    expect(output).toContain('name');
+  });
+
+  it('separates columns with spacing in pretty mode', async () => {
+    mockQuery.mockResolvedValue([{ id: '1', name: 'alice' }]);
+
+    await handleSqlQuery(stubClient, 'SELECT * FROM spans', { ...baseOpts, pretty: true });
+
+    // Strip ANSI codes then check column spacing
+    // eslint-disable-next-line no-control-regex
+    const plain = stdout().replace(/\x1b\[[0-9;]*m/g, '');
+    expect(plain).toMatch(/id\s+name/);
+  });
+
+  it('prints each row in pretty mode', async () => {
+    mockQuery.mockResolvedValue([
+      { id: '1', name: 'alice' },
+      { id: '2', name: 'bob' },
+    ]);
+
+    await handleSqlQuery(stubClient, 'SELECT * FROM spans', { ...baseOpts, pretty: true });
+
+    const output = stdout();
+    expect(output).toContain('alice');
+    expect(output).toContain('bob');
+  });
+
+  it('prints row count summary to stdout in pretty mode', async () => {
+    mockQuery.mockResolvedValue([{ id: '1' }, { id: '2' }]);
+
+    await handleSqlQuery(stubClient, 'SELECT * FROM spans', { ...baseOpts, pretty: true });
+
+    expect(stdout()).toContain('2 row(s)');
+  });
+
+  it('prints "No rows returned." to stdout in pretty mode when empty', async () => {
+    mockQuery.mockResolvedValue([]);
+
+    await handleSqlQuery(stubClient, 'SELECT * FROM spans', { ...baseOpts, pretty: true });
 
     expect(logSpy).toHaveBeenCalledWith('No rows returned.');
   });

--- a/packages/lmnr-cli/src/commands/sql/index.ts
+++ b/packages/lmnr-cli/src/commands/sql/index.ts
@@ -1,7 +1,7 @@
 import { LaminarClient } from "@lmnr-ai/client";
 
 import type { GlobalOpts } from "../../auth/with-client";
-import { outputJson } from "../../utils/output";
+import { outputJson, printData } from "../../utils/output";
 import { renderTable } from "../../utils/table";
 
 /**
@@ -22,7 +22,7 @@ export const handleSqlQuery = async (
   }
 
   if (rows.length === 0) {
-    console.log("No rows returned.");
+    printData("No rows returned.");
     return;
   }
 
@@ -31,6 +31,6 @@ export const handleSqlQuery = async (
     columns.map((col) => String(row[col] ?? "")),
   );
 
-  console.log(renderTable(columns, tableRows));
-  console.log(`\n${rows.length} row(s)\n`);
+  printData(renderTable(columns, tableRows));
+  printData(`\n${rows.length} row(s)\n`);
 };

--- a/packages/lmnr-cli/src/commands/sql/index.ts
+++ b/packages/lmnr-cli/src/commands/sql/index.ts
@@ -1,13 +1,24 @@
 import { LaminarClient } from "@lmnr-ai/client";
 
 import type { GlobalOpts } from "../../auth/with-client";
+import { toCsv } from "../../utils/csv";
+import { initializeLogger } from "../../utils/logger";
 import { outputJson, printData } from "../../utils/output";
 import { renderTable } from "../../utils/table";
+
+const logger = initializeLogger();
 
 /**
  * Run a SQL query against the project's data and print the rows. Pure handler:
  * the command wrapper (`withProjectClient`) resolves the client and owns the
  * error envelope (`--json` → structured error + exit, otherwise log + exit).
+ *
+ * Output modes:
+ * - `--json`   → JSON array of row objects (machine-readable, unchanged).
+ * - `--pretty` → the borderless human table (previous default).
+ * - default    → CSV: one record per line, compact and agent-parseable when
+ *   piped. Only the CSV goes to stdout; the row-count summary is logged to
+ *   stderr so a downstream parser gets pure CSV.
  */
 export const handleSqlQuery = async (
   client: LaminarClient,
@@ -22,15 +33,29 @@ export const handleSqlQuery = async (
   }
 
   if (rows.length === 0) {
-    printData("No rows returned.");
+    // Nothing to serialize. In the default (CSV) path keep stdout empty so a
+    // piped consumer doesn't parse a note as a data row; humans get a stderr
+    // note. `--pretty` keeps the note on stdout, as before.
+    if (opts.pretty) {
+      printData("No rows returned.");
+    } else {
+      logger.info("No rows returned.");
+    }
     return;
   }
 
   const columns = Object.keys(rows[0]);
-  const tableRows = rows.map((row) =>
-    columns.map((col) => String(row[col] ?? "")),
-  );
 
-  printData(renderTable(columns, tableRows));
-  printData(`\n${rows.length} row(s)\n`);
+  if (opts.pretty) {
+    const tableRows = rows.map((row) =>
+      columns.map((col) => String(row[col] ?? "")),
+    );
+    printData(renderTable(columns, tableRows));
+    printData(`\n${rows.length} row(s)\n`);
+    return;
+  }
+
+  // Default: CSV to stdout, row-count summary to stderr (keeps stdout pure CSV).
+  printData(toCsv(columns, rows));
+  logger.info(`${rows.length} row(s)`);
 };

--- a/packages/lmnr-cli/src/commands/sql/index.ts
+++ b/packages/lmnr-cli/src/commands/sql/index.ts
@@ -9,16 +9,11 @@ import { renderTable } from "../../utils/table";
 const logger = initializeLogger();
 
 /**
- * Run a SQL query against the project's data and print the rows. Pure handler:
- * the command wrapper (`withProjectClient`) resolves the client and owns the
- * error envelope (`--json` → structured error + exit, otherwise log + exit).
+ * Run a SQL query and print the rows. Pure handler — `withProjectClient` owns
+ * the client and error envelope.
  *
- * Output modes:
- * - `--json`   → JSON array of row objects (machine-readable, unchanged).
- * - `--pretty` → the borderless human table (previous default).
- * - default    → CSV: one record per line, compact and agent-parseable when
- *   piped. Only the CSV goes to stdout; the row-count summary is logged to
- *   stderr so a downstream parser gets pure CSV.
+ * Output: `--json` → JSON array, `--pretty` → human table, default → CSV to
+ * stdout with the row-count on stderr (keeps stdout pure CSV for piping).
  */
 export const handleSqlQuery = async (
   client: LaminarClient,
@@ -33,9 +28,8 @@ export const handleSqlQuery = async (
   }
 
   if (rows.length === 0) {
-    // Nothing to serialize. In the default (CSV) path keep stdout empty so a
-    // piped consumer doesn't parse a note as a data row; humans get a stderr
-    // note. `--pretty` keeps the note on stdout, as before.
+    // Keep stdout empty in the CSV path so a piped consumer doesn't read the
+    // note as a data row; --pretty still puts it on stdout.
     if (opts.pretty) {
       printData("No rows returned.");
     } else {

--- a/packages/lmnr-cli/src/commands/status/index.test.ts
+++ b/packages/lmnr-cli/src/commands/status/index.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const h = vi.hoisted(() => ({
+  safeReadCredentials: vi.fn(),
+  readLocalProjectFile: vi.fn(),
+  readDebugSessionFile: vi.fn(),
+  resolveDebugSessionDir: vi.fn(() => "/repo"),
+}));
+
+vi.mock("../../auth/credentials", () => ({ safeReadCredentials: h.safeReadCredentials }));
+vi.mock("../../utils/local-project-file", () => ({ readLocalProjectFile: h.readLocalProjectFile }));
+vi.mock("../../utils/debug-session-file", () => ({
+  readDebugSessionFile: h.readDebugSessionFile,
+  resolveDebugSessionDir: h.resolveDebugSessionDir,
+}));
+
+import { handleStatus } from "./index";
+
+let stdoutSpy: ReturnType<typeof vi.spyOn>;
+let logSpy: ReturnType<typeof vi.spyOn>;
+
+const out = (): string =>
+  (stdoutSpy.mock.calls as unknown[][]).map((c) => String(c[0])).join("");
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+  // outputJson uses console.log.
+  logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("handleStatus", () => {
+  it("renders user, project, workspace, and debug session in human mode", async () => {
+    h.safeReadCredentials.mockResolvedValue({ userEmail: "dev@example.com" });
+    h.readLocalProjectFile.mockResolvedValue({
+      projectId: "p1",
+      projectName: "Alpha",
+      workspaceName: "Acme",
+    });
+    h.readDebugSessionFile.mockReturnValue({
+      session_id: "sess-1",
+      debugger_url: "https://laminar.sh/project/p1/debugger-sessions/sess-1",
+    });
+
+    await handleStatus({});
+
+    const text = out();
+    expect(text).toContain("dev@example.com");
+    expect(text).toContain("Alpha");
+    expect(text).toContain("p1");
+    expect(text).toContain("Acme");
+    expect(text).toContain("sess-1");
+    expect(text).toContain("debugger-sessions/sess-1");
+  });
+
+  it("degrades gracefully when nothing is set (no error)", async () => {
+    h.safeReadCredentials.mockResolvedValue(null);
+    h.readLocalProjectFile.mockResolvedValue(null);
+    h.readDebugSessionFile.mockReturnValue(null);
+
+    await handleStatus({});
+
+    const text = out();
+    expect(text).toContain("not logged in");
+    expect(text).toContain("no project linked here");
+    expect(text).toContain("none active");
+  });
+
+  it("--json emits a single flat object with stable keys, no decorative text", async () => {
+    h.safeReadCredentials.mockResolvedValue({ userEmail: "dev@example.com" });
+    h.readLocalProjectFile.mockResolvedValue({
+      projectId: "p1",
+      projectName: "Alpha",
+      workspaceId: "w1",
+      workspaceName: "Acme",
+    });
+    h.readDebugSessionFile.mockReturnValue({
+      session_id: "sess-1",
+      debugger_url: "https://laminar.sh/x",
+    });
+
+    await handleStatus({ json: true });
+
+    // JSON goes through outputJson (console.log); nothing decorative on stdout.
+    expect(stdoutSpy).not.toHaveBeenCalled();
+    expect(logSpy).toHaveBeenCalledOnce();
+    const parsed = JSON.parse(String(logSpy.mock.calls[0][0]));
+    expect(parsed).toEqual({
+      userEmail: "dev@example.com",
+      projectId: "p1",
+      projectName: "Alpha",
+      workspaceId: "w1",
+      workspaceName: "Acme",
+      debugSessionId: "sess-1",
+      debuggerUrl: "https://laminar.sh/x",
+    });
+  });
+
+  it("--json uses null for every absent field", async () => {
+    h.safeReadCredentials.mockResolvedValue(null);
+    h.readLocalProjectFile.mockResolvedValue(null);
+    h.readDebugSessionFile.mockReturnValue(null);
+
+    await handleStatus({ json: true });
+
+    const parsed = JSON.parse(String(logSpy.mock.calls[0][0]));
+    expect(parsed).toEqual({
+      userEmail: null,
+      projectId: null,
+      projectName: null,
+      workspaceId: null,
+      workspaceName: null,
+      debugSessionId: null,
+      debuggerUrl: null,
+    });
+  });
+});

--- a/packages/lmnr-cli/src/commands/status/index.ts
+++ b/packages/lmnr-cli/src/commands/status/index.ts
@@ -1,0 +1,86 @@
+import { safeReadCredentials } from "../../auth/credentials";
+import type { GlobalOpts } from "../../auth/with-client";
+import { pc } from "../../utils/colors";
+import { readDebugSessionFile, resolveDebugSessionDir } from "../../utils/debug-session-file";
+import { readLocalProjectFile } from "../../utils/local-project-file";
+import { outputJson } from "../../utils/output";
+
+/** Flat, stable-keyed status object — the `--json` contract. */
+interface StatusReport {
+  userEmail: string | null;
+  projectId: string | null;
+  projectName: string | null;
+  workspaceId: string | null;
+  workspaceName: string | null;
+  debugSessionId: string | null;
+  debuggerUrl: string | null;
+}
+
+/** Fixed label column width so the human report lines up. */
+const LABEL_WIDTH = 14;
+
+const row = (label: string, value: string): string =>
+  `  ${label.padEnd(LABEL_WIDTH)}${value}\n`;
+
+/**
+ * `lmnr-cli status` — report the CLI's current context: the signed-in user, the
+ * project linked to this directory, and the active debug session. Everything is
+ * read from local state (credentials.json, `.lmnr/project.json`,
+ * `.lmnr/debug-session.json`), so it works offline and never makes an API call.
+ *
+ * Each field degrades gracefully to a "not set" line when absent rather than
+ * erroring — the command exits 0 as long as it ran. Local-only handler
+ * (registered via `withLocalOpts`): no auth resolution, no network.
+ *
+ * The debug session's display NAME is intentionally omitted: it is not stored
+ * locally and there is no endpoint to read it back, so `status` shows the
+ * session id + debugger URL only (a backend GET-session endpoint is the
+ * follow-up that would let it show the name).
+ */
+export const handleStatus = async (opts: GlobalOpts): Promise<void> => {
+  const creds = await safeReadCredentials();
+  const link = await readLocalProjectFile();
+  const session = readDebugSessionFile(resolveDebugSessionDir());
+
+  const report: StatusReport = {
+    userEmail: creds?.userEmail ?? null,
+    projectId: link?.projectId ?? null,
+    projectName: link?.projectName ?? null,
+    workspaceId: link?.workspaceId ?? null,
+    workspaceName: link?.workspaceName ?? null,
+    debugSessionId: session?.session_id ?? null,
+    debuggerUrl: session?.debugger_url ?? null,
+  };
+
+  if (opts.json) {
+    outputJson(report);
+    return;
+  }
+
+  const notSet = (msg: string) => pc.dim(msg);
+
+  let out = "\n";
+  out += row(
+    "User",
+    report.userEmail ?? notSet("not logged in — run `lmnr-cli login`"),
+  );
+
+  if (report.projectId) {
+    const project = report.projectName
+      ? `${report.projectName} ${pc.dim(`(${report.projectId})`)}`
+      : report.projectId;
+    out += row("Project", project);
+    out += row("Workspace", report.workspaceName ?? notSet("unknown"));
+  } else {
+    out += row("Project", notSet("no project linked here — run `lmnr-cli project link`"));
+  }
+
+  if (report.debugSessionId) {
+    out += row("Debug session", report.debugSessionId);
+    if (report.debuggerUrl) out += row("Debugger URL", report.debuggerUrl);
+  } else {
+    out += row("Debug session", notSet("none active — run `lmnr-cli debug session new`"));
+  }
+
+  process.stdout.write(out);
+};

--- a/packages/lmnr-cli/src/commands/status/index.ts
+++ b/packages/lmnr-cli/src/commands/status/index.ts
@@ -23,19 +23,12 @@ const row = (label: string, value: string): string =>
   `  ${label.padEnd(LABEL_WIDTH)}${value}\n`;
 
 /**
- * `lmnr-cli status` — report the CLI's current context: the signed-in user, the
- * project linked to this directory, and the active debug session. Everything is
- * read from local state (credentials.json, `.lmnr/project.json`,
- * `.lmnr/debug-session.json`), so it works offline and never makes an API call.
+ * `lmnr-cli status` — report the signed-in user, linked project, and active
+ * debug session, all from local state (works offline, no API call). Missing
+ * fields render as "not set"; exits 0. Local-only handler (`withLocalOpts`).
  *
- * Each field degrades gracefully to a "not set" line when absent rather than
- * erroring — the command exits 0 as long as it ran. Local-only handler
- * (registered via `withLocalOpts`): no auth resolution, no network.
- *
- * The debug session's display NAME is intentionally omitted: it is not stored
- * locally and there is no endpoint to read it back, so `status` shows the
- * session id + debugger URL only (a backend GET-session endpoint is the
- * follow-up that would let it show the name).
+ * Session display NAME is omitted — it's not stored locally and there's no
+ * endpoint to read it back, so we show session id + debugger URL only.
  */
 export const handleStatus = async (opts: GlobalOpts): Promise<void> => {
   const creds = await safeReadCredentials();

--- a/packages/lmnr-cli/src/errors.ts
+++ b/packages/lmnr-cli/src/errors.ts
@@ -39,6 +39,15 @@ export const configWriteFailed = (m: string) => new CliError("config_write_faile
 export const unsupportedAgent = (m: string) => new CliError("unsupported_agent", 13, m);
 
 /**
+ * Bare exit codes for the two sites that DON'T go through `failWith`: each emits
+ * a bespoke `--json` payload the generic `{error, detail}` envelope can't carry,
+ * so it `process.exit`s directly. The numbers live here so the whole exit-code
+ * contract stays in one place (8 is the same code as `config_write_failed`).
+ */
+export const EXIT_ENV_WRITE_FAILED = 8;
+export const EXIT_INSTALL_FAILED = 14;
+
+/**
  * Render a {@link CliError} through the shared `emitError` envelope and exit.
  * For the bare-action onboarding commands that own their --json contract.
  *

--- a/packages/lmnr-cli/src/errors.ts
+++ b/packages/lmnr-cli/src/errors.ts
@@ -1,18 +1,11 @@
 import { emitError } from "./utils/output";
 
 /**
- * A CLI error that carries its own machine-readable `code` and process
- * `exitCode` — the "first-class error" shape shared by commander's
- * `CommanderError(exitCode, code, message)` and oclif's `CLIError` (`oclif.exit`
- * + `code`). Pairing the two here means a catch site can't drift them apart or
- * forget the mapping (the failure mode behind the SessionExpiredError bug).
+ * A CLI error carrying its own machine-readable `code` and process `exitCode`.
+ * Pairing them here keeps a catch site from drifting them apart.
  *
- * Two entry styles, one type:
- *  - wrapped commands (the with-client envelope) `throw` it — the envelope's
- *    `ExitCodeMapper` reads `.exitCode` (see `defaultExitCode`).
- *  - bare-action commands (`setup` / `plugin` / `link` / `mint-key`) pass it to
- *    {@link failWith}, which renders + exits inline — they own their own --json
- *    output contract and are not wrapped by the envelope.
+ * Two entry styles: wrapped commands `throw` it (the envelope's `ExitCodeMapper`
+ * reads `.exitCode`); bare-action commands pass it to {@link failWith}.
  */
 export class CliError extends Error {
   constructor(
@@ -26,14 +19,10 @@ export class CliError extends Error {
 }
 
 /**
- * Factories — the SINGLE source of truth pairing each wire `code` with its exit
- * code. These numbers were previously duplicated across `plugin/index.ts` and
- * `project/link-core.ts` (already drifting in name: `EXIT_MINT_FAILED` vs
- * `EXIT_SETUP_KEY_FAILED`, both 9); they live here exactly once now.
- *
- * The `code` strings are a wire contract (agents parse `{error: <code>}`), so
- * several distinct codes intentionally share an exit number (e.g. `no_project`,
- * `no_projects`, `project_ambiguous`, `setup_invariant` are all exit 7).
+ * Factories — the single source of truth pairing each wire `code` with its exit
+ * code. The `code` strings are a wire contract (agents parse `{error: <code>}`),
+ * so several distinct codes intentionally share an exit number (e.g. the exit-7
+ * group below).
  */
 export const loginFailed = (m: string) => new CliError("login_failed", 6, m);
 export const noAccess = (m: string) => new CliError("no_access", 4, m);
@@ -50,18 +39,12 @@ export const configWriteFailed = (m: string) => new CliError("config_write_faile
 export const unsupportedAgent = (m: string) => new CliError("unsupported_agent", 13, m);
 
 /**
- * Render a {@link CliError} through the shared `{error, detail}` envelope
- * (`emitError`) and exit with its code. For the bare-action onboarding commands
- * that own their --json contract and are NOT wrapped by the with-client
- * envelope. Uses a direct `process.exit` — same control flow the audited
- * setup/link flows already rely on, so no exception unwinds through code that
- * wasn't written to catch it.
+ * Render a {@link CliError} through the shared `emitError` envelope and exit.
+ * For the bare-action onboarding commands that own their --json contract.
  *
- * Intentionally a `function` declaration, NOT an arrow (which the style guide
- * otherwise prefers): TypeScript only applies `never`-return control-flow
- * narrowing to a call statement when the callee is a function declaration, so
- * `if (!creds) failWith(...)` narrows `creds` afterward. A `const` arrow would
- * force `return failWith(...)` at every call site to get the same narrowing.
+ * A `function` declaration (not an arrow) on purpose: TS only applies
+ * `never`-return narrowing to a call when the callee is a function declaration,
+ * so `if (!creds) failWith(...)` narrows `creds` afterward.
  */
 export function failWith(isJson: boolean, err: CliError): never {
   emitError(isJson, err.code, err.message);

--- a/packages/lmnr-cli/src/errors.ts
+++ b/packages/lmnr-cli/src/errors.ts
@@ -56,8 +56,14 @@ export const unsupportedAgent = (m: string) => new CliError("unsupported_agent",
  * envelope. Uses a direct `process.exit` — same control flow the audited
  * setup/link flows already rely on, so no exception unwinds through code that
  * wasn't written to catch it.
+ *
+ * Intentionally a `function` declaration, NOT an arrow (which the style guide
+ * otherwise prefers): TypeScript only applies `never`-return control-flow
+ * narrowing to a call statement when the callee is a function declaration, so
+ * `if (!creds) failWith(...)` narrows `creds` afterward. A `const` arrow would
+ * force `return failWith(...)` at every call site to get the same narrowing.
  */
-export const failWith = (isJson: boolean, err: CliError): never => {
+export function failWith(isJson: boolean, err: CliError): never {
   emitError(isJson, err.code, err.message);
   process.exit(err.exitCode);
-};
+}

--- a/packages/lmnr-cli/src/errors.ts
+++ b/packages/lmnr-cli/src/errors.ts
@@ -1,0 +1,63 @@
+import { emitError } from "./utils/output";
+
+/**
+ * A CLI error that carries its own machine-readable `code` and process
+ * `exitCode` — the "first-class error" shape shared by commander's
+ * `CommanderError(exitCode, code, message)` and oclif's `CLIError` (`oclif.exit`
+ * + `code`). Pairing the two here means a catch site can't drift them apart or
+ * forget the mapping (the failure mode behind the SessionExpiredError bug).
+ *
+ * Two entry styles, one type:
+ *  - wrapped commands (the with-client envelope) `throw` it — the envelope's
+ *    `ExitCodeMapper` reads `.exitCode` (see `defaultExitCode`).
+ *  - bare-action commands (`setup` / `plugin` / `link` / `mint-key`) pass it to
+ *    {@link failWith}, which renders + exits inline — they own their own --json
+ *    output contract and are not wrapped by the envelope.
+ */
+export class CliError extends Error {
+  constructor(
+    readonly code: string,
+    readonly exitCode: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = "CliError";
+  }
+}
+
+/**
+ * Factories — the SINGLE source of truth pairing each wire `code` with its exit
+ * code. These numbers were previously duplicated across `plugin/index.ts` and
+ * `project/link-core.ts` (already drifting in name: `EXIT_MINT_FAILED` vs
+ * `EXIT_SETUP_KEY_FAILED`, both 9); they live here exactly once now.
+ *
+ * The `code` strings are a wire contract (agents parse `{error: <code>}`), so
+ * several distinct codes intentionally share an exit number (e.g. `no_project`,
+ * `no_projects`, `project_ambiguous`, `setup_invariant` are all exit 7).
+ */
+export const loginFailed = (m: string) => new CliError("login_failed", 6, m);
+export const noAccess = (m: string) => new CliError("no_access", 4, m);
+export const noProject = (m: string) => new CliError("no_project", 7, m);
+export const noProjects = (m: string) => new CliError("no_projects", 7, m);
+export const projectAmbiguous = (m: string) => new CliError("project_ambiguous", 7, m);
+export const setupInvariant = (m: string) => new CliError("setup_invariant", 7, m);
+export const listProjectsFailed = (m: string) => new CliError("list_projects_failed", 10, m);
+export const keyProbeFailed = (m: string) => new CliError("key_probe_failed", 11, m);
+export const keyMismatch = (m: string) => new CliError("key_mismatch", 12, m);
+export const setupKeyFailed = (m: string) => new CliError("setup_key_failed", 9, m);
+export const mintFailed = (m: string) => new CliError("mint_failed", 9, m);
+export const configWriteFailed = (m: string) => new CliError("config_write_failed", 8, m);
+export const unsupportedAgent = (m: string) => new CliError("unsupported_agent", 13, m);
+
+/**
+ * Render a {@link CliError} through the shared `{error, detail}` envelope
+ * (`emitError`) and exit with its code. For the bare-action onboarding commands
+ * that own their --json contract and are NOT wrapped by the with-client
+ * envelope. Uses a direct `process.exit` — same control flow the audited
+ * setup/link flows already rely on, so no exception unwinds through code that
+ * wasn't written to catch it.
+ */
+export const failWith = (isJson: boolean, err: CliError): never => {
+  emitError(isJson, err.code, err.message);
+  process.exit(err.exitCode);
+};

--- a/packages/lmnr-cli/src/index.ts
+++ b/packages/lmnr-cli/src/index.ts
@@ -23,10 +23,13 @@ import { handleLogin } from "./commands/login";
 import { handleLogout } from "./commands/logout";
 import { handlePluginAdd } from "./commands/plugin";
 import { handleProjectsList } from "./commands/project";
+import { handleProjectLink } from "./commands/project/link";
+import { handleProjectMintKey } from "./commands/project/mint-key";
 import { handleSetup } from "./commands/setup";
 import { handleSkillAdd, handleSkillUpdate } from "./commands/skill";
 import { handleSqlQuery } from "./commands/sql";
 import { SQL_SCHEMA_HELP } from "./commands/sql/schema";
+import { handleStatus } from "./commands/status";
 import { pc } from "./utils/colors";
 import { loadLocalEnv } from "./utils/env-file";
 
@@ -43,6 +46,12 @@ async function main() {
     .name("lmnr-cli")
     .description("CLI for the Laminar agent observability platform")
     .version(version, "-v, --version", "display version number");
+
+  // Auto-tracking of investigative commands (sql query / ask) into the active
+  // debug session lives in the command error envelope (`runWithEnvelope` in
+  // auth/with-client.ts), NOT a Commander hook: the envelope is the only place
+  // that sees both success AND failure with the real exit code (Commander has no
+  // on-error hook). See `maybeTrackCommand`.
 
   const datasetsCmd = program
     .command("dataset")
@@ -177,15 +186,26 @@ async function main() {
     .command("query")
     .description("Execute a SQL query")
     .argument("<query>", "SQL query string")
+    .option(
+      "--no-track",
+      "Do not record this command into the active debug session " +
+      "(also: LMNR_NO_COMMAND_TRACKING=1)",
+    )
     .action(withProjectClient(handleSqlQuery))
     .addHelpText(
       "after",
       SQL_SCHEMA_HELP +
       `
+When a debug session is active in this directory, the command (and its args) is
+recorded into that session as a \`command\` block so a reviewer sees what ran.
+The raw query string is uploaded. Disable with --no-track or
+LMNR_NO_COMMAND_TRACKING=1.
+
 Examples:
   $ lmnr-cli sql query "SELECT * FROM spans LIMIT 10"
   $ lmnr-cli sql query "SELECT id, total_cost, status FROM traces LIMIT 20"
   $ lmnr-cli sql query "SELECT * FROM spans LIMIT 10" --json
+  $ lmnr-cli sql query "SELECT * FROM spans LIMIT 10" --no-track
 `,
     );
 
@@ -220,6 +240,11 @@ Examples:
       "or in the `--json` output as `conversationId`)",
     )
     .option("--json", "Output structured JSON ({ answer, conversationId, tools }) to stdout")
+    .option(
+      "--no-track",
+      "Do not record this command into the active debug session " +
+      "(also: LMNR_NO_COMMAND_TRACKING=1)",
+    )
     .action(withLocalOpts(handleAsk))
     .addHelpText(
       "after",
@@ -228,11 +253,16 @@ Runs on your logged-in user session (\`lmnr-cli login\`) and targets a project v
 --project-id or the linked .lmnr/project.json. The agent answers from your
 project's traces/spans/evals via read-only SQL and trace inspection.
 
+When a debug session is active in this directory, the command (and its args) is
+recorded into that session as a \`command\` block. The raw question is uploaded.
+Disable with --no-track or LMNR_NO_COMMAND_TRACKING=1.
+
 Examples:
   $ lmnr-cli ask "why did my latest trace fail?"
   $ lmnr-cli ask "how many traces errored in the last day?"
   $ lmnr-cli ask "summarize the most expensive trace today" --json
   $ lmnr-cli ask "and which model did it use?" --conversation <id>
+  $ lmnr-cli ask "why did my latest trace fail?" --no-track
 `,
     );
 
@@ -252,6 +282,67 @@ Examples:
     )
     .option("--json", "Output structured JSON to stdout")
     .action(withUserToken(handleProjectsList));
+
+  projectCmd
+    .command("link")
+    .description("Re-point this directory to a project (rewrites .lmnr/project.json)")
+    .option(
+      "--project-id <id>",
+      "Project to link. Omit to open the interactive (alphabetically sorted) picker",
+    )
+    .option(
+      "--base-url <url>",
+      "Base URL for the Laminar API. Defaults to https://api.lmnr.ai or LMNR_BASE_URL env variable",
+    )
+    .option("--no-write-env", "Do not write LMNR_PROJECT_API_KEY to ./.env")
+    .option("--json", "Emit a machine-readable JSON line ({ projectId, ... }) on stdout")
+    .action(async (options) => {
+      await handleProjectLink(options);
+    })
+    .addHelpText(
+      "after",
+      `
+Re-binds the current directory to a project by rewriting .lmnr/project.json,
+then ensures a Project API Key for the new project (probes an existing
+LMNR_PROJECT_API_KEY, mints + writes one only when needed). If a valid key for a
+DIFFERENT project is present it is never clobbered — the re-link still succeeds
+and you're pointed at \`lmnr-cli project mint-key\` to mint + paste a new one.
+Requires an existing login (\`lmnr-cli login\`); it does NOT open a browser.
+
+Examples:
+  $ lmnr-cli project link
+  $ lmnr-cli project link --project-id <id>
+  $ lmnr-cli project link --project-id <id> --json
+  $ lmnr-cli project link --no-write-env
+`,
+    );
+
+  projectCmd
+    .command("mint-key")
+    .description("Mint a fresh Project API Key for the linked project and print it")
+    .option(
+      "--project-id <id>",
+      "Project to mint for. Defaults to the linked .lmnr/project.json",
+    )
+    .option("--json", "Emit { projectId, apiKey, apiKeyId } as JSON on stdout")
+    .action(async (options) => {
+      await handleProjectMintKey(options);
+    })
+    .addHelpText(
+      "after",
+      `
+Mints a NEW key each run (find/revoke keys in the dashboard) and PRINTS it — it
+does not write .env. The bare key goes to stdout so you can pipe or copy it;
+paste it into your environment as LMNR_PROJECT_API_KEY. Requires an existing
+login (\`lmnr-cli login\`).
+
+Examples:
+  $ lmnr-cli project mint-key
+  $ lmnr-cli project mint-key --project-id <id>
+  $ export LMNR_PROJECT_API_KEY="$(lmnr-cli project mint-key)"
+  $ lmnr-cli project mint-key --json
+`,
+    );
 
   program
     .command("login")
@@ -278,6 +369,28 @@ Examples:
     .action(async () => {
       await handleLogout();
     });
+
+  program
+    .command("status")
+    .description("Show the signed-in user, linked project, and active debug session")
+    .option("--json", "Output a single flat JSON object to stdout")
+    .action(withLocalOpts(handleStatus))
+    .addHelpText(
+      "after",
+      `
+Reads everything from local state (credentials.json, .lmnr/project.json,
+.lmnr/debug-session.json), so it works offline and makes no API call. Missing
+pieces render as "not set" lines rather than errors.
+
+The debug session's display NAME is intentionally not shown: it isn't stored
+locally and there's no endpoint to read it back yet — status shows the session
+id + debugger URL only.
+
+Examples:
+  $ lmnr-cli status
+  $ lmnr-cli status --json
+`,
+    );
 
   program
     .command("setup")
@@ -567,7 +680,10 @@ Examples:
   lmnr-cli setup                                           # Logs in and prepares directory
   lmnr-cli login                                           # Authenticate (user)
   lmnr-cli project list                                    # Projects you can access
+  lmnr-cli project link                                    # Re-point this directory to a project
+  lmnr-cli project mint-key                                     # Mint + print a Project API Key
   lmnr-cli logout                                          # Log out
+  lmnr-cli status                                          # Show user, project, and debug session
   lmnr-cli dataset list --json                             # List all datasets
   lmnr-cli dataset push data.jsonl -n my-dataset --json    # Push data to a dataset
   lmnr-cli dataset pull output.jsonl -n my-dataset --json  # Pull data from a dataset

--- a/packages/lmnr-cli/src/index.ts
+++ b/packages/lmnr-cli/src/index.ts
@@ -32,6 +32,7 @@ import { SQL_SCHEMA_HELP } from "./commands/sql/schema";
 import { handleStatus } from "./commands/status";
 import { pc } from "./utils/colors";
 import { loadLocalEnv } from "./utils/env-file";
+import { withTrackingOptions } from "./utils/track-command";
 
 async function main() {
   // Hydrate LMNR_* config from a project .env(.local) before anything reads it
@@ -186,15 +187,11 @@ async function main() {
       "Render results as a human-readable table (default is CSV to stdout)",
     );
 
-  sqlCmd
+  const sqlQueryCmd = sqlCmd
     .command("query")
     .description("Execute a SQL query")
-    .argument("<query>", "SQL query string")
-    .option(
-      "--no-track",
-      "Do not record this command into the active debug session " +
-      "(also: LMNR_NO_COMMAND_TRACKING=1)",
-    )
+    .argument("<query>", "SQL query string");
+  withTrackingOptions(sqlQueryCmd)
     .action(withProjectClient(handleSqlQuery))
     .addHelpText(
       "after",
@@ -202,8 +199,8 @@ async function main() {
       `
 When a debug session is active in this directory, the command (and its args) is
 recorded into that session as a \`command\` block so a reviewer sees what ran.
-The raw query string is uploaded. Disable with --no-track or
-LMNR_NO_COMMAND_TRACKING=1.
+The raw query string is uploaded. Attach agent reasoning with --reasoning.
+Disable recording with --no-track or LMNR_NO_COMMAND_TRACKING=1.
 
 Output defaults to CSV on stdout (one record per line, agent-parseable). Use
 --json for a JSON array, or --pretty for a human-readable table.
@@ -213,6 +210,7 @@ Examples:
   $ lmnr-cli sql query "SELECT id, total_cost, status FROM traces LIMIT 20"
   $ lmnr-cli sql query "SELECT * FROM spans LIMIT 10" --json
   $ lmnr-cli sql query "SELECT * FROM spans LIMIT 10" --pretty
+  $ lmnr-cli sql query "SELECT * FROM spans LIMIT 10" --reasoning "checking error rate"
   $ lmnr-cli sql query "SELECT * FROM spans LIMIT 10" --no-track
 `,
     );
@@ -224,7 +222,7 @@ Examples:
       process.stdout.write(SQL_SCHEMA_HELP);
     });
 
-  program
+  const askCmd = program
     .command("ask")
     .description("Ask the Laminar agent a natural-language question about your project")
     .argument("<query>", "Natural-language question")
@@ -247,12 +245,8 @@ Examples:
       "Continue a previous conversation by its id (printed after each answer in human mode, " +
       "or in the `--json` output as `conversationId`)",
     )
-    .option("--json", "Output structured JSON ({ answer, conversationId, tools }) to stdout")
-    .option(
-      "--no-track",
-      "Do not record this command into the active debug session " +
-      "(also: LMNR_NO_COMMAND_TRACKING=1)",
-    )
+    .option("--json", "Output structured JSON ({ answer, conversationId, tools }) to stdout");
+  withTrackingOptions(askCmd)
     .action(withLocalOpts(handleAsk))
     .addHelpText(
       "after",
@@ -263,13 +257,15 @@ project's traces/spans/evals via read-only SQL and trace inspection.
 
 When a debug session is active in this directory, the command (and its args) is
 recorded into that session as a \`command\` block. The raw question is uploaded.
-Disable with --no-track or LMNR_NO_COMMAND_TRACKING=1.
+Attach agent reasoning with --reasoning. Disable recording with --no-track or
+LMNR_NO_COMMAND_TRACKING=1.
 
 Examples:
   $ lmnr-cli ask "why did my latest trace fail?"
   $ lmnr-cli ask "how many traces errored in the last day?"
   $ lmnr-cli ask "summarize the most expensive trace today" --json
   $ lmnr-cli ask "and which model did it use?" --conversation <id>
+  $ lmnr-cli ask "why did my latest trace fail?" --reasoning "triaging the failure"
   $ lmnr-cli ask "why did my latest trace fail?" --no-track
 `,
     );

--- a/packages/lmnr-cli/src/index.ts
+++ b/packages/lmnr-cli/src/index.ts
@@ -48,11 +48,9 @@ async function main() {
     .description("CLI for the Laminar agent observability platform")
     .version(version, "-v, --version", "display version number");
 
-  // Auto-tracking of investigative commands (sql query / ask) into the active
-  // debug session lives in the command error envelope (`runWithEnvelope` in
-  // auth/with-client.ts), NOT a Commander hook: the envelope is the only place
-  // that sees both success AND failure with the real exit code (Commander has no
-  // on-error hook). See `maybeTrackCommand`.
+  // Command tracking runs in runWithEnvelope (auth/with-client.ts), not a
+  // Commander hook — it's the only place that sees both success and failure with
+  // the real exit code. See `maybeTrackCommand`.
 
   const datasetsCmd = program
     .command("dataset")

--- a/packages/lmnr-cli/src/index.ts
+++ b/packages/lmnr-cli/src/index.ts
@@ -199,7 +199,7 @@ async function main() {
       `
 When a debug session is active in this directory, the command (and its args) is
 recorded into that session as a \`command\` block so a reviewer sees what ran.
-The raw query string is uploaded. Attach agent reasoning with --reasoning.
+The raw query string is uploaded. Attach agent thinking with --thinking.
 Disable recording with --no-track or LMNR_NO_COMMAND_TRACKING=1.
 
 Output defaults to CSV on stdout (one record per line, agent-parseable). Use
@@ -210,7 +210,7 @@ Examples:
   $ lmnr-cli sql query "SELECT id, total_cost, status FROM traces LIMIT 20"
   $ lmnr-cli sql query "SELECT * FROM spans LIMIT 10" --json
   $ lmnr-cli sql query "SELECT * FROM spans LIMIT 10" --pretty
-  $ lmnr-cli sql query "SELECT * FROM spans LIMIT 10" --reasoning "checking error rate"
+  $ lmnr-cli sql query "SELECT * FROM spans LIMIT 10" --thinking "checking error rate"
   $ lmnr-cli sql query "SELECT * FROM spans LIMIT 10" --no-track
 `,
     );
@@ -257,7 +257,7 @@ project's traces/spans/evals via read-only SQL and trace inspection.
 
 When a debug session is active in this directory, the command (and its args) is
 recorded into that session as a \`command\` block. The raw question is uploaded.
-Attach agent reasoning with --reasoning. Disable recording with --no-track or
+Attach agent thinking with --thinking. Disable recording with --no-track or
 LMNR_NO_COMMAND_TRACKING=1.
 
 Examples:
@@ -265,7 +265,7 @@ Examples:
   $ lmnr-cli ask "how many traces errored in the last day?"
   $ lmnr-cli ask "summarize the most expensive trace today" --json
   $ lmnr-cli ask "and which model did it use?" --conversation <id>
-  $ lmnr-cli ask "why did my latest trace fail?" --reasoning "triaging the failure"
+  $ lmnr-cli ask "why did my latest trace fail?" --thinking "triaging the failure"
   $ lmnr-cli ask "why did my latest trace fail?" --no-track
 `,
     );

--- a/packages/lmnr-cli/src/index.ts
+++ b/packages/lmnr-cli/src/index.ts
@@ -197,7 +197,7 @@ async function main() {
       `
 When a debug session is active in this directory, the command (and its args) is
 recorded into that session as a \`command\` block so a reviewer sees what ran.
-The raw query string is uploaded. Attach agent thinking with --thinking.
+The raw query string is uploaded. Attach agent reasoning with --reasoning.
 Disable recording with --no-track or LMNR_NO_COMMAND_TRACKING=1.
 
 Output defaults to CSV on stdout (one record per line, agent-parseable). Use
@@ -208,7 +208,7 @@ Examples:
   $ lmnr-cli sql query "SELECT id, total_cost, status FROM traces LIMIT 20"
   $ lmnr-cli sql query "SELECT * FROM spans LIMIT 10" --json
   $ lmnr-cli sql query "SELECT * FROM spans LIMIT 10" --pretty
-  $ lmnr-cli sql query "SELECT * FROM spans LIMIT 10" --thinking "checking error rate"
+  $ lmnr-cli sql query "SELECT * FROM spans LIMIT 10" --reasoning "checking error rate"
   $ lmnr-cli sql query "SELECT * FROM spans LIMIT 10" --no-track
 `,
     );
@@ -255,7 +255,7 @@ project's traces/spans/evals via read-only SQL and trace inspection.
 
 When a debug session is active in this directory, the command (and its args) is
 recorded into that session as a \`command\` block. The raw question is uploaded.
-Attach agent thinking with --thinking. Disable recording with --no-track or
+Attach agent reasoning with --reasoning. Disable recording with --no-track or
 LMNR_NO_COMMAND_TRACKING=1.
 
 Examples:
@@ -263,7 +263,7 @@ Examples:
   $ lmnr-cli ask "how many traces errored in the last day?"
   $ lmnr-cli ask "summarize the most expensive trace today" --json
   $ lmnr-cli ask "and which model did it use?" --conversation <id>
-  $ lmnr-cli ask "why did my latest trace fail?" --thinking "triaging the failure"
+  $ lmnr-cli ask "why did my latest trace fail?" --reasoning "triaging the failure"
   $ lmnr-cli ask "why did my latest trace fail?" --no-track
 `,
     );

--- a/packages/lmnr-cli/src/index.ts
+++ b/packages/lmnr-cli/src/index.ts
@@ -180,7 +180,11 @@ async function main() {
       "Port for the Laminar API. Defaults to 443",
       (val) => parseInt(val, 10),
     )
-    .option("--json", "Output structured JSON to stdout");
+    .option("--json", "Output structured JSON to stdout")
+    .option(
+      "--pretty",
+      "Render results as a human-readable table (default is CSV to stdout)",
+    );
 
   sqlCmd
     .command("query")
@@ -201,10 +205,14 @@ recorded into that session as a \`command\` block so a reviewer sees what ran.
 The raw query string is uploaded. Disable with --no-track or
 LMNR_NO_COMMAND_TRACKING=1.
 
+Output defaults to CSV on stdout (one record per line, agent-parseable). Use
+--json for a JSON array, or --pretty for a human-readable table.
+
 Examples:
   $ lmnr-cli sql query "SELECT * FROM spans LIMIT 10"
   $ lmnr-cli sql query "SELECT id, total_cost, status FROM traces LIMIT 20"
   $ lmnr-cli sql query "SELECT * FROM spans LIMIT 10" --json
+  $ lmnr-cli sql query "SELECT * FROM spans LIMIT 10" --pretty
   $ lmnr-cli sql query "SELECT * FROM spans LIMIT 10" --no-track
 `,
     );

--- a/packages/lmnr-cli/src/utils/command-capture.ts
+++ b/packages/lmnr-cli/src/utils/command-capture.ts
@@ -1,0 +1,81 @@
+import { Writable } from "node:stream";
+
+/**
+ * Process-lifetime capture of the current command's stdout / stderr, so
+ * `maybeTrackCommand` can record what an investigative command produced into
+ * its `command` session block.
+ *
+ * A single CLI invocation runs exactly one command action, so a
+ * process-global buffer IS that command's output — there is no per-command
+ * reset and no cross-command bleed to worry about. Two sinks feed it: the
+ * `emitData` / `emitErr` write-through helpers (direct stdout/stderr writes)
+ * and the pino logger tee (`createStderrCaptureStream`). Both strip ANSI so the
+ * recorded text is clean, and appends stop at a hard cap so a command that
+ * streams megabytes can't grow the buffer without bound.
+ */
+
+// The most we ship in a block field. The frontend renderer also truncates at
+// this size — keeping the two in step means the UI never has to trim what we
+// send. Kept as a plain number (not shared) to avoid a client/types dep here.
+const MAX_CAPTURE_CHARS = 20_000;
+
+// Stop appending well past the display cap: we only ever ship MAX_CAPTURE_CHARS,
+// so buffering a bit beyond it is enough to know truncation happened, and the
+// extra headroom absorbs a final chunk that straddles the boundary.
+const HARD_LIMIT = MAX_CAPTURE_CHARS * 2;
+
+// SGR color/style escapes (what `pc.*` and pino-pretty emit). Stripped before
+// recording so captured output is plain text, not terminal control codes.
+// eslint-disable-next-line no-control-regex
+const ANSI_SGR = /\[[0-9;]*m/g;
+const stripAnsi = (s: string): string => s.replace(ANSI_SGR, "");
+
+let stdoutBuf = "";
+let stderrBuf = "";
+
+const append = (buf: string, chunk: string): string =>
+  buf.length >= HARD_LIMIT ? buf : buf + stripAnsi(chunk);
+
+export const recordStdout = (chunk: string): void => {
+  stdoutBuf = append(stdoutBuf, chunk);
+};
+
+export const recordStderr = (chunk: string): void => {
+  stderrBuf = append(stderrBuf, chunk);
+};
+
+// Null when empty (so the block field is omitted rather than an empty string);
+// otherwise the recorded text, truncated to the display cap with a marker.
+const finalize = (buf: string): string | null => {
+  if (!buf) return null;
+  if (buf.length > MAX_CAPTURE_CHARS) {
+    return `${buf.slice(0, MAX_CAPTURE_CHARS)}\n… [output truncated]`;
+  }
+  return buf;
+};
+
+export const getCapturedOutput = (): { stdout: string | null; stderr: string | null } => ({
+  stdout: finalize(stdoutBuf),
+  stderr: finalize(stderrBuf),
+});
+
+/**
+ * A pino multistream target that tees the logger's records into the shared
+ * stderr buffer. multistream hands each stream the serialized NDJSON log line;
+ * we extract `msg` so the captured stderr reads like the human diagnostics a
+ * user saw, not raw JSON (falling back to the raw line if a record has no
+ * string `msg` or doesn't parse).
+ */
+export const createStderrCaptureStream = (): Writable =>
+  new Writable({
+    write(chunk: Buffer | string, _enc, cb) {
+      const line = chunk.toString();
+      try {
+        const record = JSON.parse(line) as { msg?: unknown };
+        recordStderr(typeof record.msg === "string" ? `${record.msg}\n` : line);
+      } catch {
+        recordStderr(line);
+      }
+      cb();
+    },
+  });

--- a/packages/lmnr-cli/src/utils/command-capture.ts
+++ b/packages/lmnr-cli/src/utils/command-capture.ts
@@ -2,30 +2,23 @@ import { Writable } from "node:stream";
 
 /**
  * Process-lifetime capture of the current command's stdout / stderr, so
- * `maybeTrackCommand` can record what an investigative command produced into
- * its `command` session block.
- *
- * A single CLI invocation runs exactly one command action, so a
- * process-global buffer IS that command's output — there is no per-command
- * reset and no cross-command bleed to worry about. Two sinks feed it: the
- * `emitData` / `emitErr` write-through helpers (direct stdout/stderr writes)
- * and the pino logger tee (`createStderrCaptureStream`). Both strip ANSI so the
- * recorded text is clean, and appends stop at a hard cap so a command that
- * streams megabytes can't grow the buffer without bound.
+ * `maybeTrackCommand` can record it into a `command` session block. One CLI
+ * invocation runs one command, so a process-global buffer IS that command's
+ * output — no reset, no cross-command bleed. Fed by the `emitData` / `emitErr`
+ * write-through helpers and the pino logger tee; both strip ANSI and stop at a
+ * hard cap.
  */
 
-// The most we ship in a block field. The frontend renderer also truncates at
-// this size — keeping the two in step means the UI never has to trim what we
-// send. Kept as a plain number (not shared) to avoid a client/types dep here.
+// Most we ship in a block field; matches the frontend renderer's truncation so
+// the UI never has to trim what we send.
 const MAX_CAPTURE_CHARS = 20_000;
 
-// Stop appending well past the display cap: we only ever ship MAX_CAPTURE_CHARS,
-// so buffering a bit beyond it is enough to know truncation happened, and the
-// extra headroom absorbs a final chunk that straddles the boundary.
+// Buffer a bit past the display cap: enough to detect truncation and absorb a
+// final chunk straddling the boundary.
 const HARD_LIMIT = MAX_CAPTURE_CHARS * 2;
 
-// SGR color/style escapes (what `pc.*` and pino-pretty emit). Stripped before
-// recording so captured output is plain text, not terminal control codes.
+// SGR color/style escapes (from `pc.*` / pino-pretty), stripped so captured
+// output is plain text.
 // eslint-disable-next-line no-control-regex
 const ANSI_SGR = /\[[0-9;]*m/g;
 const stripAnsi = (s: string): string => s.replace(ANSI_SGR, "");
@@ -33,8 +26,8 @@ const stripAnsi = (s: string): string => s.replace(ANSI_SGR, "");
 let stdoutBuf = "";
 let stderrBuf = "";
 
-// Slice the raw chunk to remaining headroom BEFORE stripping, so `stripAnsi`
-// never processes (nor copies) more than HARD_LIMIT chars for a huge chunk.
+// Slice to remaining headroom BEFORE stripping, so `stripAnsi` never processes
+// more than HARD_LIMIT chars for a huge chunk.
 const append = (buf: string, chunk: string): string => {
   if (buf.length >= HARD_LIMIT) return buf;
   const room = HARD_LIMIT - buf.length;
@@ -49,8 +42,8 @@ export const recordStderr = (chunk: string): void => {
   stderrBuf = append(stderrBuf, chunk);
 };
 
-// Null when empty (so the block field is omitted rather than an empty string);
-// otherwise the recorded text, truncated to the display cap with a marker.
+// Null when empty (so the field is omitted); otherwise the text, truncated to
+// the display cap with a marker.
 const finalize = (buf: string): string | null => {
   if (!buf) return null;
   if (buf.length > MAX_CAPTURE_CHARS) {
@@ -65,11 +58,9 @@ export const getCapturedOutput = (): { stdout: string | null; stderr: string | n
 });
 
 /**
- * A pino multistream target that tees the logger's records into the shared
- * stderr buffer. multistream hands each stream the serialized NDJSON log line;
- * we extract `msg` so the captured stderr reads like the human diagnostics a
- * user saw, not raw JSON (falling back to the raw line if a record has no
- * string `msg` or doesn't parse).
+ * A pino multistream target that tees log records into the shared stderr buffer.
+ * We extract `msg` from each NDJSON line so captured stderr reads like the human
+ * diagnostics the user saw, falling back to the raw line if there's no string `msg`.
  */
 export const createStderrCaptureStream = (): Writable =>
   new Writable({

--- a/packages/lmnr-cli/src/utils/command-capture.ts
+++ b/packages/lmnr-cli/src/utils/command-capture.ts
@@ -13,8 +13,9 @@ import { Writable } from "node:stream";
 // the UI never has to trim what we send.
 const MAX_CAPTURE_CHARS = 20_000;
 
-// Buffer a bit past the display cap: enough to detect truncation and absorb a
-// final chunk straddling the boundary.
+// Buffer up to double the ship cap. The extra 20k is headroom so a large final
+// chunk is still captured in full past what we ship, and so exceeding the ship
+// cap reliably signals truncation; `append` drops anything beyond this.
 const HARD_LIMIT = MAX_CAPTURE_CHARS * 2;
 
 // SGR color/style escapes (from `pc.*` / pino-pretty), stripped so captured

--- a/packages/lmnr-cli/src/utils/command-capture.ts
+++ b/packages/lmnr-cli/src/utils/command-capture.ts
@@ -33,8 +33,13 @@ const stripAnsi = (s: string): string => s.replace(ANSI_SGR, "");
 let stdoutBuf = "";
 let stderrBuf = "";
 
-const append = (buf: string, chunk: string): string =>
-  buf.length >= HARD_LIMIT ? buf : buf + stripAnsi(chunk);
+// Slice the raw chunk to remaining headroom BEFORE stripping, so `stripAnsi`
+// never processes (nor copies) more than HARD_LIMIT chars for a huge chunk.
+const append = (buf: string, chunk: string): string => {
+  if (buf.length >= HARD_LIMIT) return buf;
+  const room = HARD_LIMIT - buf.length;
+  return buf + stripAnsi(chunk.slice(0, room));
+};
 
 export const recordStdout = (chunk: string): void => {
   stdoutBuf = append(stdoutBuf, chunk);

--- a/packages/lmnr-cli/src/utils/csv.test.ts
+++ b/packages/lmnr-cli/src/utils/csv.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+
+import { toCsv } from './csv';
+
+describe('toCsv', () => {
+  it('emits a header row then one line per record', () => {
+    const csv = toCsv(['id', 'name'], [
+      { id: '1', name: 'alice' },
+      { id: '2', name: 'bob' },
+    ]);
+    expect(csv).toBe('id,name\n1,alice\n2,bob');
+  });
+
+  it('returns just the header when there are no rows', () => {
+    expect(toCsv(['id', 'name'], [])).toBe('id,name');
+  });
+
+  it('fills missing keys with empty fields, honoring column order', () => {
+    const csv = toCsv(['id', 'name', 'extra'], [{ id: '1', name: 'alice' }]);
+    expect(csv).toBe('id,name,extra\n1,alice,');
+  });
+
+  it('stringifies numbers and booleans without quoting', () => {
+    const csv = toCsv(['n', 'b'], [{ n: 42, b: true }]);
+    expect(csv).toBe('n,b\n42,true');
+  });
+
+  it('renders null and undefined as empty fields', () => {
+    const csv = toCsv(['a', 'b'], [{ a: null, b: undefined }]);
+    expect(csv).toBe('a,b\n,');
+  });
+
+  it('quotes and escapes commas, quotes, LF and CR', () => {
+    expect(toCsv(['v'], [{ v: 'a,b' }])).toBe('v\n"a,b"');
+    expect(toCsv(['v'], [{ v: 'a"b' }])).toBe('v\n"a""b"');
+    expect(toCsv(['v'], [{ v: 'a\nb' }])).toBe('v\n"a\nb"');
+    expect(toCsv(['v'], [{ v: 'a\rb' }])).toBe('v\n"a\rb"');
+  });
+
+  it('serializes object cells as a single JSON string cell', () => {
+    const csv = toCsv(['j'], [{ j: { a: 1, b: [2, 3] } }]);
+    expect(csv).toBe('j\n"{""a"":1,""b"":[2,3]}"');
+  });
+});

--- a/packages/lmnr-cli/src/utils/csv.ts
+++ b/packages/lmnr-cli/src/utils/csv.ts
@@ -1,0 +1,57 @@
+/**
+ * Minimal RFC 4180-style CSV serializer for tabular command output.
+ *
+ * Design notes (kept deliberately narrow — this is the default `sql query`
+ * output format, tuned for agents piping stdout):
+ * - Rows are joined with `\n` (LF), NOT CRLF. RFC 4180 specifies CRLF, but
+ *   Unix tooling and agent parsers handle LF universally and it avoids stray
+ *   `\r` bytes in piped output.
+ * - A cell is quoted only when it contains a comma, double-quote, CR, or LF;
+ *   embedded double-quotes are doubled (`"` -> `""`).
+ * - `null` / `undefined` render as an empty (unquoted) field.
+ * - Object/array cells (e.g. jsonb columns) are `JSON.stringify`-ed, then
+ *   escaped like any other string. This keeps one record per row (the whole
+ *   point of CSV here) instead of expanding nested structures across cells.
+ */
+
+const needsQuoting = (value: string): boolean =>
+  value.includes(",") ||
+  value.includes('"') ||
+  value.includes("\n") ||
+  value.includes("\r");
+
+const toStringCell = (value: unknown): string => {
+  if (value === null || value === undefined) {
+    return "";
+  }
+  if (typeof value === "string") {
+    return value;
+  }
+  // Primitives from JSON-parsed rows stringify without Object's default format.
+  if (typeof value === "number" || typeof value === "boolean" || typeof value === "bigint") {
+    return value.toString();
+  }
+  // Objects/arrays (e.g. jsonb columns) become a single JSON string cell.
+  return JSON.stringify(value);
+};
+
+const escapeCell = (value: unknown): string => {
+  const str = toStringCell(value);
+  return needsQuoting(str) ? `"${str.replace(/"/g, '""')}"` : str;
+};
+
+/**
+ * Serialize rows to CSV. The first line is the header (column names, escaped
+ * like any cell); each subsequent line is one record. Column order is fixed by
+ * `columns`, so missing keys in a row become empty fields.
+ */
+export const toCsv = (
+  columns: string[],
+  rows: Record<string, unknown>[],
+): string => {
+  const lines = [columns.map(escapeCell).join(",")];
+  for (const row of rows) {
+    lines.push(columns.map((col) => escapeCell(row[col])).join(","));
+  }
+  return lines.join("\n");
+};

--- a/packages/lmnr-cli/src/utils/csv.ts
+++ b/packages/lmnr-cli/src/utils/csv.ts
@@ -1,17 +1,11 @@
 /**
- * Minimal RFC 4180-style CSV serializer for tabular command output.
- *
- * Design notes (kept deliberately narrow — this is the default `sql query`
- * output format, tuned for agents piping stdout):
- * - Rows are joined with `\n` (LF), NOT CRLF. RFC 4180 specifies CRLF, but
- *   Unix tooling and agent parsers handle LF universally and it avoids stray
- *   `\r` bytes in piped output.
- * - A cell is quoted only when it contains a comma, double-quote, CR, or LF;
- *   embedded double-quotes are doubled (`"` -> `""`).
- * - `null` / `undefined` render as an empty (unquoted) field.
- * - Object/array cells (e.g. jsonb columns) are `JSON.stringify`-ed, then
- *   escaped like any other string. This keeps one record per row (the whole
- *   point of CSV here) instead of expanding nested structures across cells.
+ * Minimal RFC 4180-style CSV serializer for tabular command output (the default
+ * `sql query` format, tuned for agents piping stdout).
+ * - Rows joined with LF, not CRLF — Unix tooling handles LF and it avoids stray `\r`.
+ * - A cell is quoted only if it has a comma, double-quote, CR, or LF; embedded
+ *   double-quotes are doubled.
+ * - `null` / `undefined` render as an empty field.
+ * - Object/array cells (e.g. jsonb) are JSON-stringified, keeping one record per row.
  */
 
 const needsQuoting = (value: string): boolean =>
@@ -27,7 +21,6 @@ const toStringCell = (value: unknown): string => {
   if (typeof value === "string") {
     return value;
   }
-  // Primitives from JSON-parsed rows stringify without Object's default format.
   if (typeof value === "number" || typeof value === "boolean" || typeof value === "bigint") {
     return value.toString();
   }
@@ -41,9 +34,8 @@ const escapeCell = (value: unknown): string => {
 };
 
 /**
- * Serialize rows to CSV. The first line is the header (column names, escaped
- * like any cell); each subsequent line is one record. Column order is fixed by
- * `columns`, so missing keys in a row become empty fields.
+ * Serialize rows to CSV: first line is the header, the rest are records. Column
+ * order is fixed by `columns`, so keys missing from a row become empty fields.
  */
 export const toCsv = (
   columns: string[],

--- a/packages/lmnr-cli/src/utils/logger.ts
+++ b/packages/lmnr-cli/src/utils/logger.ts
@@ -1,6 +1,16 @@
 import pino, { Level } from 'pino';
 import { PinoPretty } from 'pino-pretty';
 
+import { createStderrCaptureStream } from './command-capture';
+
+// Shared logger tee: one capture stream for the whole process, so every
+// `initializeLogger()` instance records into the SAME command-capture buffer.
+// Created once at module scope (a fresh stream per logger would each hold their
+// own state and only the last would be observed). Diagnostics still render to
+// stderr (fd 2) exactly as before; this only forks a copy into the buffer that
+// `maybeTrackCommand` reads.
+const captureStream = createStderrCaptureStream();
+
 export function initializeLogger(options?: { colorize?: boolean; level?: Level }) {
   const colorize = options?.colorize ?? true;
   const level =
@@ -12,10 +22,9 @@ export function initializeLogger(options?: { colorize?: boolean; level?: Level }
     {
       level,
     },
-    PinoPretty({
-      colorize,
-      minimumLevel: level,
-      destination: 2,
-    }),
+    pino.multistream([
+      { level, stream: PinoPretty({ colorize, minimumLevel: level, destination: 2 }) },
+      { level, stream: captureStream },
+    ]),
   );
 }

--- a/packages/lmnr-cli/src/utils/output.ts
+++ b/packages/lmnr-cli/src/utils/output.ts
@@ -14,9 +14,14 @@ export function emitData(text: string): void {
   process.stdout.write(text);
 }
 
-/** `console.log`-equivalent (space-joined args, trailing newline) that records. */
+/**
+ * `console.log`-equivalent that also records into the capture buffer. Writes via
+ * `console.log` (NOT the raw `emitData` stream) so it keeps console.log's exact
+ * observable behavior — the recording is a parallel side-channel.
+ */
 export function printData(...args: unknown[]): void {
-  emitData(args.map((a) => (typeof a === 'string' ? a : String(a))).join(' ') + '\n');
+  recordStdout(args.map((a) => (typeof a === 'string' ? a : String(a))).join(' ') + '\n');
+  console.log(...args);
 }
 
 /**
@@ -32,10 +37,13 @@ export function emitErr(text: string): void {
 
 /**
  * Write structured JSON to stdout. Use this for machine-readable output
- * when --json is set.
+ * when --json is set. Writes via `console.log` (its long-standing behavior) and
+ * records the payload into the capture buffer as a parallel side-channel.
  */
 export function outputJson(data: unknown): void {
-  emitData(JSON.stringify(data) + '\n');
+  const serialized = JSON.stringify(data);
+  recordStdout(serialized + '\n');
+  console.log(serialized);
 }
 
 /**

--- a/packages/lmnr-cli/src/utils/output.ts
+++ b/packages/lmnr-cli/src/utils/output.ts
@@ -1,13 +1,41 @@
 import { errorMessage } from '@lmnr-ai/types';
 
 import { pc } from './colors';
+import { recordStderr, recordStdout } from './command-capture';
+
+/**
+ * stdout data sink: write-through to stdout AND record into the command-capture
+ * buffer, so an investigative command's real output lands in its session block.
+ * Prefer this (and `printData`) over raw `process.stdout.write` / `console.log`
+ * in commands whose output is worth recording.
+ */
+export function emitData(text: string): void {
+  recordStdout(text);
+  process.stdout.write(text);
+}
+
+/** `console.log`-equivalent (space-joined args, trailing newline) that records. */
+export function printData(...args: unknown[]): void {
+  emitData(args.map((a) => (typeof a === 'string' ? a : String(a))).join(' ') + '\n');
+}
+
+/**
+ * stderr diagnostics sink for DIRECT (non-logger) writes — e.g. streamed agent
+ * activity. Write-through to stderr AND record. Logger output is teed into the
+ * same buffer separately (see `utils/logger.ts`), so only raw
+ * `process.stderr.write` sites need this.
+ */
+export function emitErr(text: string): void {
+  recordStderr(text);
+  process.stderr.write(text);
+}
 
 /**
  * Write structured JSON to stdout. Use this for machine-readable output
  * when --json is set.
  */
 export function outputJson(data: unknown): void {
-  console.log(JSON.stringify(data));
+  emitData(JSON.stringify(data) + '\n');
 }
 
 /**

--- a/packages/lmnr-cli/src/utils/output.ts
+++ b/packages/lmnr-cli/src/utils/output.ts
@@ -4,8 +4,7 @@ import { pc } from './colors';
 import { recordStderr, recordStdout } from './command-capture';
 
 /**
- * stdout data sink: write-through to stdout AND record into the command-capture
- * buffer, so an investigative command's real output lands in its session block.
+ * stdout data sink: write-through to stdout AND record into the capture buffer.
  * Prefer this (and `printData`) over raw `process.stdout.write` / `console.log`
  * in commands whose output is worth recording.
  */
@@ -16,8 +15,7 @@ export function emitData(text: string): void {
 
 /**
  * `console.log`-equivalent that also records into the capture buffer. Writes via
- * `console.log` (NOT the raw `emitData` stream) so it keeps console.log's exact
- * observable behavior — the recording is a parallel side-channel.
+ * `console.log` to keep its exact behavior; recording is a parallel side-channel.
  */
 export function printData(...args: unknown[]): void {
   recordStdout(args.map((a) => (typeof a === 'string' ? a : String(a))).join(' ') + '\n');
@@ -26,9 +24,8 @@ export function printData(...args: unknown[]): void {
 
 /**
  * stderr diagnostics sink for DIRECT (non-logger) writes — e.g. streamed agent
- * activity. Write-through to stderr AND record. Logger output is teed into the
- * same buffer separately (see `utils/logger.ts`), so only raw
- * `process.stderr.write` sites need this.
+ * activity. Write-through to stderr AND record. Logger output is teed separately,
+ * so only raw `process.stderr.write` sites need this.
  */
 export function emitErr(text: string): void {
   recordStderr(text);
@@ -36,9 +33,8 @@ export function emitErr(text: string): void {
 }
 
 /**
- * Write structured JSON to stdout. Use this for machine-readable output
- * when --json is set. Writes via `console.log` (its long-standing behavior) and
- * records the payload into the capture buffer as a parallel side-channel.
+ * Write structured JSON to stdout for machine-readable `--json` output. Writes
+ * via `console.log` and records the payload as a parallel side-channel.
  */
 export function outputJson(data: unknown): void {
   const serialized = JSON.stringify(data);
@@ -48,9 +44,8 @@ export function outputJson(data: unknown): void {
 
 /**
  * Emit a coded error without exiting: `{error, detail}` JSON on stdout in --json
- * mode, otherwise a colored `ERROR (code): detail` line on stderr. Shared error
- * envelope for the interactive device-flow commands (`setup`, `plugin add`),
- * which manage their own exit codes rather than using the with-client wrapper.
+ * mode, else a colored `ERROR (code): detail` on stderr. Used by the interactive
+ * device-flow commands (`setup`, `plugin add`) that manage their own exit codes.
  */
 export const emitError = (json: boolean, code: string, detail: string): void => {
   if (json) {

--- a/packages/lmnr-cli/src/utils/text.ts
+++ b/packages/lmnr-cli/src/utils/text.ts
@@ -5,3 +5,6 @@ export const firstNonEmpty = (...candidates: (string | undefined)[]): string => 
   }
   return "";
 };
+
+/** Strip any trailing slashes from a URL (so path suffixes don't double up). */
+export const trimSlash = (url: string): string => url.replace(/\/+$/, "");

--- a/packages/lmnr-cli/src/utils/track-command.test.ts
+++ b/packages/lmnr-cli/src/utils/track-command.test.ts
@@ -98,6 +98,9 @@ describe("maybeTrackCommand", () => {
         command: "sql query",
         args: ["SELECT * FROM spans LIMIT 1"],
         exitCode: 0,
+        // No emit/log happened in this unit context, so capture is empty.
+        output: null,
+        stderr: null,
       },
       failOnNotFound: false,
     });
@@ -110,6 +113,21 @@ describe("maybeTrackCommand", () => {
 
     expect(h.addBlock).toHaveBeenCalledWith(
       expect.objectContaining({ content: expect.objectContaining({ exitCode: 9 }) }),
+    );
+  });
+
+  it("folds the explicit fatal error text into stderr on the failure path", async () => {
+    const query = makeCmd("query", makeCmd("sql", root), {}, ["BAD SQL"]);
+
+    await maybeTrackCommand(query, 1, "relation \"nonexistent_table\" does not exist");
+
+    expect(h.addBlock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.objectContaining({
+          exitCode: 1,
+          stderr: 'relation "nonexistent_table" does not exist',
+        }),
+      }),
     );
   });
 

--- a/packages/lmnr-cli/src/utils/track-command.test.ts
+++ b/packages/lmnr-cli/src/utils/track-command.test.ts
@@ -1,0 +1,155 @@
+import type { Command } from "commander";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const h = vi.hoisted(() => ({
+  buildLaminarClient: vi.fn(),
+  readDebugSessionFile: vi.fn(),
+  resolveDebugSessionDir: vi.fn(() => "/repo"),
+  addBlock: vi.fn(),
+}));
+
+vi.mock("../auth/client", () => ({ buildLaminarClient: h.buildLaminarClient }));
+vi.mock("./debug-session-file", () => ({
+  readDebugSessionFile: h.readDebugSessionFile,
+  resolveDebugSessionDir: h.resolveDebugSessionDir,
+}));
+
+import {
+  commandPath,
+  isTrackedCommand,
+  maybeTrackCommand,
+  trackingDisabled,
+} from "./track-command";
+
+// Minimal Command stand-in: just the surface maybeTrackCommand reads.
+const makeCmd = (
+  name: string,
+  parent: Command | null,
+  opts: Record<string, unknown> = {},
+  args: string[] = [],
+): Command =>
+  ({
+    name: () => name,
+    parent,
+    args,
+    optsWithGlobals: () => opts,
+  }) as unknown as Command;
+
+const root = makeCmd("lmnr-cli", null);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  delete process.env.LMNR_NO_COMMAND_TRACKING;
+  h.readDebugSessionFile.mockReturnValue({ session_id: "sess-1" });
+  h.buildLaminarClient.mockResolvedValue({ rolloutSessions: { addBlock: h.addBlock } });
+  h.addBlock.mockResolvedValue("block-1");
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("commandPath / isTrackedCommand", () => {
+  it("joins the path up to (not including) the program root", () => {
+    const sql = makeCmd("sql", root);
+    expect(commandPath(makeCmd("query", sql))).toBe("sql query");
+    expect(commandPath(makeCmd("ask", root))).toBe("ask");
+  });
+
+  it("allowlists only sql query and ask", () => {
+    expect(isTrackedCommand("sql query")).toBe(true);
+    expect(isTrackedCommand("ask")).toBe(true);
+    expect(isTrackedCommand("login")).toBe(false);
+    expect(isTrackedCommand("debug session add-note")).toBe(false);
+  });
+});
+
+describe("trackingDisabled", () => {
+  it("honors the --no-track flag", () => {
+    expect(trackingDisabled({ track: false })).toBe(true);
+    expect(trackingDisabled({ track: true })).toBe(false);
+    expect(trackingDisabled({})).toBe(false);
+  });
+
+  it("honors LMNR_NO_COMMAND_TRACKING", () => {
+    for (const v of ["1", "true", "YES"]) {
+      process.env.LMNR_NO_COMMAND_TRACKING = v;
+      expect(trackingDisabled({})).toBe(true);
+    }
+    process.env.LMNR_NO_COMMAND_TRACKING = "0";
+    expect(trackingDisabled({})).toBe(false);
+  });
+});
+
+describe("maybeTrackCommand", () => {
+  it("posts a command block for an allowlisted command with an active session", async () => {
+    const sql = makeCmd("sql", root);
+    const query = makeCmd("query", sql, { projectId: "p1" }, ["SELECT * FROM spans LIMIT 1"]);
+
+    await maybeTrackCommand(query, 0);
+
+    expect(h.buildLaminarClient).toHaveBeenCalledWith(
+      expect.objectContaining({ projectId: "p1" }),
+    );
+    expect(h.addBlock).toHaveBeenCalledWith({
+      sessionId: "sess-1",
+      type: "command",
+      content: {
+        command: "sql query",
+        args: ["SELECT * FROM spans LIMIT 1"],
+        exitCode: 0,
+      },
+      failOnNotFound: false,
+    });
+  });
+
+  it("records the real exit code on a failed command", async () => {
+    const query = makeCmd("query", makeCmd("sql", root), {}, ["BAD SQL"]);
+
+    await maybeTrackCommand(query, 9);
+
+    expect(h.addBlock).toHaveBeenCalledWith(
+      expect.objectContaining({ content: expect.objectContaining({ exitCode: 9 }) }),
+    );
+  });
+
+  it("posts nothing for a non-allowlisted command", async () => {
+    await maybeTrackCommand(makeCmd("login", root), 0);
+
+    expect(h.buildLaminarClient).not.toHaveBeenCalled();
+    expect(h.addBlock).not.toHaveBeenCalled();
+  });
+
+  it("posts nothing (and builds no client) when no session is active", async () => {
+    h.readDebugSessionFile.mockReturnValue(null);
+
+    await maybeTrackCommand(makeCmd("ask", root, {}, ["why?"]), 0);
+
+    expect(h.buildLaminarClient).not.toHaveBeenCalled();
+    expect(h.addBlock).not.toHaveBeenCalled();
+  });
+
+  it("swallows a write failure — never throws", async () => {
+    h.addBlock.mockRejectedValue(new Error("network down"));
+    const query = makeCmd("query", makeCmd("sql", root), {}, ["SELECT 1"]);
+
+    await expect(maybeTrackCommand(query, 0)).resolves.toBeUndefined();
+  });
+
+  it("posts nothing when opted out via --no-track", async () => {
+    const query = makeCmd("query", makeCmd("sql", root), { track: false }, ["SELECT 1"]);
+
+    await maybeTrackCommand(query, 0);
+
+    expect(h.addBlock).not.toHaveBeenCalled();
+  });
+
+  it("posts nothing when opted out via LMNR_NO_COMMAND_TRACKING", async () => {
+    process.env.LMNR_NO_COMMAND_TRACKING = "1";
+    const query = makeCmd("query", makeCmd("sql", root), {}, ["SELECT 1"]);
+
+    await maybeTrackCommand(query, 0);
+
+    expect(h.addBlock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/lmnr-cli/src/utils/track-command.test.ts
+++ b/packages/lmnr-cli/src/utils/track-command.test.ts
@@ -6,12 +6,19 @@ const h = vi.hoisted(() => ({
   readDebugSessionFile: vi.fn(),
   resolveDebugSessionDir: vi.fn(() => "/repo"),
   addBlock: vi.fn(),
+  logWarn: vi.fn(),
+  logDebug: vi.fn(),
 }));
 
 vi.mock("../auth/client", () => ({ buildLaminarClient: h.buildLaminarClient }));
 vi.mock("./debug-session-file", () => ({
   readDebugSessionFile: h.readDebugSessionFile,
   resolveDebugSessionDir: h.resolveDebugSessionDir,
+}));
+// track-command binds its logger at module load, so stub the factory here (not
+// mid-test) to capture the module-scope `logger.warn` / `logger.debug`.
+vi.mock("./logger", () => ({
+  initializeLogger: () => ({ warn: h.logWarn, debug: h.logDebug }),
 }));
 
 import {
@@ -101,9 +108,28 @@ describe("maybeTrackCommand", () => {
         // No emit/log happened in this unit context, so capture is empty.
         output: null,
         stderr: null,
+        // No --reasoning passed → null.
+        reasoning: null,
       },
       failOnNotFound: false,
     });
+  });
+
+  it("records --reasoning on the command block when provided", async () => {
+    const query = makeCmd(
+      "query",
+      makeCmd("sql", root),
+      { reasoning: "checking error rate" },
+      ["SELECT 1"],
+    );
+
+    await maybeTrackCommand(query, 0);
+
+    expect(h.addBlock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.objectContaining({ reasoning: "checking error rate" }),
+      }),
+    );
   });
 
   it("records the real exit code on a failed command", async () => {
@@ -145,6 +171,20 @@ describe("maybeTrackCommand", () => {
 
     expect(h.buildLaminarClient).not.toHaveBeenCalled();
     expect(h.addBlock).not.toHaveBeenCalled();
+    // No reasoning → stays silent (no session is the normal case).
+    expect(h.logWarn).not.toHaveBeenCalled();
+  });
+
+  it("warns (but posts nothing) when --reasoning is given with no active session", async () => {
+    h.readDebugSessionFile.mockReturnValue(null);
+
+    await maybeTrackCommand(
+      makeCmd("ask", root, { reasoning: "triaging the failure" }, ["why?"]),
+      0,
+    );
+
+    expect(h.addBlock).not.toHaveBeenCalled();
+    expect(h.logWarn).toHaveBeenCalledWith(expect.stringContaining("no active debug session"));
   });
 
   it("swallows a write failure — never throws", async () => {

--- a/packages/lmnr-cli/src/utils/track-command.test.ts
+++ b/packages/lmnr-cli/src/utils/track-command.test.ts
@@ -98,21 +98,25 @@ describe("maybeTrackCommand", () => {
     expect(h.buildLaminarClient).toHaveBeenCalledWith(
       expect.objectContaining({ projectId: "p1" }),
     );
-    expect(h.addBlock).toHaveBeenCalledWith({
-      sessionId: "sess-1",
-      type: "command",
-      content: {
-        command: "sql query",
-        args: ["SELECT * FROM spans LIMIT 1"],
-        exitCode: 0,
-        // No emit/log happened in this unit context, so capture is empty.
-        output: null,
-        stderr: null,
-        // No --reasoning passed → null.
-        reasoning: null,
-      },
-      failOnNotFound: false,
-    });
+    expect(h.addBlock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: "sess-1",
+        type: "command",
+        content: {
+          command: "sql query",
+          args: ["SELECT * FROM spans LIMIT 1"],
+          exitCode: 0,
+          // No emit/log happened in this unit context, so capture is empty.
+          output: null,
+          stderr: null,
+          // No --reasoning passed → null.
+          reasoning: null,
+        },
+        failOnNotFound: false,
+        // A cancellation signal is threaded through for the tracking deadline.
+        signal: expect.any(AbortSignal),
+      }),
+    );
   });
 
   it("records --reasoning on the command block when provided", async () => {

--- a/packages/lmnr-cli/src/utils/track-command.test.ts
+++ b/packages/lmnr-cli/src/utils/track-command.test.ts
@@ -108,18 +108,18 @@ describe("maybeTrackCommand", () => {
         // No emit/log happened in this unit context, so capture is empty.
         output: null,
         stderr: null,
-        // No --thinking passed → null.
-        thinking: null,
+        // No --reasoning passed → null.
+        reasoning: null,
       },
       failOnNotFound: false,
     });
   });
 
-  it("records --thinking on the command block when provided", async () => {
+  it("records --reasoning on the command block when provided", async () => {
     const query = makeCmd(
       "query",
       makeCmd("sql", root),
-      { thinking: "checking error rate" },
+      { reasoning: "checking error rate" },
       ["SELECT 1"],
     );
 
@@ -127,7 +127,7 @@ describe("maybeTrackCommand", () => {
 
     expect(h.addBlock).toHaveBeenCalledWith(
       expect.objectContaining({
-        content: expect.objectContaining({ thinking: "checking error rate" }),
+        content: expect.objectContaining({ reasoning: "checking error rate" }),
       }),
     );
   });
@@ -171,15 +171,15 @@ describe("maybeTrackCommand", () => {
 
     expect(h.buildLaminarClient).not.toHaveBeenCalled();
     expect(h.addBlock).not.toHaveBeenCalled();
-    // No thinking → stays silent (no session is the normal case).
+    // No reasoning → stays silent (no session is the normal case).
     expect(h.logWarn).not.toHaveBeenCalled();
   });
 
-  it("warns (but posts nothing) when --thinking is given with no active session", async () => {
+  it("warns (but posts nothing) when --reasoning is given with no active session", async () => {
     h.readDebugSessionFile.mockReturnValue(null);
 
     await maybeTrackCommand(
-      makeCmd("ask", root, { thinking: "triaging the failure" }, ["why?"]),
+      makeCmd("ask", root, { reasoning: "triaging the failure" }, ["why?"]),
       0,
     );
 

--- a/packages/lmnr-cli/src/utils/track-command.test.ts
+++ b/packages/lmnr-cli/src/utils/track-command.test.ts
@@ -108,18 +108,18 @@ describe("maybeTrackCommand", () => {
         // No emit/log happened in this unit context, so capture is empty.
         output: null,
         stderr: null,
-        // No --reasoning passed → null.
-        reasoning: null,
+        // No --thinking passed → null.
+        thinking: null,
       },
       failOnNotFound: false,
     });
   });
 
-  it("records --reasoning on the command block when provided", async () => {
+  it("records --thinking on the command block when provided", async () => {
     const query = makeCmd(
       "query",
       makeCmd("sql", root),
-      { reasoning: "checking error rate" },
+      { thinking: "checking error rate" },
       ["SELECT 1"],
     );
 
@@ -127,7 +127,7 @@ describe("maybeTrackCommand", () => {
 
     expect(h.addBlock).toHaveBeenCalledWith(
       expect.objectContaining({
-        content: expect.objectContaining({ reasoning: "checking error rate" }),
+        content: expect.objectContaining({ thinking: "checking error rate" }),
       }),
     );
   });
@@ -171,15 +171,15 @@ describe("maybeTrackCommand", () => {
 
     expect(h.buildLaminarClient).not.toHaveBeenCalled();
     expect(h.addBlock).not.toHaveBeenCalled();
-    // No reasoning → stays silent (no session is the normal case).
+    // No thinking → stays silent (no session is the normal case).
     expect(h.logWarn).not.toHaveBeenCalled();
   });
 
-  it("warns (but posts nothing) when --reasoning is given with no active session", async () => {
+  it("warns (but posts nothing) when --thinking is given with no active session", async () => {
     h.readDebugSessionFile.mockReturnValue(null);
 
     await maybeTrackCommand(
-      makeCmd("ask", root, { reasoning: "triaging the failure" }, ["why?"]),
+      makeCmd("ask", root, { thinking: "triaging the failure" }, ["why?"]),
       0,
     );
 

--- a/packages/lmnr-cli/src/utils/track-command.ts
+++ b/packages/lmnr-cli/src/utils/track-command.ts
@@ -1,0 +1,99 @@
+import { errorMessage } from "@lmnr-ai/types";
+import type { Command } from "commander";
+
+import { buildLaminarClient } from "../auth/client";
+import type { GlobalOpts } from "../auth/with-client";
+import { readDebugSessionFile, resolveDebugSessionDir } from "./debug-session-file";
+import { initializeLogger } from "./logger";
+
+const logger = initializeLogger();
+
+/**
+ * CLI commands worth recording into an active debug session — the investigative
+ * ones a reviewer wants to see the agent ran, keyed by the space-joined command
+ * path. Everything else is deliberately excluded as noise / self-referential:
+ * `login`, `logout`, `setup`, `skill *`, `plugin *`, `project *`, `status`, and
+ * all `debug session *` (including `add-note`).
+ */
+const TRACKED_COMMANDS = new Set(["sql query", "ask"]);
+
+/** Extra opt the tracked commands carry (commander's `--no-track` → `track:false`). */
+type TrackOpts = GlobalOpts & { track?: boolean };
+
+/**
+ * The space-joined path of a command (e.g. `"sql query"`, `"ask"`), walking up
+ * to — but not including — the program root, whose name isn't part of the path.
+ */
+export const commandPath = (cmd: Command): string => {
+  const names: string[] = [];
+  let cur: Command | undefined = cmd;
+  // A command with no parent is the program root — stop before prepending it.
+  while (cur && cur.parent) {
+    names.unshift(cur.name());
+    cur = cur.parent ?? undefined;
+  }
+  return names.join(" ");
+};
+
+/** Whether `path` is on the record-into-session allowlist. */
+export const isTrackedCommand = (path: string): boolean => TRACKED_COMMANDS.has(path);
+
+/**
+ * Whether tracking is opted out — via the `--no-track` flag (`track === false`)
+ * or the `LMNR_NO_COMMAND_TRACKING` env var (`1` / `true` / `yes`).
+ */
+export const trackingDisabled = (opts: TrackOpts): boolean => {
+  if (opts.track === false) return true;
+  const env = process.env.LMNR_NO_COMMAND_TRACKING?.trim().toLowerCase();
+  return env === "1" || env === "true" || env === "yes";
+};
+
+/**
+ * Best-effort: record an allowlisted CLI command into the active debug session
+ * as a `command` block, so a reviewer sees which investigative commands the
+ * agent ran — and how each one turned out. Called from the command error
+ * envelope (`runWithEnvelope`), which is the one place that knows both that a
+ * command finished AND its real exit code (0 on success, the mapped code on
+ * failure) — Commander itself has no on-error hook, so a plain `postAction`
+ * hook would only ever see successes.
+ *
+ * Every failure mode is swallowed — no active session, no linked project, a
+ * network error, a 404 from a server that doesn't know the block type — because
+ * tracking must NEVER change the wrapped command's outcome, output, or exit
+ * code. On the no-session path it returns silently with no output at all.
+ *
+ * @param exitCode the resolved exit code of the wrapped command (0 = success).
+ */
+export const maybeTrackCommand = async (
+  actionCommand: Command,
+  exitCode: number,
+): Promise<void> => {
+  try {
+    const opts = actionCommand.optsWithGlobals();
+    if (trackingDisabled(opts)) return;
+
+    const path = commandPath(actionCommand);
+    if (!isTrackedCommand(path)) return;
+
+    const sessionId = readDebugSessionFile(resolveDebugSessionDir())?.session_id;
+    if (!sessionId) return;
+
+    const client = await buildLaminarClient({
+      projectId: opts.projectId,
+      baseUrl: opts.baseUrl,
+      port: opts.port,
+    });
+    await client.rolloutSessions.addBlock({
+      sessionId,
+      type: "command",
+      content: { command: path, args: actionCommand.args ?? [], exitCode },
+      // Best-effort: a missing session / unsupported endpoint (404) is logged and
+      // swallowed, never thrown — an exit 0 from the real command stays exit 0.
+      failOnNotFound: false,
+    });
+  } catch (err) {
+    // Debug-level (below the default `info`) so tracking stays invisible unless
+    // a user opts into verbose logs; it must never surface on a normal run.
+    logger.debug(`Command tracking skipped: ${errorMessage(err)}`);
+  }
+};

--- a/packages/lmnr-cli/src/utils/track-command.ts
+++ b/packages/lmnr-cli/src/utils/track-command.ts
@@ -3,6 +3,7 @@ import type { Command } from "commander";
 
 import { buildLaminarClient } from "../auth/client";
 import type { GlobalOpts } from "../auth/with-client";
+import { getCapturedOutput } from "./command-capture";
 import { readDebugSessionFile, resolveDebugSessionDir } from "./debug-session-file";
 import { initializeLogger } from "./logger";
 
@@ -62,11 +63,19 @@ export const trackingDisabled = (opts: TrackOpts): boolean => {
  * tracking must NEVER change the wrapped command's outcome, output, or exit
  * code. On the no-session path it returns silently with no output at all.
  *
+ * Captured stdout/stderr (via the `emitData`/`emitErr` sinks + the logger tee)
+ * ride along so a reviewer sees not just which command ran but what it produced.
+ * The fatal error on a failure is logged AFTER this runs (the envelope's terminal
+ * output is intentionally last), so the tee can't have it yet — the envelope
+ * passes it explicitly as `errorText`, appended to whatever the tee captured.
+ *
  * @param exitCode the resolved exit code of the wrapped command (0 = success).
+ * @param errorText the fatal error message on the failure path, else undefined.
  */
 export const maybeTrackCommand = async (
   actionCommand: Command,
   exitCode: number,
+  errorText?: string,
 ): Promise<void> => {
   try {
     const opts = actionCommand.optsWithGlobals();
@@ -83,10 +92,15 @@ export const maybeTrackCommand = async (
       baseUrl: opts.baseUrl,
       port: opts.port,
     });
+    // Fold the explicit fatal error into the teed diagnostics (either may be
+    // empty). `getCapturedOutput` already caps each field.
+    const { stdout, stderr: capturedStderr } = getCapturedOutput();
+    const stderr = [capturedStderr, errorText].filter(Boolean).join("\n") || null;
+
     await client.rolloutSessions.addBlock({
       sessionId,
       type: "command",
-      content: { command: path, args: actionCommand.args ?? [], exitCode },
+      content: { command: path, args: actionCommand.args ?? [], exitCode, output: stdout, stderr },
       // Best-effort: a missing session / unsupported endpoint (404) is logged and
       // swallowed, never thrown — an exit 0 from the real command stays exit 0.
       failOnNotFound: false,

--- a/packages/lmnr-cli/src/utils/track-command.ts
+++ b/packages/lmnr-cli/src/utils/track-command.ts
@@ -17,15 +17,29 @@ const TRACKED_COMMANDS = new Set(["sql query", "ask"]);
 // already-decided exit code; on timeout we abandon the request and move on.
 const TRACKING_TIMEOUT_MS = 3_000;
 
-/** Race `work` against a timer, clearing (and unref-ing) it so it never holds the loop. */
-const withTimeout = async <T>(work: Promise<T>, ms: number): Promise<T> => {
+/**
+ * Run `work(signal)` under a deadline. On timeout we do two things: abort the
+ * signal — so an in-flight `fetch` is cancelled and its socket torn down, not
+ * merely abandoned (a leaked socket would keep the process alive past exit) —
+ * and reject, so the await stops even if `work` was blocked somewhere the signal
+ * doesn't reach (e.g. a token refresh). The timer is unref'd so it never holds
+ * the loop itself.
+ */
+const withDeadline = async <T>(
+  ms: number,
+  work: (signal: AbortSignal) => Promise<T>,
+): Promise<T> => {
+  const controller = new AbortController();
   let timer: ReturnType<typeof setTimeout> | undefined;
   const timeout = new Promise<never>((_, reject) => {
-    timer = setTimeout(() => reject(new Error(`timed out after ${ms}ms`)), ms);
+    timer = setTimeout(() => {
+      controller.abort();
+      reject(new Error(`timed out after ${ms}ms`));
+    }, ms);
     timer.unref?.();
   });
   try {
-    return await Promise.race([work, timeout]);
+    return await Promise.race([work(controller.signal), timeout]);
   } finally {
     clearTimeout(timer);
   }
@@ -115,39 +129,38 @@ export const maybeTrackCommand = async (
       return;
     }
 
-    // Cap the whole round-trip so a stalled server can't delay the command's exit.
-    await withTimeout(
-      (async () => {
-        const client = await buildLaminarClient({
-          projectId: opts.projectId,
-          baseUrl: opts.baseUrl,
-          port: opts.port,
-        });
-        // Fold the fatal error into the teed diagnostics (either may be empty).
-        const { stdout, stderr: capturedStderr } = getCapturedOutput();
-        const stderr = [capturedStderr, errorText].filter(Boolean).join("\n") || null;
+    // Cap the whole round-trip so a stalled server can't delay the command's
+    // exit; on timeout the signal aborts the in-flight block POST.
+    await withDeadline(TRACKING_TIMEOUT_MS, async (signal) => {
+      const client = await buildLaminarClient({
+        projectId: opts.projectId,
+        baseUrl: opts.baseUrl,
+        port: opts.port,
+      });
+      // Fold the fatal error into the teed diagnostics (either may be empty).
+      const { stdout, stderr: capturedStderr } = getCapturedOutput();
+      const stderr = [capturedStderr, errorText].filter(Boolean).join("\n") || null;
 
-        // Typed against the shared contract so a field rename in @lmnr-ai/types
-        // is a compile error, not a silent drop.
-        const content: CommandBlockContent = {
-          command: path,
-          args: actionCommand.args ?? [],
-          exitCode,
-          output: stdout,
-          stderr,
-          reasoning: opts.reasoning ?? null,
-        };
+      // Typed against the shared contract so a field rename in @lmnr-ai/types
+      // is a compile error, not a silent drop.
+      const content: CommandBlockContent = {
+        command: path,
+        args: actionCommand.args ?? [],
+        exitCode,
+        output: stdout,
+        stderr,
+        reasoning: opts.reasoning ?? null,
+      };
 
-        await client.rolloutSessions.addBlock({
-          sessionId,
-          type: "command",
-          content,
-          // A 404 (unsupported endpoint) is swallowed, never thrown.
-          failOnNotFound: false,
-        });
-      })(),
-      TRACKING_TIMEOUT_MS,
-    );
+      await client.rolloutSessions.addBlock({
+        sessionId,
+        type: "command",
+        content,
+        // A 404 (unsupported endpoint) is swallowed, never thrown.
+        failOnNotFound: false,
+        signal,
+      });
+    });
   } catch (err) {
     // Debug-level so tracking stays invisible on a normal run.
     logger.debug(`Command tracking skipped: ${errorMessage(err)}`);

--- a/packages/lmnr-cli/src/utils/track-command.ts
+++ b/packages/lmnr-cli/src/utils/track-command.ts
@@ -18,8 +18,34 @@ const logger = initializeLogger();
  */
 const TRACKED_COMMANDS = new Set(["sql query", "ask"]);
 
-/** Extra opt the tracked commands carry (commander's `--no-track` → `track:false`). */
-type TrackOpts = GlobalOpts & { track?: boolean };
+/**
+ * Extra opts the tracked commands carry: commander's `--no-track` → `track:false`,
+ * and `--reasoning <text>` → `reasoning`. Both are attached via
+ * {@link withTrackingOptions} rather than per-command.
+ */
+type TrackOpts = GlobalOpts & { track?: boolean; reasoning?: string };
+
+/**
+ * Attach the flags shared by every tracked command (see {@link TRACKED_COMMANDS}):
+ * the `--no-track` opt-out and `--reasoning` capture. Applying this in one place —
+ * rather than re-declaring the flags per command — keeps the tracked-command flag
+ * surface in sync with the allowlist it pairs with. Returns the same command for
+ * chaining (`.action(...)`, `.addHelpText(...)`).
+ */
+export const withTrackingOptions = (cmd: Command): Command =>
+  cmd
+    .option(
+      "--no-track",
+      "Do not record this command into the active debug session " +
+      "(also: LMNR_NO_COMMAND_TRACKING=1)",
+    )
+    .option(
+      "--reasoning <text>",
+      // The "15 words maximum" is guidance to keep agents terse — it is NOT
+      // enforced; any-length text is accepted and recorded verbatim.
+      "Agent reasoning to track with the Debugger session. Why are you calling " +
+      "this command? Limit 15 words maximum.",
+    );
 
 /**
  * The space-joined path of a command (e.g. `"sql query"`, `"ask"`), walking up
@@ -61,7 +87,9 @@ export const trackingDisabled = (opts: TrackOpts): boolean => {
  * Every failure mode is swallowed — no active session, no linked project, a
  * network error, a 404 from a server that doesn't know the block type — because
  * tracking must NEVER change the wrapped command's outcome, output, or exit
- * code. On the no-session path it returns silently with no output at all.
+ * code. On the no-session path it returns silently — EXCEPT when `--reasoning`
+ * was supplied, where it warns that the reasoning went unrecorded (a caller that
+ * bothered to pass reasoning expected it to land somewhere).
  *
  * Captured stdout/stderr (via the `emitData`/`emitErr` sinks + the logger tee)
  * ride along so a reviewer sees not just which command ran but what it produced.
@@ -85,7 +113,18 @@ export const maybeTrackCommand = async (
     if (!isTrackedCommand(path)) return;
 
     const sessionId = readDebugSessionFile(resolveDebugSessionDir())?.session_id;
-    if (!sessionId) return;
+    if (!sessionId) {
+      // No session is the normal case, so stay silent — unless reasoning was
+      // passed, which the caller clearly expected to be recorded somewhere.
+      if (opts.reasoning) {
+        logger.warn(
+          "--reasoning was provided but there is no active debug session in " +
+          "this directory, so it was not recorded. Start one with " +
+          "`lmnr-cli debug session new`.",
+        );
+      }
+      return;
+    }
 
     const client = await buildLaminarClient({
       projectId: opts.projectId,
@@ -100,7 +139,14 @@ export const maybeTrackCommand = async (
     await client.rolloutSessions.addBlock({
       sessionId,
       type: "command",
-      content: { command: path, args: actionCommand.args ?? [], exitCode, output: stdout, stderr },
+      content: {
+        command: path,
+        args: actionCommand.args ?? [],
+        exitCode,
+        output: stdout,
+        stderr,
+        reasoning: opts.reasoning ?? null,
+      },
       // Best-effort: a missing session / unsupported endpoint (404) is logged and
       // swallowed, never thrown — an exit 0 from the real command stays exit 0.
       failOnNotFound: false,

--- a/packages/lmnr-cli/src/utils/track-command.ts
+++ b/packages/lmnr-cli/src/utils/track-command.ts
@@ -12,11 +12,30 @@ const logger = initializeLogger();
 /** Allowlist of commands recorded into an active debug session, by command path. */
 const TRACKED_COMMANDS = new Set(["sql query", "ask"]);
 
-/** Extra opts on tracked commands: `--no-track` → `track`, `--thinking` → `thinking`. */
-type TrackOpts = GlobalOpts & { track?: boolean; thinking?: string };
+// Best-effort tracking must never delay the command's exit. Cap the network
+// round-trip so a stalled server can't hang an allowlisted command past its
+// already-decided exit code; on timeout we abandon the request and move on.
+const TRACKING_TIMEOUT_MS = 3_000;
+
+/** Race `work` against a timer, clearing (and unref-ing) it so it never holds the loop. */
+const withTimeout = async <T>(work: Promise<T>, ms: number): Promise<T> => {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error(`timed out after ${ms}ms`)), ms);
+    timer.unref?.();
+  });
+  try {
+    return await Promise.race([work, timeout]);
+  } finally {
+    clearTimeout(timer);
+  }
+};
+
+/** Extra opts on tracked commands: `--no-track` → `track`, `--reasoning` → `reasoning`. */
+type TrackOpts = GlobalOpts & { track?: boolean; reasoning?: string };
 
 /**
- * Attach the `--no-track` and `--thinking` flags shared by every tracked command.
+ * Attach the `--no-track` and `--reasoning` flags shared by every tracked command.
  * One place keeps the flags in sync with the allowlist. Returns the command for chaining.
  */
 export const withTrackingOptions = (cmd: Command): Command =>
@@ -27,9 +46,9 @@ export const withTrackingOptions = (cmd: Command): Command =>
       "(also: LMNR_NO_COMMAND_TRACKING=1)",
     )
     .option(
-      "--thinking <text>",
+      "--reasoning <text>",
       // "15 words maximum" is guidance only — any-length text is recorded verbatim.
-      "Agent thinking to track with the Debugger session. Why are you calling " +
+      "Agent reasoning to track with the Debugger session. Why are you calling " +
       "this command? Limit 15 words maximum.",
     );
 
@@ -62,7 +81,7 @@ export const trackingDisabled = (opts: TrackOpts): boolean => {
  * on-error hook, so a `postAction` hook would only see successes).
  *
  * Every failure is swallowed so tracking never changes the command's outcome or
- * exit code. The no-session path is silent EXCEPT when `--thinking` was passed,
+ * exit code. The no-session path is silent EXCEPT when `--reasoning` was passed,
  * which the caller clearly expected to be recorded.
  *
  * The fatal error is logged AFTER this runs, so the tee doesn't have it — the
@@ -85,10 +104,10 @@ export const maybeTrackCommand = async (
 
     const sessionId = readDebugSessionFile(resolveDebugSessionDir())?.session_id;
     if (!sessionId) {
-      // No session is normal, so stay silent — unless thinking was passed.
-      if (opts.thinking) {
+      // No session is normal, so stay silent — unless reasoning was passed.
+      if (opts.reasoning) {
         logger.warn(
-          "--thinking was provided but there is no active debug session in " +
+          "--reasoning was provided but there is no active debug session in " +
           "this directory, so it was not recorded. Start one with " +
           "`lmnr-cli debug session new`.",
         );
@@ -96,33 +115,39 @@ export const maybeTrackCommand = async (
       return;
     }
 
-    const client = await buildLaminarClient({
-      projectId: opts.projectId,
-      baseUrl: opts.baseUrl,
-      port: opts.port,
-    });
-    // Fold the fatal error into the teed diagnostics (either may be empty).
-    const { stdout, stderr: capturedStderr } = getCapturedOutput();
-    const stderr = [capturedStderr, errorText].filter(Boolean).join("\n") || null;
+    // Cap the whole round-trip so a stalled server can't delay the command's exit.
+    await withTimeout(
+      (async () => {
+        const client = await buildLaminarClient({
+          projectId: opts.projectId,
+          baseUrl: opts.baseUrl,
+          port: opts.port,
+        });
+        // Fold the fatal error into the teed diagnostics (either may be empty).
+        const { stdout, stderr: capturedStderr } = getCapturedOutput();
+        const stderr = [capturedStderr, errorText].filter(Boolean).join("\n") || null;
 
-    // Typed against the shared contract so a field rename in @lmnr-ai/types
-    // is a compile error, not a silent drop.
-    const content: CommandBlockContent = {
-      command: path,
-      args: actionCommand.args ?? [],
-      exitCode,
-      output: stdout,
-      stderr,
-      thinking: opts.thinking ?? null,
-    };
+        // Typed against the shared contract so a field rename in @lmnr-ai/types
+        // is a compile error, not a silent drop.
+        const content: CommandBlockContent = {
+          command: path,
+          args: actionCommand.args ?? [],
+          exitCode,
+          output: stdout,
+          stderr,
+          reasoning: opts.reasoning ?? null,
+        };
 
-    await client.rolloutSessions.addBlock({
-      sessionId,
-      type: "command",
-      content,
-      // A 404 (unsupported endpoint) is swallowed, never thrown.
-      failOnNotFound: false,
-    });
+        await client.rolloutSessions.addBlock({
+          sessionId,
+          type: "command",
+          content,
+          // A 404 (unsupported endpoint) is swallowed, never thrown.
+          failOnNotFound: false,
+        });
+      })(),
+      TRACKING_TIMEOUT_MS,
+    );
   } catch (err) {
     // Debug-level so tracking stays invisible on a normal run.
     logger.debug(`Command tracking skipped: ${errorMessage(err)}`);

--- a/packages/lmnr-cli/src/utils/track-command.ts
+++ b/packages/lmnr-cli/src/utils/track-command.ts
@@ -20,14 +20,14 @@ const TRACKED_COMMANDS = new Set(["sql query", "ask"]);
 
 /**
  * Extra opts the tracked commands carry: commander's `--no-track` → `track:false`,
- * and `--reasoning <text>` → `reasoning`. Both are attached via
+ * and `--thinking <text>` → `thinking`. Both are attached via
  * {@link withTrackingOptions} rather than per-command.
  */
-type TrackOpts = GlobalOpts & { track?: boolean; reasoning?: string };
+type TrackOpts = GlobalOpts & { track?: boolean; thinking?: string };
 
 /**
  * Attach the flags shared by every tracked command (see {@link TRACKED_COMMANDS}):
- * the `--no-track` opt-out and `--reasoning` capture. Applying this in one place —
+ * the `--no-track` opt-out and `--thinking` capture. Applying this in one place —
  * rather than re-declaring the flags per command — keeps the tracked-command flag
  * surface in sync with the allowlist it pairs with. Returns the same command for
  * chaining (`.action(...)`, `.addHelpText(...)`).
@@ -40,10 +40,10 @@ export const withTrackingOptions = (cmd: Command): Command =>
       "(also: LMNR_NO_COMMAND_TRACKING=1)",
     )
     .option(
-      "--reasoning <text>",
+      "--thinking <text>",
       // The "15 words maximum" is guidance to keep agents terse — it is NOT
       // enforced; any-length text is accepted and recorded verbatim.
-      "Agent reasoning to track with the Debugger session. Why are you calling " +
+      "Agent thinking to track with the Debugger session. Why are you calling " +
       "this command? Limit 15 words maximum.",
     );
 
@@ -87,9 +87,9 @@ export const trackingDisabled = (opts: TrackOpts): boolean => {
  * Every failure mode is swallowed — no active session, no linked project, a
  * network error, a 404 from a server that doesn't know the block type — because
  * tracking must NEVER change the wrapped command's outcome, output, or exit
- * code. On the no-session path it returns silently — EXCEPT when `--reasoning`
- * was supplied, where it warns that the reasoning went unrecorded (a caller that
- * bothered to pass reasoning expected it to land somewhere).
+ * code. On the no-session path it returns silently — EXCEPT when `--thinking`
+ * was supplied, where it warns that the thinking went unrecorded (a caller that
+ * bothered to pass thinking expected it to land somewhere).
  *
  * Captured stdout/stderr (via the `emitData`/`emitErr` sinks + the logger tee)
  * ride along so a reviewer sees not just which command ran but what it produced.
@@ -114,11 +114,11 @@ export const maybeTrackCommand = async (
 
     const sessionId = readDebugSessionFile(resolveDebugSessionDir())?.session_id;
     if (!sessionId) {
-      // No session is the normal case, so stay silent — unless reasoning was
+      // No session is the normal case, so stay silent — unless thinking was
       // passed, which the caller clearly expected to be recorded somewhere.
-      if (opts.reasoning) {
+      if (opts.thinking) {
         logger.warn(
-          "--reasoning was provided but there is no active debug session in " +
+          "--thinking was provided but there is no active debug session in " +
           "this directory, so it was not recorded. Start one with " +
           "`lmnr-cli debug session new`.",
         );
@@ -145,7 +145,7 @@ export const maybeTrackCommand = async (
         exitCode,
         output: stdout,
         stderr,
-        reasoning: opts.reasoning ?? null,
+        thinking: opts.thinking ?? null,
       },
       // Best-effort: a missing session / unsupported endpoint (404) is logged and
       // swallowed, never thrown — an exit 0 from the real command stays exit 0.

--- a/packages/lmnr-cli/src/utils/track-command.ts
+++ b/packages/lmnr-cli/src/utils/track-command.ts
@@ -1,4 +1,4 @@
-import { errorMessage } from "@lmnr-ai/types";
+import { type CommandBlockContent, errorMessage } from "@lmnr-ai/types";
 import type { Command } from "commander";
 
 import { buildLaminarClient } from "../auth/client";
@@ -136,17 +136,21 @@ export const maybeTrackCommand = async (
     const { stdout, stderr: capturedStderr } = getCapturedOutput();
     const stderr = [capturedStderr, errorText].filter(Boolean).join("\n") || null;
 
+    // Typed against the shared contract so a field rename that drifts from
+    // @lmnr-ai/types (e.g. thinking → …) is a compile error, not a silent drop.
+    const content: CommandBlockContent = {
+      command: path,
+      args: actionCommand.args ?? [],
+      exitCode,
+      output: stdout,
+      stderr,
+      thinking: opts.thinking ?? null,
+    };
+
     await client.rolloutSessions.addBlock({
       sessionId,
       type: "command",
-      content: {
-        command: path,
-        args: actionCommand.args ?? [],
-        exitCode,
-        output: stdout,
-        stderr,
-        thinking: opts.thinking ?? null,
-      },
+      content,
       // Best-effort: a missing session / unsupported endpoint (404) is logged and
       // swallowed, never thrown — an exit 0 from the real command stays exit 0.
       failOnNotFound: false,

--- a/packages/lmnr-cli/src/utils/track-command.ts
+++ b/packages/lmnr-cli/src/utils/track-command.ts
@@ -9,28 +9,15 @@ import { initializeLogger } from "./logger";
 
 const logger = initializeLogger();
 
-/**
- * CLI commands worth recording into an active debug session — the investigative
- * ones a reviewer wants to see the agent ran, keyed by the space-joined command
- * path. Everything else is deliberately excluded as noise / self-referential:
- * `login`, `logout`, `setup`, `skill *`, `plugin *`, `project *`, `status`, and
- * all `debug session *` (including `add-note`).
- */
+/** Allowlist of commands recorded into an active debug session, by command path. */
 const TRACKED_COMMANDS = new Set(["sql query", "ask"]);
 
-/**
- * Extra opts the tracked commands carry: commander's `--no-track` → `track:false`,
- * and `--thinking <text>` → `thinking`. Both are attached via
- * {@link withTrackingOptions} rather than per-command.
- */
+/** Extra opts on tracked commands: `--no-track` → `track`, `--thinking` → `thinking`. */
 type TrackOpts = GlobalOpts & { track?: boolean; thinking?: string };
 
 /**
- * Attach the flags shared by every tracked command (see {@link TRACKED_COMMANDS}):
- * the `--no-track` opt-out and `--thinking` capture. Applying this in one place —
- * rather than re-declaring the flags per command — keeps the tracked-command flag
- * surface in sync with the allowlist it pairs with. Returns the same command for
- * chaining (`.action(...)`, `.addHelpText(...)`).
+ * Attach the `--no-track` and `--thinking` flags shared by every tracked command.
+ * One place keeps the flags in sync with the allowlist. Returns the command for chaining.
  */
 export const withTrackingOptions = (cmd: Command): Command =>
   cmd
@@ -41,20 +28,16 @@ export const withTrackingOptions = (cmd: Command): Command =>
     )
     .option(
       "--thinking <text>",
-      // The "15 words maximum" is guidance to keep agents terse — it is NOT
-      // enforced; any-length text is accepted and recorded verbatim.
+      // "15 words maximum" is guidance only — any-length text is recorded verbatim.
       "Agent thinking to track with the Debugger session. Why are you calling " +
       "this command? Limit 15 words maximum.",
     );
 
-/**
- * The space-joined path of a command (e.g. `"sql query"`, `"ask"`), walking up
- * to — but not including — the program root, whose name isn't part of the path.
- */
+/** Space-joined command path (e.g. `"sql query"`), excluding the program root. */
 export const commandPath = (cmd: Command): string => {
   const names: string[] = [];
   let cur: Command | undefined = cmd;
-  // A command with no parent is the program root — stop before prepending it.
+  // The parent-less command is the program root — stop before prepending it.
   while (cur && cur.parent) {
     names.unshift(cur.name());
     cur = cur.parent ?? undefined;
@@ -65,10 +48,7 @@ export const commandPath = (cmd: Command): string => {
 /** Whether `path` is on the record-into-session allowlist. */
 export const isTrackedCommand = (path: string): boolean => TRACKED_COMMANDS.has(path);
 
-/**
- * Whether tracking is opted out — via the `--no-track` flag (`track === false`)
- * or the `LMNR_NO_COMMAND_TRACKING` env var (`1` / `true` / `yes`).
- */
+/** Opted out via `--no-track` or `LMNR_NO_COMMAND_TRACKING` (`1`/`true`/`yes`). */
 export const trackingDisabled = (opts: TrackOpts): boolean => {
   if (opts.track === false) return true;
   const env = process.env.LMNR_NO_COMMAND_TRACKING?.trim().toLowerCase();
@@ -76,29 +56,20 @@ export const trackingDisabled = (opts: TrackOpts): boolean => {
 };
 
 /**
- * Best-effort: record an allowlisted CLI command into the active debug session
- * as a `command` block, so a reviewer sees which investigative commands the
- * agent ran — and how each one turned out. Called from the command error
- * envelope (`runWithEnvelope`), which is the one place that knows both that a
- * command finished AND its real exit code (0 on success, the mapped code on
- * failure) — Commander itself has no on-error hook, so a plain `postAction`
- * hook would only ever see successes.
+ * Best-effort: record an allowlisted command into the active debug session as a
+ * `command` block. Called from the error envelope (`runWithEnvelope`) — the only
+ * place that knows a command finished AND its real exit code (Commander has no
+ * on-error hook, so a `postAction` hook would only see successes).
  *
- * Every failure mode is swallowed — no active session, no linked project, a
- * network error, a 404 from a server that doesn't know the block type — because
- * tracking must NEVER change the wrapped command's outcome, output, or exit
- * code. On the no-session path it returns silently — EXCEPT when `--thinking`
- * was supplied, where it warns that the thinking went unrecorded (a caller that
- * bothered to pass thinking expected it to land somewhere).
+ * Every failure is swallowed so tracking never changes the command's outcome or
+ * exit code. The no-session path is silent EXCEPT when `--thinking` was passed,
+ * which the caller clearly expected to be recorded.
  *
- * Captured stdout/stderr (via the `emitData`/`emitErr` sinks + the logger tee)
- * ride along so a reviewer sees not just which command ran but what it produced.
- * The fatal error on a failure is logged AFTER this runs (the envelope's terminal
- * output is intentionally last), so the tee can't have it yet — the envelope
- * passes it explicitly as `errorText`, appended to whatever the tee captured.
+ * The fatal error is logged AFTER this runs, so the tee doesn't have it — the
+ * envelope passes it as `errorText`, appended to the teed output.
  *
- * @param exitCode the resolved exit code of the wrapped command (0 = success).
- * @param errorText the fatal error message on the failure path, else undefined.
+ * @param exitCode resolved exit code of the wrapped command (0 = success).
+ * @param errorText fatal error message on the failure path, else undefined.
  */
 export const maybeTrackCommand = async (
   actionCommand: Command,
@@ -114,8 +85,7 @@ export const maybeTrackCommand = async (
 
     const sessionId = readDebugSessionFile(resolveDebugSessionDir())?.session_id;
     if (!sessionId) {
-      // No session is the normal case, so stay silent — unless thinking was
-      // passed, which the caller clearly expected to be recorded somewhere.
+      // No session is normal, so stay silent — unless thinking was passed.
       if (opts.thinking) {
         logger.warn(
           "--thinking was provided but there is no active debug session in " +
@@ -131,13 +101,12 @@ export const maybeTrackCommand = async (
       baseUrl: opts.baseUrl,
       port: opts.port,
     });
-    // Fold the explicit fatal error into the teed diagnostics (either may be
-    // empty). `getCapturedOutput` already caps each field.
+    // Fold the fatal error into the teed diagnostics (either may be empty).
     const { stdout, stderr: capturedStderr } = getCapturedOutput();
     const stderr = [capturedStderr, errorText].filter(Boolean).join("\n") || null;
 
-    // Typed against the shared contract so a field rename that drifts from
-    // @lmnr-ai/types (e.g. thinking → …) is a compile error, not a silent drop.
+    // Typed against the shared contract so a field rename in @lmnr-ai/types
+    // is a compile error, not a silent drop.
     const content: CommandBlockContent = {
       command: path,
       args: actionCommand.args ?? [],
@@ -151,13 +120,11 @@ export const maybeTrackCommand = async (
       sessionId,
       type: "command",
       content,
-      // Best-effort: a missing session / unsupported endpoint (404) is logged and
-      // swallowed, never thrown — an exit 0 from the real command stays exit 0.
+      // A 404 (unsupported endpoint) is swallowed, never thrown.
       failOnNotFound: false,
     });
   } catch (err) {
-    // Debug-level (below the default `info`) so tracking stays invisible unless
-    // a user opts into verbose logs; it must never surface on a normal run.
+    // Debug-level so tracking stays invisible on a normal run.
     logger.debug(`Command tracking skipped: ${errorMessage(err)}`);
   }
 };

--- a/packages/lmnr/package.json
+++ b/packages/lmnr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lmnr-ai/lmnr",
-  "version": "0.8.38",
+  "version": "0.8.39",
   "description": "TypeScript SDK for Laminar AI",
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lmnr-ai/types",
-  "version": "0.8.38",
+  "version": "0.8.39",
   "description": "Shared types for Laminar AI SDK",
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",

--- a/packages/types/src/session-block.ts
+++ b/packages/types/src/session-block.ts
@@ -12,13 +12,16 @@
  *  - `text`       — a free-text note the agent attaches post-factum via
  *    `lmnr-cli debug session add-note` (keyed by session id, not tied to any
  *    trace / eval).
+ *  - `command`    — an investigative CLI command (e.g. `sql query`, `ask`) the
+ *    CLI records into the active session so a reviewer sees which commands ran
+ *    during the investigation (best-effort, opt-out).
  *
  * `type` is a plain string on the wire so new block types can be added without
  * a client bump; the union below is the set this SDK knows how to render.
  */
 
 /** Block type the CLI knows how to render. `type` is a plain string on the wire. */
-export type SessionBlockType = "trace" | "evaluation" | "text";
+export type SessionBlockType = "trace" | "evaluation" | "text" | "command";
 
 /** `content` of a `trace` block. */
 export interface TraceBlockContent {
@@ -39,11 +42,26 @@ export interface TextBlockContent {
   text: string;
 }
 
+/**
+ * `content` of a `command` block — an investigative CLI command recorded into
+ * the active debug session. The raw command string is uploaded so a reviewer can
+ * see exactly what ran.
+ */
+export interface CommandBlockContent {
+  /** The command path, e.g. `"sql query"` or `"ask"`. */
+  command: string;
+  /** The command's positional arguments (raw — may contain the query text). */
+  args: string[];
+  /** The process exit code observed at post-action time (0 on the success path). */
+  exitCode: number;
+}
+
 /** Union of the known block content shapes. */
 export type SessionBlockContent =
   | TraceBlockContent
   | EvaluationBlockContent
-  | TextBlockContent;
+  | TextBlockContent
+  | CommandBlockContent;
 
 /**
  * One block in a debugger session, as returned by

--- a/packages/types/src/session-block.ts
+++ b/packages/types/src/session-block.ts
@@ -54,6 +54,16 @@ export interface CommandBlockContent {
   args: string[];
   /** The process exit code observed at post-action time (0 on the success path). */
   exitCode: number;
+  /**
+   * Captured stdout (the command's data output), truncated to a bounded prefix.
+   * Omitted / null when the command produced no stdout.
+   */
+  output?: string | null;
+  /**
+   * Captured stderr (diagnostics + the fatal error on failure), truncated to a
+   * bounded prefix. Omitted / null when the command produced no stderr.
+   */
+  stderr?: string | null;
 }
 
 /** Union of the known block content shapes. */

--- a/packages/types/src/session-block.ts
+++ b/packages/types/src/session-block.ts
@@ -1,23 +1,14 @@
 /**
- * Shared contract for debugger-session blocks.
+ * Shared contract for debugger-session blocks — an ordered list of blocks (see
+ * app-server `debugger_session_blocks`), each with a `type` and type-specific
+ * `content`:
  *
- * A debug session renders as an ordered list of blocks (see the app-server
- * `debugger_session_blocks` table). Each block has a plain-text `type` and a
- * jsonb `content` whose shape depends on the type:
+ *  - `trace`      — a trace under the session; written at ingest.
+ *  - `evaluation` — an eval under the session; written at eval creation.
+ *  - `text`       — a free-text note via `debug session add-note`.
+ *  - `command`    — a CLI command (`sql query`, `ask`) recorded into the session.
  *
- *  - `trace`      — a trace produced under the session (`rollout.session_id`);
- *    written at ingest.
- *  - `evaluation` — an evaluation created under the session; written at eval
- *    creation.
- *  - `text`       — a free-text note the agent attaches post-factum via
- *    `lmnr-cli debug session add-note` (keyed by session id, not tied to any
- *    trace / eval).
- *  - `command`    — an investigative CLI command (e.g. `sql query`, `ask`) the
- *    CLI records into the active session so a reviewer sees which commands ran
- *    during the investigation (best-effort, opt-out).
- *
- * `type` is a plain string on the wire so new block types can be added without
- * a client bump; the union below is the set this SDK knows how to render.
+ * `type` is a plain string on the wire so new types need no client bump.
  */
 
 /** Block type the CLI knows how to render. `type` is a plain string on the wire. */
@@ -42,11 +33,7 @@ export interface TextBlockContent {
   text: string;
 }
 
-/**
- * `content` of a `command` block — an investigative CLI command recorded into
- * the active debug session. The raw command string is uploaded so a reviewer can
- * see exactly what ran.
- */
+/** `content` of a `command` block — a CLI command recorded into the session. */
 export interface CommandBlockContent {
   /** The command path, e.g. `"sql query"` or `"ask"`. */
   command: string;
@@ -54,22 +41,11 @@ export interface CommandBlockContent {
   args: string[];
   /** The process exit code observed at post-action time (0 on the success path). */
   exitCode: number;
-  /**
-   * Captured stdout (the command's data output), truncated to a bounded prefix.
-   * Omitted / null when the command produced no stdout.
-   */
+  /** Captured stdout, truncated to a bounded prefix. Null when empty. */
   output?: string | null;
-  /**
-   * Captured stderr (diagnostics + the fatal error on failure), truncated to a
-   * bounded prefix. Omitted / null when the command produced no stderr.
-   */
+  /** Captured stderr, truncated to a bounded prefix. Null when empty. */
   stderr?: string | null;
-  /**
-   * Free-text agent thinking for this step, recorded alongside the command so a
-   * reviewer sees what the agent was thinking when it ran it. Supplied via
-   * `--thinking`; omitted / null when not provided. Additive on the wire — no
-   * client bump (same as `output` / `stderr`).
-   */
+  /** Agent thinking for this step, via `--thinking`. Null when not provided. */
   thinking?: string | null;
 }
 
@@ -81,12 +57,9 @@ export type SessionBlockContent =
   | CommandBlockContent;
 
 /**
- * One block in a debugger session, as returned by
- * `GET /v1/cli/rollouts/{sessionId}/blocks`.
- *
- * `content` is typed loosely (`Record<string, unknown>`) because `type` is
- * open-ended on the wire; narrow it with the `*BlockContent` interfaces above
- * once `type` is known.
+ * One block in a debugger session (from `GET /v1/cli/rollouts/{sessionId}/blocks`).
+ * `content` is loose (`Record<string, unknown>`) since `type` is open-ended;
+ * narrow it with the `*BlockContent` interfaces above once `type` is known.
  */
 export interface SessionBlock {
   /** Block id (deterministic UUIDv5 for trace/eval blocks; random for text). */

--- a/packages/types/src/session-block.ts
+++ b/packages/types/src/session-block.ts
@@ -45,8 +45,8 @@ export interface CommandBlockContent {
   output?: string | null;
   /** Captured stderr, truncated to a bounded prefix. Null when empty. */
   stderr?: string | null;
-  /** Agent thinking for this step, via `--thinking`. Null when not provided. */
-  thinking?: string | null;
+  /** Agent reasoning for this step, via `--reasoning`. Null when not provided. */
+  reasoning?: string | null;
 }
 
 /** Union of the known block content shapes. */

--- a/packages/types/src/session-block.ts
+++ b/packages/types/src/session-block.ts
@@ -64,6 +64,13 @@ export interface CommandBlockContent {
    * bounded prefix. Omitted / null when the command produced no stderr.
    */
   stderr?: string | null;
+  /**
+   * Free-text agent reasoning for this step, recorded alongside the command so a
+   * reviewer sees what the agent was thinking when it ran it. Supplied via
+   * `--reasoning`; omitted / null when not provided. Additive on the wire — no
+   * client bump (same as `output` / `stderr`).
+   */
+  reasoning?: string | null;
 }
 
 /** Union of the known block content shapes. */

--- a/packages/types/src/session-block.ts
+++ b/packages/types/src/session-block.ts
@@ -65,12 +65,12 @@ export interface CommandBlockContent {
    */
   stderr?: string | null;
   /**
-   * Free-text agent reasoning for this step, recorded alongside the command so a
+   * Free-text agent thinking for this step, recorded alongside the command so a
    * reviewer sees what the agent was thinking when it ran it. Supplied via
-   * `--reasoning`; omitted / null when not provided. Additive on the wire — no
+   * `--thinking`; omitted / null when not provided. Additive on the wire — no
    * client bump (same as `output` / `stderr`).
    */
-  reasoning?: string | null;
+  thinking?: string | null;
 }
 
 /** Union of the known block content shapes. */


### PR DESCRIPTION
## Summary

Five `lmnr-cli` onboarding / project-linking / tracking improvements, plus follow-up refinements from review. Spans `lmnr-cli` and the shared `@lmnr-ai/client` / `@lmnr-ai/types` packages.

## Changes

### Sort CLI project listings alphabetically
`client.cli.listProjects()` now sorts by workspace name then project name (locale-aware, case-insensitive via `Intl.Collator`) at the single client choke point, so the `project list` table, its `--json`, and the interactive picker (`setup` / `plugin add` / `project link`) all inherit one stable order — no re-sorting per call site.

### `setup` absorbs an expired session
An expired session leaves a valid-shaped `credentials.json`, so `setup` used to take the "already logged in" path and then dead-end on the first authed call with `list_projects_failed` (exit 10). A new discriminable `SessionExpiredError` (thrown by `refreshIfNeeded`) lets `setup` detect the expiry up front and re-run the device-flow login (honoring `--no-browser`) instead. Transient network/5xx errors still surface as `list_projects_failed` (10) and a genuine login failure as `login_failed` (6) — the two are never conflated.

### `lmnr-cli project link`
Re-points the current directory to a project by rewriting `.lmnr/project.json` (interactive sorted picker, or `--project-id` validated against accessible projects → `no_access`=4), then runs the same key probe/mint/write as `setup`. That probe/mint/write is extracted into a shared `ensureProjectKey` primitive both commands use (no duplicated copy). The key check runs **before** the link file is written, so a failure never leaves a half-applied re-link. A valid key for a *different* project no longer hard-stops the re-link — it **warns** and points at `project mint-key`.

### `lmnr-cli project mint-key`
Mints a fresh Project API Key (via the shared `mintProjectApiKey`, same call `setup` / `plugin add` use) and **prints** it — bare key to stdout for copy-paste/pipe, `{ projectId, apiKey, apiKeyId }` under `--json`. Deliberately does **not** write `.env`.

### `lmnr-cli status`
Local-only report of the signed-in user, the linked project, and the active debug session, read entirely from local files (`credentials.json`, `.lmnr/project.json`, `.lmnr/debug-session.json`). Works offline, degrades each absent field to a "not set" line (exit 0), and emits a flat object under `--json`. Session *name* is intentionally omitted (documented in `--help`) pending a backend endpoint.

### Auto-track investigative commands
When a debug session is active, allowlisted commands (`sql query`, `ask`) are recorded into that session as `command` blocks so a reviewer sees what the agent ran, and how each turned out. Recording lives in the command error envelope (`runWithEnvelope`) — the one place that sees both success **and** failure with the real exit code (Commander has no on-error hook). Best-effort: every failure is swallowed and the wrapped command's exit code is never changed. Opt-out via `--no-track` or `LMNR_NO_COMMAND_TRACKING`. Adds `"command"` to `SessionBlockType` + `CommandBlockContent` in `@lmnr-ai/types` — additive on the open wire string, no client bump.

### Cleanups (from review)
- Consolidated duplicated `trimSlash` into `utils/text.ts`; pointed `setup` at the shared `DEFAULT_*` constants.
- Error text that recommended `rm .lmnr/project.json && lmnr-cli setup` now points at `lmnr-cli project link`.

## Cross-repo follow-up (not in this PR)
The TS side is self-contained and no-ops gracefully if the server doesn't recognize the block (same posture as `addBlock`'s existing 404 handling). **Ingesting / storing / rendering the `command` block requires backend + frontend work in the other Laminar repos** — sequence it there.

## Testing
- All package builds pass; lint clean.
- 170 `lmnr-cli` unit tests + 45 `@lmnr-ai/client` tests pass. New tests cover: the sort, expired-session recovery, `project link` (incl. mismatch-warns-and-relinks), `project mint-key`, `status`, and command tracking (allowlist, no-session skip, opt-out, failure-swallowed, real exit code on failure).
- Note: two pre-existing `lmnr-cli` integration test files (`sql`, `datasets`) fail on this environment's lockfile vitest version — they fail identically on a clean `main`, unrelated to these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches auth/session refresh, API key probe/mint paths, and best-effort uploads of command output (including raw SQL/questions) to debug sessions; behavior is mostly additive with graceful no-ops when the server lacks support.
> 
> **Overview**
> **lmnr-cli 0.4.0** adds project lifecycle commands, debugger-oriented command tracking, and several UX/auth fixes across the CLI and shared client/types packages.
> 
> New commands: **`project link`** rewrites `.lmnr/project.json` and runs shared **`ensureProjectKey`** (probe/mint/write like `setup`, with warn-on-mismatch so re-link isn’t blocked by another project’s key); **`project mint-key`** prints a fresh API key without touching `.env`; **`status`** reports user, linked project, and debug session from local files only (offline, `--json`).
> 
> **`setup`** now detects **`SessionExpiredError`** up front and re-runs login instead of failing with `list_projects_failed` (10). Expired grants elsewhere map to **`login_failed`** (6) via centralized **`CliError`** / **`failWith`**.
> 
> With an active debug session, **`sql query`** and **`ask`** are best-effort recorded as **`command`** blocks (exit code, captured stdout/stderr, optional `--reasoning`, opt-out via `--no-track`). Debug **`session summary`** renders those blocks; **`sql query`** defaults to **CSV** on stdout (`--pretty` for tables).
> 
> **`@lmnr-ai/client`**: `listProjects()` sorts workspace then project name; **`addBlock`** accepts **`AbortSignal`**. **`@lmnr-ai/types`**: adds **`command`** block type and **`CommandBlockContent`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2fcb3a41e2d0148f36e89430e6954ba3a4cafab8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->