### PR TITLE
feat(pi-extension): add @lmnr-ai/pi-extension package

### DIFF
--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -29,7 +29,7 @@ jobs:
         run: cd packages/lmnr-cli && pnpm publish --provenance --access public --no-git-checks
 
   publish-sdk:
-    if: "!startsWith(github.event.release.tag_name, 'cli-')"
+    if: "!startsWith(github.event.release.tag_name, 'cli-') && !startsWith(github.event.release.tag_name, 'pi-extension-')"
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -63,3 +63,32 @@ jobs:
 
       - name: Publish main SDK package
         run: cd packages/lmnr && pnpm publish --provenance --access public --no-git-checks
+
+  # pi-extension is versioned and released independently of the SDK (own tag
+  # prefix `pi-extension-*`). It is build-free — pi runs the TypeScript source
+  # directly — so there is no build step; we publish `src` as-is.
+  publish-pi-extension:
+    if: startsWith(github.event.release.tag_name, 'pi-extension-')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v5
+        with:
+          version: 10
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+      # Freeze to latest 11, because 12 / latest fails in publish
+      # https://github.com/npm/cli/issues/9722
+      - run: npm install -g npm@next-11
+      - run: pnpm install --frozen-lockfile
+
+      - name: Run tests
+        run: pnpm --filter @lmnr-ai/pi-extension test
+
+      - name: Publish pi-extension package
+        run: cd packages/pi-extension && pnpm publish --provenance --access public --no-git-checks

--- a/packages/pi-extension/README.md
+++ b/packages/pi-extension/README.md
@@ -1,0 +1,100 @@
+# @lmnr-ai/pi-extension
+
+[![npm](https://img.shields.io/npm/v/@lmnr-ai/pi-extension)](https://www.npmjs.com/package/@lmnr-ai/pi-extension)
+[![license](https://img.shields.io/npm/l/@lmnr-ai/pi-extension)](https://github.com/lmnr-ai/lmnr-ts/blob/main/LICENSE)
+
+[Laminar](https://laminar.sh) observability for the [pi coding agent](https://pi.dev). A pi extension that emits, **live and in-process**, one Laminar trace per agent run — with granular LLM and tool spans — over OTLP/HTTP. No build step, no code changes to your agent, and fully fail-open.
+
+## Install
+
+```sh
+pi install npm:@lmnr-ai/pi-extension
+```
+
+Set your Laminar project key and run pi as usual:
+
+```sh
+export LMNR_PROJECT_API_KEY="..."   # from https://laminar.sh
+pi -p "…"
+```
+
+That's it — every agent run now streams a trace to Laminar. With no key set, the extension disables itself silently, so it's safe to leave installed.
+
+<details><summary>Other install methods</summary>
+
+```sh
+pi install git:github.com/lmnr-ai/lmnr-ts#subdir=packages/pi-extension   # from the monorepo
+pi install /path/to/pi-extension                                         # from a local path
+```
+
+Or declare it in `~/.pi/agent/settings.json`:
+
+```json
+{ "packages": ["npm:@lmnr-ai/pi-extension"] }
+```
+
+</details>
+
+## What you get
+
+One Laminar **trace per pi agent run** (`before_agent_start` → `agent_end`), with fully granular child spans opened and closed in realtime:
+
+```
+pi agent run          (DEFAULT)   ← the whole run
+├─ LLM call (turn 0)  (LLM)       ← each model call, with token usage + cost
+├─ bash               (TOOL)      ← each tool execution
+├─ LLM call (turn 1)  (LLM)
+└─ …
+```
+
+- **Live streaming** — spans export as they close, not batched at the end.
+- **Cost + tokens** — emitted under Laminar's canonical `gen_ai.usage.*` attributes.
+- **Debugger sessions** — group runs into a Laminar debugger session (see below).
+- **Evaluation-aware** — under a harness that injects a parent span (e.g. Harbor), pi's trace nests beneath it and inherits its trace type (e.g. `EVALUATION`), so eval traces are classified correctly.
+- **Fail-open** — any tracing or export error is swallowed; it can never break an agent run.
+
+## Configuration
+
+All configuration is via environment variables (no secrets in files):
+
+| Variable | Required | Description |
+|---|---|---|
+| `LMNR_PROJECT_API_KEY` | yes | Laminar project key. Absent ⇒ tracing disabled (fail-open). |
+| `LMNR_BASE_URL` | no | Laminar API base URL (default `https://api.lmnr.ai`). |
+| `LMNR_USER_ID` | no | Associates traces with a user id. |
+| `LMNR_DEBUG` | no | Truthy ⇒ enable debugger sessions + a local log at `~/.pi/agent/lmnr-pi-extension.log`. |
+| `LMNR_DEBUG_SESSION_ID` | no | Pin a specific debugger (rollout) session id. |
+| `LMNR_MAX_CHARS` | no | Truncation cap for span input/output (default `20000`). |
+
+## Debugger sessions
+
+With `LMNR_DEBUG` truthy, each run joins a Laminar **debugger session** so it shows up in the debugger UI. The session id resolves exactly like the Laminar SDK: `LMNR_DEBUG_SESSION_ID` → the nearest `.lmnr/debug-session.json` (written by `lmnr-cli debug session new`) → a freshly minted UUID.
+
+```sh
+lmnr-cli debug session new      # open a session (writes .lmnr/debug-session.json)
+LMNR_DEBUG=true pi -p "…"        # runs join that session automatically
+lmnr-cli debug session summary  # see your run as a <trace> block
+```
+
+## Evaluation / harness integration
+
+When an upstream harness injects a serialized Laminar span context via `LMNR_SPAN_CONTEXT`, the extension nests pi's trace under that parent span (sharing its trace id) and carries the parent's `trace_type` (e.g. `EVALUATION`) onto every span. So a harness like [Harbor](https://github.com/lmnr-ai) gets pi's LLM/tool spans under its evaluation trace, classified correctly — no configuration required; it's automatic whenever the env var is present.
+
+## Develop
+
+This package lives in the [`lmnr-ts`](https://github.com/lmnr-ai/lmnr-ts) monorepo (pnpm workspace). From the repo root:
+
+```sh
+pnpm install
+pnpm --filter @lmnr-ai/pi-extension typecheck   # tsc --noEmit
+pnpm --filter @lmnr-ai/pi-extension test         # node:test via tsx — unit + end-to-end OTLP-capture tests
+pi -e "$PWD/packages/pi-extension/src/index.ts" -p "…"   # load the local source directly
+```
+
+There is **no build step** — pi runs the TypeScript entry (`src/index.ts`) directly via jiti, so the shipped source is exactly what runs. The end-to-end test drives the extension with synthetic pi events against a local OTLP capture server and asserts the resulting span tree — no network or Laminar account required.
+
+The extension deliberately depends only on raw OpenTelemetry at runtime (not the Laminar SDK) so it stays light enough to upload into a sandbox. It reuses shared *type* definitions (`SpanType`, `DebugSessionFile`) from [`@lmnr-ai/types`](../types) as type-only imports, which are erased at runtime.
+
+## License
+
+Apache-2.0 © LMNR AI, Inc.

--- a/packages/pi-extension/eslint.config.mjs
+++ b/packages/pi-extension/eslint.config.mjs
@@ -1,0 +1,3 @@
+import config from "../../eslint.config.mjs";
+
+export default config;

--- a/packages/pi-extension/package.json
+++ b/packages/pi-extension/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@lmnr-ai/pi-extension",
+  "version": "0.1.0",
+  "description": "Laminar observability extension for the pi coding agent — live in-process OTLP tracing",
+  "type": "module",
+  "license": "Apache-2.0",
+  "author": "founders@lmnr.ai",
+  "homepage": "https://github.com/lmnr-ai/lmnr-ts/tree/main/packages/pi-extension#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/lmnr-ai/lmnr-ts.git",
+    "directory": "packages/pi-extension"
+  },
+  "bugs": {
+    "url": "https://github.com/lmnr-ai/lmnr-ts/issues"
+  },
+  "keywords": ["pi-package", "pi", "laminar", "lmnr", "observability", "tracing", "otel", "otlp"],
+  "files": ["src", "README.md"],
+  "engines": {
+    "node": ">=18"
+  },
+  "pi": {
+    "extensions": ["src/index.ts"]
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "tsx --test test/*.test.ts",
+    "lint": "eslint",
+    "lint:fix": "eslint --fix"
+  },
+  "dependencies": {
+    "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/core": "^1.30.0",
+    "@opentelemetry/exporter-trace-otlp-http": "^0.57.0",
+    "@opentelemetry/resources": "^1.30.0",
+    "@opentelemetry/sdk-trace-base": "^1.30.0"
+  },
+  "devDependencies": {
+    "@lmnr-ai/types": "workspace:*"
+  }
+}

--- a/packages/pi-extension/src/attributes.ts
+++ b/packages/pi-extension/src/attributes.ts
@@ -1,0 +1,144 @@
+import { ASSOC_PREFIX } from "./tracer.js";
+import type { Json, PiAssistantMessage, PiUsage } from "./types.js";
+import { extractText, jsonDumpsTruncated } from "./util.js";
+
+// ----------------- Attribute mapping (wayfinder ticket 5) -----------------
+// pi payloads → Laminar `lmnr.*` / OTel `gen_ai.*` attributes. Field-name
+// divergences from Anthropic-raw are handled here (usage.input vs input_tokens;
+// `toolCall{arguments}` blocks; tool result arrives on the event, not content).
+
+/**
+ * Infer the model vendor for `gen_ai.system` from pi's `model` string.
+ * pi models look like `us.anthropic.claude-opus-4-8`, `us.openai.gpt-5.5`,
+ * `amazon-bedrock/qwen.qwen3-coder-...`. We look for a known vendor token,
+ * falling back to `provider`, then "unknown".
+ */
+const KNOWN_VENDORS = [
+  "anthropic", "openai", "google", "meta", "mistral", "cohere", "qwen", "deepseek", "amazon",
+];
+
+export function inferVendor(model: string | undefined, provider: string | undefined): string {
+  const haystack = (model ?? "").toLowerCase();
+  for (const vendor of KNOWN_VENDORS) {
+    if (haystack.includes(vendor)) {
+      return vendor;
+    }
+  }
+  return (provider ?? "").toLowerCase() || "unknown";
+}
+
+/** Map pi `usage` token fields to gen_ai.usage.* (kept only when > 0, matching CC). */
+export function mapUsageTokens(usage: PiUsage | undefined): Record<string, number> {
+  const out: Record<string, number> = {};
+  if (!usage) {
+    return out;
+  }
+  const pairs: [string, number | undefined][] = [
+    ["gen_ai.usage.input_tokens", usage.input],
+    ["gen_ai.usage.output_tokens", usage.output],
+    ["gen_ai.usage.cache_read_input_tokens", usage.cacheRead],
+    ["gen_ai.usage.cache_creation_input_tokens", usage.cacheWrite],
+  ];
+  for (const [key, value] of pairs) {
+    if (typeof value === "number" && Number.isFinite(value) && value > 0) {
+      out[key] = value;
+    }
+  }
+  if (typeof usage.totalTokens === "number" && usage.totalTokens > 0) {
+    out["llm.usage.total_tokens"] = usage.totalTokens;
+  }
+  return out;
+}
+
+/**
+ * Map pi's precomputed `usage.cost` to the SDK's canonical cost attributes
+ * (`gen_ai.usage.cost` / `input_cost` / `output_cost`, per lmnr-ts
+ * `LaminarAttributes`). pi hands us the authoritative cost, so we emit it
+ * directly rather than relying on Laminar deriving cost from tokens — the
+ * derivation only works for models Laminar has pricing for, whereas pi's
+ * number is correct for every provider/model.
+ */
+export function mapUsageCost(usage: PiUsage | undefined): Record<string, number> {
+  const out: Record<string, number> = {};
+  const cost = usage?.cost;
+  if (!cost) {
+    return out;
+  }
+  const pairs: [string, number | undefined][] = [
+    ["gen_ai.usage.cost", cost.total],
+    ["gen_ai.usage.input_cost", cost.input],
+    ["gen_ai.usage.output_cost", cost.output],
+  ];
+  for (const [key, value] of pairs) {
+    if (typeof value === "number" && Number.isFinite(value)) {
+      out[key] = value;
+    }
+  }
+  return out;
+}
+
+/** Represent a pi assistant message's content as a single gen_ai output message. */
+export function buildOutputMessage(message: PiAssistantMessage): Json {
+  const text = extractText(message.content);
+  const toolCalls: Json[] = [];
+  for (const block of message.content ?? []) {
+    if (block && typeof block === "object" && block.type === "toolCall") {
+      toolCalls.push({ id: block.id, name: block.name, arguments: block.arguments ?? null });
+    }
+  }
+  const out: Json = { role: "assistant", content: text };
+  if (toolCalls.length > 0) {
+    out.tool_calls = toolCalls;
+  }
+  return out;
+}
+
+/** Attributes for an LLM span, from a pi assistant message. */
+export function buildLlmAttributes(
+  message: PiAssistantMessage,
+  inputMessages: Json[] | null,
+): Record<string, Json> {
+  const attrs: Record<string, Json> = {
+    "gen_ai.system": inferVendor(message.model, message.provider),
+  };
+  if (message.provider) {
+    attrs["gen_ai.provider.name"] = message.provider;
+  }
+  if (message.model) {
+    attrs["gen_ai.request.model"] = message.model;
+    attrs["gen_ai.response.model"] = message.model;
+  }
+  if (message.api) {
+    attrs["gen_ai.request.api"] = message.api;
+  }
+  if (message.stopReason) {
+    attrs["gen_ai.response.finish_reasons"] = [message.stopReason];
+  }
+  if (inputMessages) {
+    attrs["gen_ai.input.messages"] = jsonDumpsTruncated(inputMessages);
+  }
+  attrs["gen_ai.output.messages"] = jsonDumpsTruncated([buildOutputMessage(message)]);
+
+  Object.assign(attrs, mapUsageTokens(message.usage));
+  Object.assign(attrs, mapUsageCost(message.usage));
+  return attrs;
+}
+
+/** Association-property attributes for the run root span. */
+export function buildRootAssociation(
+  sessionId: string,
+  userId: string | null,
+  cwd?: string,
+): Record<string, Json> {
+  const attrs: Record<string, Json> = {
+    [`${ASSOC_PREFIX}.session_id`]: sessionId,
+    [`${ASSOC_PREFIX}.metadata.source`]: "pi",
+  };
+  if (userId) {
+    attrs[`${ASSOC_PREFIX}.user_id`] = userId;
+  }
+  if (cwd) {
+    attrs[`${ASSOC_PREFIX}.metadata.cwd`] = cwd;
+  }
+  return attrs;
+}

--- a/packages/pi-extension/src/config.ts
+++ b/packages/pi-extension/src/config.ts
@@ -1,0 +1,98 @@
+import { randomUUID } from "node:crypto";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+// Type-only: the shared `.lmnr/debug-session.json` contract, written by the SDK
+// and lmnr-cli. Imported as a type (erased at runtime) so the on-disk shape we
+// read here can't silently drift from the writers'. See @lmnr-ai/types.
+import type { DebugSessionFile } from "@lmnr-ai/types";
+
+// ----------------- Configuration (wayfinder ticket 3: env-primary) -----------------
+// No pi `userConfig` manifest exists, so config comes from process.env. We reuse
+// the plain LMNR_* names (Laminar's SDK convention; the CC plugin honored them as
+// its primary fallback) and drop CC's CLAUDE_PLUGIN_OPTION_/CC_ layers.
+
+/** Read a plain env var, trimmed; "" when absent. */
+function env(name: string): string {
+  return (process.env[name] ?? "").trim();
+}
+
+// LMNR_DEBUG truthy set — matches the Laminar SDK (true/1/yes/on), broader than
+// our historical "true"-only DEBUG (kept for the log-file gate below).
+const DEBUG_TRUTHY = new Set(["true", "1", "yes", "on"]);
+export function isDebugEnabled(): boolean {
+  return DEBUG_TRUTHY.has(env("LMNR_DEBUG").toLowerCase());
+}
+export const DEBUG = env("LMNR_DEBUG").toLowerCase() === "true";
+
+/** Read the `session_id` from the nearest `.lmnr/debug-session.json`, walking up from `cwd`. */
+function readDebugSessionFile(cwd: string): string | null {
+  let dir = path.resolve(cwd);
+  for (let i = 0; i < 40; i++) {
+    try {
+      const raw = fs.readFileSync(path.join(dir, ".lmnr", "debug-session.json"), "utf8");
+      const sid = (JSON.parse(raw) as Partial<DebugSessionFile> | null)?.session_id;
+      if (typeof sid === "string" && sid) {
+        return sid;
+      }
+    } catch {
+      // no file here — keep walking up
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) {
+      break;
+    }
+    dir = parent;
+  }
+  return null;
+}
+
+/**
+ * Resolve the Laminar debugger (rollout) session id when LMNR_DEBUG is set.
+ *
+ * Mirrors the SDK's precedence: `LMNR_DEBUG_SESSION_ID` env → nearest
+ * `.lmnr/debug-session.json` (written by `lmnr-cli debug session new`) → a
+ * freshly-minted UUID. Returns null when debug mode is off — the extension then
+ * emits no rollout association and behaves exactly as before.
+ */
+export function getRolloutSessionId(cwd: string): string | null {
+  if (!isDebugEnabled()) {
+    return null;
+  }
+  return env("LMNR_DEBUG_SESSION_ID") || readDebugSessionFile(cwd) || randomUUID();
+}
+
+const DEFAULT_MAX_CHARS = 20000;
+
+function parseMaxChars(): number {
+  const n = Number.parseInt(env("LMNR_MAX_CHARS"), 10);
+  return Number.isFinite(n) && n > 0 ? n : DEFAULT_MAX_CHARS;
+}
+export const MAX_CHARS = parseMaxChars();
+
+// Cap for a single OTLP export request (connect + response), in seconds.
+// A constant for v1 (ticket 3; ticket 6 confirms).
+export const EXPORT_TIMEOUT_S = 5.0;
+
+/** Absolute path to the extension's debug log (pi is a TUI — never log to stdout/stderr). */
+export function logFile(): string {
+  return path.join(os.homedir(), ".pi", "agent", "lmnr-pi-extension.log");
+}
+
+export interface LaminarConfig {
+  apiKey: string;
+  baseUrl: string;
+  userId: string | null;
+}
+
+/** Resolve Laminar config from env, or null when the API key is absent (fail-open). */
+export function getLaminarConfig(): LaminarConfig | null {
+  const apiKey = env("LMNR_PROJECT_API_KEY");
+  const baseUrl = (env("LMNR_BASE_URL") || "https://api.lmnr.ai").replace(/\/+$/, "");
+  const userId = env("LMNR_USER_ID") || null;
+  if (!apiKey) {
+    return null;
+  }
+  return { apiKey, baseUrl, userId };
+}

--- a/packages/pi-extension/src/index.ts
+++ b/packages/pi-extension/src/index.ts
@@ -1,0 +1,292 @@
+import { buildLlmAttributes, buildOutputMessage, buildRootAssociation } from "./attributes.js";
+import { getLaminarConfig, getRolloutSessionId } from "./config.js";
+import { debug, info } from "./logger.js";
+import {
+  exportWithTimeout,
+  parseInjectedSpanContext,
+  registerRolloutSession,
+  ROLLOUT_SESSION_META,
+  SPAN_OUTPUT_ATTR,
+  SpanHandle,
+  startSpan,
+  TRACE_TYPE_ATTR,
+  TraceEmitter,
+} from "./tracer.js";
+import type { Json, PiAssistantMessage } from "./types.js";
+import { extractText, jsonDumpsTruncated, parseTimestamp } from "./util.js";
+
+// ----------------- Minimal structural pi types -----------------
+// The extension is loaded BY pi, which supplies these objects. We type them
+// structurally (rather than importing pi) so the extension builds standalone.
+interface PiApi {
+  on(event: string, handler: (event: any, ctx: PiContext) => unknown): void;
+}
+interface PiContext {
+  sessionManager: { getSessionId(): string; getCwd?(): string };
+  cwd?: string;
+}
+
+// A pi message as delivered on message_start/_end — role may be non-assistant.
+interface AgentMessage extends Omit<PiAssistantMessage, "role"> {
+  role: string;
+}
+
+// ----------------- Per-run state (ticket 2: bounded, dies with the run) -----------------
+interface RunState {
+  emitter: TraceEmitter;
+  root: SpanHandle;
+  llm: SpanHandle | null; // current turn's open LLM span
+  tools: Map<string, SpanHandle>; // toolCallId -> open TOOL span
+  turnIndex: number;
+  // Running conversation transcript, grown across turns (user prompt →
+  // assistant messages → tool results). Snapshotted at each message_start as
+  // that turn's LLM input, so every turn — not just turn 0 — reports its input.
+  messages: Json[];
+  pendingInput: Json[] | null; // input snapshot for the currently-open LLM span
+  finalAssistantText: string;
+}
+
+/**
+ * Laminar observability extension for pi.
+ *
+ * One Laminar trace per agent run (ticket 2); spans opened on start events and
+ * closed on end events (fully granular, realtime); exported live over
+ * OTLP/HTTP/JSON reusing the CC emitter. Fail-open throughout — a Laminar
+ * problem must never break a pi turn.
+ */
+export default function laminar(pi: PiApi): void {
+  // At most one agent run is active per session at a time; tools within a run
+  // may be parallel (handled by the toolCallId-keyed map).
+  let run: RunState | null = null;
+
+  const now = (msg?: PiAssistantMessage): Date => parseTimestamp(msg?.timestamp) ?? new Date();
+
+  /** Fire-and-forget realtime export of finished spans. Never blocks pi, never throws. */
+  const flush = (emitter: TraceEmitter): void => {
+    void exportWithTimeout(emitter).catch((e) => info(`flush error (swallowed): ${String(e)}`));
+  };
+
+  const isAssistant = (m: AgentMessage | undefined): m is PiAssistantMessage =>
+    !!m && m.role === "assistant";
+
+  pi.on("before_agent_start", (event: { prompt?: string }, ctx: PiContext) => {
+    try {
+      const config = getLaminarConfig();
+      if (!config) {
+        debug("no LMNR_PROJECT_API_KEY — tracing disabled (fail-open)");
+        run = null;
+        return;
+      }
+      const sessionId = ctx.sessionManager.getSessionId();
+      const cwd = ctx.cwd ?? ctx.sessionManager.getCwd?.();
+      // Debugger (rollout) session: when LMNR_DEBUG is on, associate this trace
+      // with the debugger session so it appears there. Register it (idempotent)
+      // and stamp its id on every span this run emits.
+      const rolloutSessionId = getRolloutSessionId(cwd ?? process.cwd());
+      const defaultAttributes: Record<string, Json> = rolloutSessionId
+        ? { [ROLLOUT_SESSION_META]: rolloutSessionId }
+        : {};
+      // When Harbor (or any upstream) injects LMNR_SPAN_CONTEXT, nest this run's
+      // trace under that parent span instead of rooting a new trace, so pi's
+      // LLM/tool spans appear under the caller's EXECUTOR span. Carry the
+      // parent's trace_type (e.g. EVALUATION) onto every span too, so the
+      // backend classifies this trace like the SDK does — otherwise harbor eval
+      // trials land as debugger-only traces instead of evaluation traces.
+      const injectedParent = parseInjectedSpanContext(process.env.LMNR_SPAN_CONTEXT);
+      const rootParent = injectedParent?.context ?? null;
+      if (injectedParent?.traceType) {
+        defaultAttributes[TRACE_TYPE_ATTR] = injectedParent.traceType;
+      }
+      const emitter = new TraceEmitter(config, defaultAttributes, rootParent);
+      if (rootParent) {
+        debug("nesting trace under injected LMNR_SPAN_CONTEXT parent");
+      }
+      if (rolloutSessionId) {
+        void registerRolloutSession(config, rolloutSessionId).catch((e) =>
+          info(`rollout register (swallowed): ${String(e)}`),
+        );
+        debug(`debugger session ${rolloutSessionId}`);
+      }
+      const prompt = event.prompt ?? "";
+      const root = startSpan(emitter, {
+        name: "pi agent run",
+        parent: null,
+        startTime: new Date(),
+        spanType: "DEFAULT",
+        inputValue: { role: "user", content: prompt },
+        attributes: buildRootAssociation(sessionId, config.userId, cwd),
+      });
+      run = {
+        emitter,
+        root,
+        llm: null,
+        tools: new Map(),
+        turnIndex: 0,
+        messages: [{ role: "user", content: prompt }],
+        pendingInput: null,
+        finalAssistantText: "",
+      };
+      debug(`run started (session ${sessionId})`);
+    } catch (e) {
+      info(`before_agent_start failed (swallowed): ${String(e)}`);
+      run = null;
+    }
+  });
+
+  pi.on("turn_start", (event: { turnIndex?: number }) => {
+    if (run && typeof event.turnIndex === "number") {
+      run.turnIndex = event.turnIndex;
+    }
+  });
+
+  pi.on("message_start", (event: { message?: AgentMessage }) => {
+    try {
+      if (!run || !isAssistant(event.message)) {
+        return;
+      }
+      // Snapshot the transcript-so-far as this turn's input BEFORE the
+      // assistant message is appended — this is what was sent to the model.
+      run.pendingInput = [...run.messages];
+      run.llm = startSpan(run.emitter, {
+        name: `LLM call (turn ${run.turnIndex})`,
+        parent: run.root,
+        startTime: now(event.message),
+        spanType: "LLM",
+      });
+    } catch (e) {
+      info(`message_start failed (swallowed): ${String(e)}`);
+    }
+  });
+
+  pi.on("message_end", (event: { message?: AgentMessage }) => {
+    try {
+      if (!run || !run.llm || !isAssistant(event.message)) {
+        return;
+      }
+      const message = event.message;
+      run.llm.setAttributes({
+        ...buildLlmAttributes(message, run.pendingInput),
+        "pi.turn.index": run.turnIndex,
+      });
+      // Append this assistant message (incl. tool_calls) to the transcript so
+      // the next turn's input snapshot includes it.
+      run.messages.push(buildOutputMessage(message));
+      run.pendingInput = null;
+      run.finalAssistantText = extractText(message.content) || run.finalAssistantText;
+      run.llm.end(now(message));
+      run.llm = null;
+      flush(run.emitter);
+    } catch (e) {
+      info(`message_end failed (swallowed): ${String(e)}`);
+    }
+  });
+
+  pi.on("tool_execution_start", (
+    event: { toolCallId?: string; toolName?: string; args?: Json },
+  ) => {
+    try {
+      if (!run || !event.toolCallId) {
+        return;
+      }
+      const span = startSpan(run.emitter, {
+        name: event.toolName ?? "tool",
+        parent: run.root,
+        startTime: new Date(),
+        spanType: "TOOL",
+        inputValue: event.args ?? null,
+        attributes: {
+          "gen_ai.tool.name": event.toolName ?? "",
+          "gen_ai.tool.call.id": event.toolCallId,
+          "pi.turn.index": run.turnIndex,
+        },
+      });
+      run.tools.set(event.toolCallId, span);
+    } catch (e) {
+      info(`tool_execution_start failed (swallowed): ${String(e)}`);
+    }
+  });
+
+  pi.on(
+    "tool_execution_end",
+    (event: { toolCallId?: string; result?: Json; isError?: boolean }) => {
+      try {
+        if (!run || !event.toolCallId) {
+          return;
+        }
+        const span = run.tools.get(event.toolCallId);
+        if (!span) {
+          return;
+        }
+        span.setAttributes({ [SPAN_OUTPUT_ATTR]: jsonDumpsTruncated(event.result ?? null) });
+        if (event.isError) {
+          span.setError("tool reported isError");
+        }
+        // Feed the tool result back into the transcript so the next turn's LLM
+        // input reflects what the model actually saw.
+        run.messages.push({
+          role: "tool",
+          tool_call_id: event.toolCallId,
+          content: event.result ?? null,
+        });
+        span.end(new Date());
+        run.tools.delete(event.toolCallId);
+        flush(run.emitter);
+      } catch (e) {
+        info(`tool_execution_end failed (swallowed): ${String(e)}`);
+      }
+    },
+  );
+
+  /** Close a run: set root output, sweep orphans, end root, export. */
+  const finishRun = (r: RunState, reason: string): void => {
+    sweepOpenSpans(r);
+    r.root.setAttributes({
+      [SPAN_OUTPUT_ATTR]: jsonDumpsTruncated({ role: "assistant", content: r.finalAssistantText }),
+    });
+    if (!r.root.isEnded) {
+      r.root.end(new Date());
+    }
+    flush(r.emitter);
+    debug(`run ended (${reason})`);
+  };
+
+  pi.on("agent_end", () => {
+    try {
+      if (run) {
+        finishRun(run, "agent_end");
+      }
+    } catch (e) {
+      info(`agent_end failed (swallowed): ${String(e)}`);
+    } finally {
+      run = null;
+    }
+  });
+
+  // Safety net: a crash/replacement mid-run must not leak open spans.
+  pi.on("session_shutdown", () => {
+    try {
+      if (run) {
+        finishRun(run, "session_shutdown");
+      }
+    } catch (e) {
+      info(`session_shutdown failed (swallowed): ${String(e)}`);
+    } finally {
+      run = null;
+    }
+  });
+}
+
+/** Close any spans still open at run end (orphan sweep, ticket 2). */
+function sweepOpenSpans(run: RunState): void {
+  const end = new Date();
+  if (run.llm && !run.llm.isEnded) {
+    run.llm.end(end);
+  }
+  run.llm = null;
+  for (const span of run.tools.values()) {
+    if (!span.isEnded) {
+      span.end(end);
+    }
+  }
+  run.tools.clear();
+}

--- a/packages/pi-extension/src/logger.ts
+++ b/packages/pi-extension/src/logger.ts
@@ -1,0 +1,55 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+import { DEBUG, logFile } from "./config.js";
+
+// pi runs a TUI, so logging to stdout/stderr would corrupt the display. We write
+// to a file instead (like the CC plugin), with simple size-based rotation.
+const MAX_BYTES = 5_000_000;
+const BACKUP_COUNT = 3;
+
+function formatTimestamp(d: Date): string {
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return (
+    `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ` +
+    `${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`
+  );
+}
+
+function rotateIfNeeded(file: string): void {
+  try {
+    if (fs.statSync(file).size < MAX_BYTES) {
+      return;
+    }
+    for (let i = BACKUP_COUNT; i >= 1; i--) {
+      const src = i === 1 ? file : `${file}.${i - 1}`;
+      const dst = `${file}.${i}`;
+      if (fs.existsSync(src)) {
+        fs.renameSync(src, dst);
+      }
+    }
+  } catch {
+    // No file yet or rotation failed — nothing to do.
+  }
+}
+
+function write(level: string, msg: string): void {
+  try {
+    const file = logFile();
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    rotateIfNeeded(file);
+    fs.appendFileSync(file, `${formatTimestamp(new Date())} [${level}] ${msg}\n`, "utf-8");
+  } catch {
+    // Fail-open: logging must never throw.
+  }
+}
+
+export function debug(msg: string): void {
+  if (DEBUG) {
+    write("DEBUG", msg);
+  }
+}
+
+export function info(msg: string): void {
+  write("INFO", msg);
+}

--- a/packages/pi-extension/src/tracer.ts
+++ b/packages/pi-extension/src/tracer.ts
@@ -1,0 +1,361 @@
+// Type-only: the canonical Laminar span-type vocabulary. Imported as a type so
+// it is erased at runtime (jiti strips it) — this keeps the sandbox upload path
+// free of any @lmnr-ai/types dependency while locking our span types to the SDK.
+import type { SpanType } from "@lmnr-ai/types";
+import {
+  type Attributes,
+  type AttributeValue,
+  type Context,
+  ROOT_CONTEXT,
+  type Span,
+  type SpanContext,
+  SpanKind,
+  SpanStatusCode,
+  trace,
+  TraceFlags,
+} from "@opentelemetry/api";
+import { type ExportResult,ExportResultCode } from "@opentelemetry/core";
+import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
+import { Resource } from "@opentelemetry/resources";
+import {
+  BasicTracerProvider,
+  type ReadableSpan,
+  type SpanProcessor,
+} from "@opentelemetry/sdk-trace-base";
+
+import { EXPORT_TIMEOUT_S, type LaminarConfig } from "./config.js";
+import { debug, info } from "./logger.js";
+import type { Json } from "./types.js";
+import { jsonDumpsTruncated } from "./util.js";
+
+// Laminar span-attribute keys (reused verbatim from the CC plugin's conventions).
+export const SPAN_TYPE_ATTR = "lmnr.span.type";
+export const SPAN_INPUT_ATTR = "lmnr.span.input";
+export const SPAN_OUTPUT_ATTR = "lmnr.span.output";
+export const SPAN_PATH_ATTR = "lmnr.span.path";
+export const ASSOC_PREFIX = "lmnr.association.properties";
+// Metadata key the Laminar backend keys debugger (rollout) sessions on. Stamped
+// on every span of a debug run so the trace shows up in the debugger session.
+export const ROLLOUT_SESSION_META = `${ASSOC_PREFIX}.metadata.rollout.session_id`;
+// Association-property attribute that classifies the trace (DEFAULT | EVALUATION).
+// Propagated from the injected span context onto every span so harbor-driven
+// eval trials are recorded as EVALUATION traces — matching the Laminar SDK,
+// which reads/writes this exact key.
+export const TRACE_TYPE_ATTR = `${ASSOC_PREFIX}.trace_type`;
+
+/** Parsed form of the injected `LMNR_SPAN_CONTEXT`: the OTel remote-parent
+ * context to nest under, plus the Laminar trace classification to propagate.
+ * Mirrors the SDK's `LaminarSpanContext`, which carries `trace_type` alongside
+ * the ids. `null` when the env var is absent/unparseable. */
+export interface InjectedSpanContext {
+  context: Context;
+  /** DEFAULT | EVALUATION | null — stamped onto this run's spans so the backend
+   * classifies the trace like the SDK does (harbor eval trials → EVALUATION). */
+  traceType: string | null;
+}
+
+/**
+ * Parse the serialized Laminar span context Harbor injects via `LMNR_SPAN_CONTEXT`
+ * to link the agent's trace to its EXECUTOR span. Returns null when
+ * absent/unparseable — the run then roots its own trace as before (fail-open).
+ *
+ * Format mirrors the Laminar SDK (`LaminarSpanContext.model_dump_json`): JSON
+ * with `trace_id`/`span_id` as UUID strings, where the SDK packs the OTel ids
+ * via `uuid.UUID(int=<otel_id>)`. So trace_id's 32 hex ARE the OTel 128-bit
+ * trace id, and span_id's LOW 64 bits (last 16 hex) are the OTel 8-byte span id.
+ * `trace_type` travels in the same JSON and is carried through verbatim.
+ */
+export function parseInjectedSpanContext(
+  raw: string | undefined | null,
+): InjectedSpanContext | null {
+  if (!raw || !raw.trim()) {
+    return null;
+  }
+  try {
+    const obj = JSON.parse(raw) as Record<string, unknown>;
+    const traceRaw = (obj.trace_id ?? obj.traceId) as string | undefined;
+    const spanRaw = (obj.span_id ?? obj.spanId) as string | undefined;
+    if (typeof traceRaw !== "string" || typeof spanRaw !== "string") {
+      return null;
+    }
+    const traceId = traceRaw.replace(/-/g, "").toLowerCase();
+    // span_id is a UUID whose low 64 bits carry the OTel 8-byte span id.
+    const spanId = spanRaw.replace(/-/g, "").toLowerCase().slice(-16);
+    if (!/^[0-9a-f]{32}$/.test(traceId) || !/^[0-9a-f]{16}$/.test(spanId)) {
+      return null;
+    }
+    const spanContext: SpanContext = {
+      traceId,
+      spanId,
+      traceFlags: TraceFlags.SAMPLED,
+      isRemote: true,
+    };
+    const traceTypeRaw = obj.trace_type ?? obj.traceType;
+    return {
+      context: trace.setSpanContext(ROOT_CONTEXT, spanContext),
+      traceType: typeof traceTypeRaw === "string" ? traceTypeRaw : null,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/** Back-compat helper: just the OTel remote-parent `Context` (or null). */
+export function remoteParentContextFromEnv(raw: string | undefined | null): Context | null {
+  return parseInjectedSpanContext(raw)?.context ?? null;
+}
+
+/** Convert loosely-typed attributes to OTel attributes, dropping unsupported values. */
+function toOtelAttributes(attrs: Record<string, Json>): Attributes {
+  const out: Attributes = {};
+  for (const [key, value] of Object.entries(attrs)) {
+    if (value === null || value === undefined) {
+      continue;
+    }
+    if (typeof value === "string" || typeof value === "boolean" || typeof value === "number") {
+      out[key] = value;
+      continue;
+    }
+    if (Array.isArray(value)) {
+      const arr = value.filter((x) => x !== null && x !== undefined);
+      out[key] = arr as AttributeValue;
+      continue;
+    }
+    // Objects and other types are unsupported as attribute values — drop them.
+  }
+  return out;
+}
+
+/** Collects finished spans in memory so we can export them together. */
+class CollectingSpanProcessor implements SpanProcessor {
+  readonly spans: ReadableSpan[] = [];
+  onStart(): void {}
+  onEnd(span: ReadableSpan): void {
+    this.spans.push(span);
+  }
+  forceFlush(): Promise<void> {
+    return Promise.resolve();
+  }
+  shutdown(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+/** Owns the OTel provider + collecting processor and mints spans. */
+export class TraceEmitter {
+  readonly config: LaminarConfig;
+  private readonly processor: CollectingSpanProcessor;
+  private readonly tracer;
+  // Attributes stamped on every span this emitter mints (e.g. the debugger
+  // rollout-session association). Empty on the common, non-debug path.
+  private readonly defaultAttributes: Record<string, Json>;
+  // Context that root spans (parent === null) attach to. ROOT_CONTEXT for a
+  // standalone trace; an injected remote parent (LMNR_SPAN_CONTEXT) when this
+  // run should nest under an upstream span (e.g. Harbor's EXECUTOR).
+  private readonly rootParent: Context;
+
+  constructor(
+    config: LaminarConfig,
+    defaultAttributes: Record<string, Json> = {},
+    rootParent: Context | null = null,
+  ) {
+    this.config = config;
+    this.defaultAttributes = defaultAttributes;
+    this.rootParent = rootParent ?? ROOT_CONTEXT;
+    this.processor = new CollectingSpanProcessor();
+    const provider = new BasicTracerProvider({
+      resource: new Resource({
+        "service.name": "pi",
+        "telemetry.sdk.language": "nodejs",
+        "telemetry.sdk.name": "lmnr-pi-extension",
+      }),
+      spanProcessors: [this.processor],
+    });
+    this.tracer = provider.getTracer("lmnr.pi");
+  }
+
+  get spans(): ReadableSpan[] {
+    return this.processor.spans;
+  }
+
+  /** Remove already-exported spans so each export ships only new ones. */
+  drainSpans(): ReadableSpan[] {
+    return this.processor.spans.splice(0, this.processor.spans.length);
+  }
+
+  startSpan(
+    name: string,
+    startTime: Date,
+    attributes: Record<string, Json>,
+    parent: SpanHandle | null,
+  ): SpanHandle {
+    const parentCtx = parent ? parent.context : this.rootParent;
+    const merged = { ...this.defaultAttributes, ...attributes };
+    const span = this.tracer.startSpan(
+      name,
+      { kind: SpanKind.INTERNAL, startTime, attributes: toOtelAttributes(merged) },
+      parentCtx,
+    );
+    span.setStatus({ code: SpanStatusCode.OK });
+    return new SpanHandle(span, startTime);
+  }
+}
+
+/** A mutable span under construction; end() finalizes it into the emitter. */
+export class SpanHandle {
+  readonly context: Context;
+  private readonly span: Span;
+  private readonly startTime: Date;
+  private ended = false;
+
+  constructor(span: Span, startTime: Date) {
+    this.span = span;
+    this.startTime = startTime;
+    this.context = trace.setSpan(ROOT_CONTEXT, span);
+  }
+
+  get traceId(): string {
+    return this.span.spanContext().traceId;
+  }
+
+  get spanId(): string {
+    return this.span.spanContext().spanId;
+  }
+
+  setAttributes(attributes: Record<string, Json>): void {
+    this.span.setAttributes(toOtelAttributes(attributes));
+  }
+
+  /** Mark the span errored (e.g. a tool result with isError). */
+  setError(message?: string): void {
+    this.span.setStatus({ code: SpanStatusCode.ERROR, message });
+  }
+
+  end(endTime: Date | null): void {
+    if (this.ended) {
+      return;
+    }
+    this.ended = true;
+    let end = endTime ?? this.startTime;
+    if (end.getTime() < this.startTime.getTime()) {
+      end = this.startTime;
+    }
+    this.span.end(end);
+  }
+
+  get isEnded(): boolean {
+    return this.ended;
+  }
+}
+
+export interface StartSpanArgs {
+  name: string;
+  parent: SpanHandle | null;
+  startTime: Date | null;
+  spanType?: SpanType;
+  inputValue?: Json;
+  attributes?: Record<string, Json>;
+}
+
+/** Mint a span with the Laminar span-type + optional JSON input attribute. */
+export function startSpan(emitter: TraceEmitter, args: StartSpanArgs): SpanHandle {
+  const attrs: Record<string, Json> = { [SPAN_TYPE_ATTR]: args.spanType ?? "DEFAULT" };
+  if (args.inputValue !== undefined && args.inputValue !== null) {
+    // Truncate here so every span input honors LMNR_MAX_CHARS (ticket 5).
+    attrs[SPAN_INPUT_ATTR] = jsonDumpsTruncated(args.inputValue);
+  }
+  if (args.attributes) {
+    Object.assign(attrs, args.attributes);
+  }
+  return emitter.startSpan(args.name, args.startTime ?? new Date(), attrs, args.parent);
+}
+
+/**
+ * Idempotently register (upsert) a debugger rollout session with the backend so
+ * it exists in the UI and collects traces stamped with its id. Mirrors the SDK's
+ * `POST /v1/rollouts/{sessionId}`. Fail-open: never throws.
+ */
+export async function registerRolloutSession(
+  config: LaminarConfig,
+  sessionId: string,
+): Promise<boolean> {
+  try {
+    const res = await fetch(`${config.baseUrl}/v1/rollouts/${sessionId}`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${config.apiKey}`,
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      body: JSON.stringify({}),
+      signal: AbortSignal.timeout(Math.round(EXPORT_TIMEOUT_S * 1000)),
+    });
+    if (!res.ok) {
+      info(`rollout session register failed: HTTP ${res.status}`);
+      return false;
+    }
+    debug(`registered debugger rollout session ${sessionId}`);
+    return true;
+  } catch (e) {
+    info(`rollout session register error (swallowed): ${String(e)}`);
+    return false;
+  }
+}
+
+/** Export the given finished spans in one OTLP/HTTP/JSON request; true on 2xx. */
+async function exportSpans(emitter: TraceEmitter, spans: ReadableSpan[]): Promise<boolean> {
+  if (spans.length === 0) {
+    return true;
+  }
+  const exporter = new OTLPTraceExporter({
+    url: `${emitter.config.baseUrl}/v1/traces`,
+    headers: { Authorization: `Bearer ${emitter.config.apiKey}` },
+    timeoutMillis: Math.round(EXPORT_TIMEOUT_S * 1000),
+  });
+  try {
+    const result = await new Promise<ExportResult>((resolve) => {
+      exporter.export(spans, resolve);
+    });
+    if (result.code === ExportResultCode.SUCCESS) {
+      debug(`OTLP export: ${spans.length} span(s)`);
+      return true;
+    }
+    info(`OTLP export failed: ${result.error ?? "unknown error"}`);
+    return false;
+  } catch (e) {
+    info(`OTLP export failed: ${String(e)}`);
+    return false;
+  } finally {
+    try {
+      await exporter.shutdown();
+    } catch {
+      // Ignore shutdown errors.
+    }
+  }
+}
+
+/**
+ * Export the emitter's undrained spans, capped by a hard timeout so a hung
+ * connection can't stall pi. Fail-open: never throws, returns false on error.
+ */
+export async function exportWithTimeout(emitter: TraceEmitter): Promise<boolean> {
+  const spans = emitter.drainSpans();
+  if (spans.length === 0) {
+    return true;
+  }
+  const timeoutMs = Math.round((EXPORT_TIMEOUT_S + 1) * 1000);
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<boolean>((resolve) => {
+    timer = setTimeout(() => resolve(false), timeoutMs);
+  });
+  try {
+    return await Promise.race([exportSpans(emitter, spans), timeout]);
+  } catch (e) {
+    info(`export error (swallowed): ${String(e)}`);
+    return false;
+  } finally {
+    if (timer) {
+      clearTimeout(timer);
+    }
+  }
+}

--- a/packages/pi-extension/src/types.ts
+++ b/packages/pi-extension/src/types.ts
@@ -1,0 +1,30 @@
+// pi event payloads are dynamic JSON objects whose exact shape is internal to
+// the pi coding agent, so we treat them as loosely-typed records. `Json` is any
+// parsed JSON value. (Mirrors the CC plugin's types.ts.)
+export type Json = any;
+
+// ---- pi payload shapes we actually read (documented in wayfinder/findings) ----
+
+/** pi assistant message usage block (see findings/001, findings/005). */
+export interface PiUsage {
+  input?: number;
+  output?: number;
+  cacheRead?: number;
+  cacheWrite?: number;
+  totalTokens?: number;
+  cost?: {
+    input?: number; output?: number; cacheRead?: number; cacheWrite?: number; total?: number;
+  };
+}
+
+/** A pi assistant `message` (the `message` field of a `turn_end`/`message_end` event). */
+export interface PiAssistantMessage {
+  role: "assistant";
+  content: Json[];
+  api?: string;
+  provider?: string;
+  model?: string;
+  stopReason?: string;
+  usage?: PiUsage;
+  timestamp?: string;
+}

--- a/packages/pi-extension/src/util.ts
+++ b/packages/pi-extension/src/util.ts
@@ -1,0 +1,54 @@
+import { MAX_CHARS } from "./config.js";
+import type { Json } from "./types.js";
+
+/** JSON.stringify with a fallback for non-serializable values. */
+export function jsonDumps(value: Json): string {
+  return JSON.stringify(value, (_key: string, v: unknown): unknown => {
+    if (typeof v === "bigint" || typeof v === "symbol" || typeof v === "function") {
+      return String(v);
+    }
+    return v;
+  });
+}
+
+/** Truncate a string to MAX_CHARS, appending a marker when clipped. */
+export function truncateText(text: string, maxChars = MAX_CHARS): string {
+  if (text.length <= maxChars) {
+    return text;
+  }
+  return `${text.slice(0, maxChars)}… [truncated ${text.length - maxChars} chars]`;
+}
+
+/** JSON-serialize then truncate — used for span input/output values. */
+export function jsonDumpsTruncated(value: Json, maxChars = MAX_CHARS): string {
+  return truncateText(jsonDumps(value), maxChars);
+}
+
+/** Parse a pi timestamp (ISO string) to a Date, or null. */
+export function parseTimestamp(ts: unknown): Date | null {
+  if (typeof ts !== "string") {
+    return null;
+  }
+  const d = new Date(ts);
+  return Number.isNaN(d.getTime()) ? null : d;
+}
+
+/** Extract concatenated text from a pi content array (text blocks only). */
+export function extractText(content: Json): string {
+  if (typeof content === "string") {
+    return content;
+  }
+  if (!Array.isArray(content)) {
+    return "";
+  }
+  const parts: string[] = [];
+  for (const block of content) {
+    if (
+      block && typeof block === "object" &&
+      block.type === "text" && typeof block.text === "string"
+    ) {
+      parts.push(block.text);
+    }
+  }
+  return parts.join("");
+}

--- a/packages/pi-extension/test/attributes.test.ts
+++ b/packages/pi-extension/test/attributes.test.ts
@@ -1,0 +1,100 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  buildLlmAttributes,
+  buildOutputMessage,
+  buildRootAssociation,
+  inferVendor,
+  mapUsageTokens,
+} from "../src/attributes.js";
+import type { PiAssistantMessage } from "../src/types.js";
+
+void test("inferVendor picks the model vendor over the gateway provider", () => {
+  assert.equal(inferVendor("us.anthropic.claude-opus-4-8", "amazon-bedrock"), "anthropic");
+  assert.equal(inferVendor("us.openai.gpt-5.5", "amazon-bedrock"), "openai");
+  assert.equal(inferVendor("amazon-bedrock/qwen.qwen3-coder-480b", "amazon-bedrock"), "qwen");
+});
+
+void test("inferVendor falls back to provider, then unknown", () => {
+  assert.equal(inferVendor(undefined, "amazon-bedrock"), "amazon-bedrock");
+  assert.equal(inferVendor("some-unlabeled-model", undefined), "unknown");
+  assert.equal(inferVendor(undefined, undefined), "unknown");
+});
+
+void test("mapUsageTokens maps pi field names and drops zeros", () => {
+  const out = mapUsageTokens({
+    input: 2, output: 89, cacheRead: 0, cacheWrite: 8209, totalTokens: 8300,
+  });
+  assert.deepEqual(out, {
+    "gen_ai.usage.input_tokens": 2,
+    "gen_ai.usage.output_tokens": 89,
+    "gen_ai.usage.cache_creation_input_tokens": 8209,
+    "llm.usage.total_tokens": 8300,
+  });
+  assert.ok(!("gen_ai.usage.cache_read_input_tokens" in out), "zero cacheRead dropped");
+});
+
+void test("buildOutputMessage renders text + toolCall blocks", () => {
+  const msg: PiAssistantMessage = {
+    role: "assistant",
+    content: [
+      { type: "text", text: "running it" },
+      { type: "toolCall", id: "t1", name: "bash", arguments: { command: "ls" } },
+    ],
+  };
+  assert.deepEqual(buildOutputMessage(msg), {
+    role: "assistant",
+    content: "running it",
+    tool_calls: [{ id: "t1", name: "bash", arguments: { command: "ls" } }],
+  });
+});
+
+void test("buildLlmAttributes: cost uses the SDK's canonical gen_ai.usage.cost keys", () => {
+  const msg: PiAssistantMessage = {
+    role: "assistant",
+    content: [{ type: "text", text: "hi" }],
+    provider: "amazon-bedrock",
+    model: "us.anthropic.claude-opus-4-8",
+    api: "bedrock-converse-stream",
+    stopReason: "toolUse",
+    usage: {
+      input: 2,
+      output: 89,
+      cacheWrite: 8209,
+      totalTokens: 8300,
+      cost: { input: 0.05, output: 0.0035, total: 0.0535 },
+    },
+  };
+  const attrs = buildLlmAttributes(msg, null);
+  assert.equal(attrs["gen_ai.system"], "anthropic");
+  assert.equal(attrs["gen_ai.provider.name"], "amazon-bedrock");
+  assert.equal(attrs["gen_ai.request.model"], "us.anthropic.claude-opus-4-8");
+  assert.deepEqual(attrs["gen_ai.response.finish_reasons"], ["toolUse"]);
+  assert.equal(attrs["gen_ai.usage.input_tokens"], 2);
+  // pi's authoritative cost is emitted under the canonical SDK keys.
+  assert.equal(attrs["gen_ai.usage.cost"], 0.0535);
+  assert.equal(attrs["gen_ai.usage.input_cost"], 0.05);
+  assert.equal(attrs["gen_ai.usage.output_cost"], 0.0035);
+});
+
+void test("buildLlmAttributes: cost keys omitted when pi reports no cost", () => {
+  const msg: PiAssistantMessage = {
+    role: "assistant",
+    content: [{ type: "text", text: "hi" }],
+    model: "us.anthropic.claude-opus-4-8",
+    usage: { input: 2, output: 89, totalTokens: 91 },
+  };
+  const attrs = buildLlmAttributes(msg, null);
+  assert.ok(!Object.keys(attrs).some((k) => k.startsWith("gen_ai.usage.cost")));
+});
+
+void test("buildRootAssociation sets session_id, source, and optional user_id", () => {
+  assert.deepEqual(buildRootAssociation("sess-1", null), {
+    "lmnr.association.properties.session_id": "sess-1",
+    "lmnr.association.properties.metadata.source": "pi",
+  });
+  const withUser = buildRootAssociation("sess-1", "user-9", "/work");
+  assert.equal(withUser["lmnr.association.properties.user_id"], "user-9");
+  assert.equal(withUser["lmnr.association.properties.metadata.cwd"], "/work");
+});

--- a/packages/pi-extension/test/config.test.ts
+++ b/packages/pi-extension/test/config.test.ts
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { getLaminarConfig, getRolloutSessionId } from "../src/config.js";
+
+const KEYS = [
+  "LMNR_PROJECT_API_KEY", "LMNR_BASE_URL", "LMNR_USER_ID", "LMNR_DEBUG", "LMNR_DEBUG_SESSION_ID",
+];
+function clear(): void {
+  for (const k of KEYS) {
+    delete process.env[k];
+  }
+}
+
+void test("getLaminarConfig returns null without an API key (fail-open)", () => {
+  clear();
+  assert.equal(getLaminarConfig(), null);
+});
+
+void test("getLaminarConfig defaults baseUrl and null userId", () => {
+  clear();
+  process.env.LMNR_PROJECT_API_KEY = "sk-test";
+  const cfg = getLaminarConfig();
+  assert.deepEqual(cfg, { apiKey: "sk-test", baseUrl: "https://api.lmnr.ai", userId: null });
+  clear();
+});
+
+void test("getLaminarConfig strips trailing slashes and reads userId", () => {
+  clear();
+  process.env.LMNR_PROJECT_API_KEY = "sk-test";
+  process.env.LMNR_BASE_URL = "http://localhost:8000///";
+  process.env.LMNR_USER_ID = "user-9";
+  const cfg = getLaminarConfig();
+  assert.equal(cfg?.baseUrl, "http://localhost:8000");
+  assert.equal(cfg?.userId, "user-9");
+  clear();
+});
+
+void test("getRolloutSessionId is null when LMNR_DEBUG is off", () => {
+  clear();
+  assert.equal(getRolloutSessionId("/tmp"), null);
+});
+
+void test("getRolloutSessionId prefers LMNR_DEBUG_SESSION_ID when debug is on", () => {
+  clear();
+  process.env.LMNR_DEBUG = "1"; // truthy set includes 1/true/yes/on
+  process.env.LMNR_DEBUG_SESSION_ID = "rollout-abc";
+  assert.equal(getRolloutSessionId("/tmp"), "rollout-abc");
+  clear();
+});

--- a/packages/pi-extension/test/extension.test.ts
+++ b/packages/pi-extension/test/extension.test.ts
@@ -1,0 +1,285 @@
+import assert from "node:assert/strict";
+import * as http from "node:http";
+import { AddressInfo } from "node:net";
+import { test } from "node:test";
+import * as zlib from "node:zlib";
+
+// ---- OTLP capture server: collects exported spans as decoded objects ----
+interface CapturedSpan {
+  name: string;
+  spanId: string;
+  parentSpanId?: string;
+  status?: { code?: number };
+  attrs: Record<string, unknown>;
+}
+
+function decodeAttrValue(v: any): unknown {
+  if (v == null) return undefined;
+  if ("stringValue" in v) return v.stringValue;
+  if ("intValue" in v) return Number(v.intValue);
+  if ("doubleValue" in v) return v.doubleValue;
+  if ("boolValue" in v) return v.boolValue;
+  if ("arrayValue" in v) return (v.arrayValue.values ?? []).map(decodeAttrValue);
+  return undefined;
+}
+
+function decodeSpans(body: any, out: CapturedSpan[]): void {
+  for (const rs of body.resourceSpans ?? []) {
+    for (const ss of rs.scopeSpans ?? []) {
+      for (const s of ss.spans ?? []) {
+        const attrs: Record<string, unknown> = {};
+        for (const a of s.attributes ?? []) {
+          attrs[a.key] = decodeAttrValue(a.value);
+        }
+        out.push({
+          name: s.name,
+          spanId: s.spanId,
+          parentSpanId: s.parentSpanId || undefined,
+          status: s.status,
+          attrs,
+        });
+      }
+    }
+  }
+}
+
+async function startCaptureServer(
+  spans: CapturedSpan[],
+): Promise<{ url: string; close: () => Promise<void> }> {
+  const server = http.createServer((req, res) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (c) => chunks.push(c));
+    req.on("end", () => {
+      try {
+        let buf = Buffer.concat(chunks);
+        if (req.headers["content-encoding"] === "gzip") {
+          buf = zlib.gunzipSync(buf);
+        }
+        decodeSpans(JSON.parse(buf.toString("utf8")), spans);
+      } catch {
+        // ignore malformed bodies in the test sink
+      }
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end("{}");
+    });
+  });
+  await new Promise<void>((r) => server.listen(0, "127.0.0.1", r));
+  const port = (server.address() as AddressInfo).port;
+  return {
+    url: `http://127.0.0.1:${port}`,
+    close: () => new Promise<void>((r) => server.close(() => r())),
+  };
+}
+
+// ---- Fake pi API ----
+function makeFakePi() {
+  const handlers = new Map<string, ((e: any, ctx: any) => unknown)[]>();
+  const pi = {
+    on(event: string, handler: (e: any, ctx: any) => unknown) {
+      const list = handlers.get(event) ?? [];
+      list.push(handler);
+      handlers.set(event, list);
+    },
+  };
+  const ctx = {
+    mode: "print",
+    hasUI: false,
+    cwd: "/work",
+    sessionManager: { getSessionId: () => "sess-123", getCwd: () => "/work" },
+  };
+  const emit = async (event: string, payload: any) => {
+    for (const h of handlers.get(event) ?? []) {
+      await h({ type: event, ...payload }, ctx);
+    }
+  };
+  return { pi, emit };
+}
+
+async function waitForSpans(spans: CapturedSpan[], count: number, timeoutMs = 3000): Promise<void> {
+  const start = Date.now();
+  while (spans.length < count && Date.now() - start < timeoutMs) {
+    await new Promise((r) => setTimeout(r, 20));
+  }
+}
+
+const asstStart = {
+  message: {
+    role: "assistant", content: [],
+    model: "us.anthropic.claude-opus-4-8", provider: "amazon-bedrock",
+  },
+};
+
+void test("end-to-end: pi event stream produces the expected Laminar span tree", async () => {
+  const spans: CapturedSpan[] = [];
+  const sink = await startCaptureServer(spans);
+  process.env.LMNR_PROJECT_API_KEY = "sk-test";
+  process.env.LMNR_BASE_URL = sink.url;
+
+  // Import AFTER env is set (config reads at call time, but be safe).
+  const { default: laminar } = await import("../src/index.js");
+  const { pi, emit } = makeFakePi();
+  laminar(pi);
+
+  await emit("before_agent_start", { prompt: "list the files" });
+  await emit("turn_start", { turnIndex: 0, timestamp: Date.now() });
+  await emit("message_start", asstStart);
+  await emit("message_end", {
+    message: {
+      role: "assistant",
+      content: [
+        { type: "text", text: "I'll list them." },
+        { type: "toolCall", id: "tc1", name: "bash", arguments: { command: "ls" } },
+      ],
+      api: "bedrock-converse-stream",
+      provider: "amazon-bedrock",
+      model: "us.anthropic.claude-opus-4-8",
+      stopReason: "toolUse",
+      usage: {
+        input: 2, output: 89, cacheRead: 0, cacheWrite: 8209, totalTokens: 8300,
+        cost: { total: 0.0535 },
+      },
+    },
+  });
+  await emit("tool_execution_start", {
+    toolCallId: "tc1", toolName: "bash", args: { command: "ls" },
+  });
+  await emit("tool_execution_end", {
+    toolCallId: "tc1", toolName: "bash", result: "a.txt\nb.txt", isError: false,
+  });
+  await emit("turn_start", { turnIndex: 1, timestamp: Date.now() });
+  await emit("message_start", asstStart);
+  await emit("message_end", {
+    message: {
+      role: "assistant",
+      content: [{ type: "text", text: "Done — 2 files." }],
+      provider: "amazon-bedrock",
+      model: "us.anthropic.claude-opus-4-8",
+      stopReason: "endTurn",
+      usage: { input: 10, output: 20, totalTokens: 30, cost: { total: 0.001 } },
+    },
+  });
+  await emit("agent_end", { messages: [] });
+
+  await waitForSpans(spans, 4);
+  await sink.close();
+
+  assert.equal(spans.length, 4, `expected 4 spans, got ${spans.length}`);
+
+  const root = spans.find((s) => s.attrs["lmnr.span.type"] === "DEFAULT");
+  const llms = spans.filter((s) => s.attrs["lmnr.span.type"] === "LLM");
+  const tools = spans.filter((s) => s.attrs["lmnr.span.type"] === "TOOL");
+
+  assert.ok(root, "has a DEFAULT root span");
+  assert.equal(root.name, "pi agent run");
+  assert.equal(root.attrs["lmnr.association.properties.session_id"], "sess-123");
+  assert.match(String(root.attrs["lmnr.span.input"]), /list the files/);
+  assert.match(String(root.attrs["lmnr.span.output"]), /Done — 2 files/);
+
+  assert.equal(llms.length, 2, "two LLM spans (one per turn)");
+  const llm0 = llms.find((s) => s.attrs["pi.turn.index"] === 0)!;
+  assert.equal(llm0.attrs["gen_ai.system"], "anthropic");
+  assert.equal(llm0.attrs["gen_ai.provider.name"], "amazon-bedrock");
+  assert.equal(llm0.attrs["gen_ai.usage.input_tokens"], 2);
+  assert.equal(llm0.attrs["llm.usage.total_tokens"], 8300);
+  assert.equal(llm0.attrs["gen_ai.usage.cost"], 0.0535);
+  assert.equal(llm0.parentSpanId, root.spanId, "LLM span nests under root");
+  const llm0Input = llm0.attrs["gen_ai.input.messages"] as string;
+  assert.match(llm0Input, /list the files/, "turn 0 input is the user prompt");
+
+  // Regression: every turn — not just turn 0 — reports its input. Turn 1's
+  // input must include the prior assistant turn and the tool result it saw.
+  const llm1 = llms.find((s) => s.attrs["pi.turn.index"] === 1)!;
+  const llm1Input = llm1.attrs["gen_ai.input.messages"] as string;
+  assert.ok(llm1Input, "turn 1 LLM span carries input messages");
+  assert.match(llm1Input, /list the files/, "turn 1 input keeps the original prompt");
+  assert.match(llm1Input, /a\.txt/, "turn 1 input includes the prior tool result");
+
+  assert.equal(tools.length, 1, "one TOOL span");
+  assert.equal(tools[0].name, "bash");
+  assert.match(String(tools[0].attrs["lmnr.span.input"]), /ls/);
+  assert.match(String(tools[0].attrs["lmnr.span.output"]), /a\.txt/);
+  assert.equal(tools[0].parentSpanId, root.spanId, "TOOL span nests under root");
+});
+
+void test("debugger mode stamps rollout.session_id on every span", async () => {
+  const spans: CapturedSpan[] = [];
+  const sink = await startCaptureServer(spans);
+  process.env.LMNR_PROJECT_API_KEY = "sk-test";
+  process.env.LMNR_BASE_URL = sink.url;
+  process.env.LMNR_DEBUG = "true";
+  process.env.LMNR_DEBUG_SESSION_ID = "rollout-xyz";
+
+  const { default: laminar } = await import("../src/index.js");
+  const { pi, emit } = makeFakePi();
+  laminar(pi);
+
+  await emit("before_agent_start", { prompt: "hi" });
+  await emit("message_start", asstStart);
+  await emit("message_end", {
+    message: {
+      role: "assistant",
+      content: [{ type: "text", text: "hello" }],
+      provider: "amazon-bedrock",
+      model: "us.anthropic.claude-opus-4-8",
+      stopReason: "endTurn",
+      usage: { input: 1, output: 1, totalTokens: 2 },
+    },
+  });
+  await emit("agent_end", {});
+
+  await waitForSpans(spans, 2);
+  await sink.close();
+
+  const key = "lmnr.association.properties.metadata.rollout.session_id";
+  assert.ok(spans.length >= 2, `expected spans, got ${spans.length}`);
+  for (const s of spans) {
+    assert.equal(s.attrs[key], "rollout-xyz", `${s.name} carries the rollout session id`);
+  }
+
+  delete process.env.LMNR_DEBUG;
+  delete process.env.LMNR_DEBUG_SESSION_ID;
+});
+
+void test("injected LMNR_SPAN_CONTEXT propagates trace_type onto every span", async () => {
+  const spans: CapturedSpan[] = [];
+  const sink = await startCaptureServer(spans);
+  process.env.LMNR_PROJECT_API_KEY = "sk-test";
+  process.env.LMNR_BASE_URL = sink.url;
+  // Mirrors what Harbor injects for an eval trial: trace_type travels in the
+  // same JSON as the ids (LaminarSpanContext.model_dump_json).
+  process.env.LMNR_SPAN_CONTEXT = JSON.stringify({
+    trace_id: "3dbfd1ba-ff43-9db7-b08f-6796af502e35",
+    span_id: "00000000-0000-0000-1234-567890abcdef",
+    is_remote: true,
+    trace_type: "EVALUATION",
+  });
+
+  const { default: laminar } = await import("../src/index.js");
+  const { pi, emit } = makeFakePi();
+  laminar(pi);
+
+  await emit("before_agent_start", { prompt: "hi" });
+  await emit("message_start", asstStart);
+  await emit("message_end", {
+    message: {
+      role: "assistant",
+      content: [{ type: "text", text: "hello" }],
+      provider: "amazon-bedrock",
+      model: "us.anthropic.claude-opus-4-8",
+      stopReason: "endTurn",
+      usage: { input: 1, output: 1, totalTokens: 2 },
+    },
+  });
+  await emit("agent_end", {});
+
+  await waitForSpans(spans, 2);
+  await sink.close();
+
+  const key = "lmnr.association.properties.trace_type";
+  assert.ok(spans.length >= 2, `expected spans, got ${spans.length}`);
+  for (const s of spans) {
+    assert.equal(s.attrs[key], "EVALUATION", `${s.name} carries trace_type=EVALUATION`);
+  }
+
+  delete process.env.LMNR_SPAN_CONTEXT;
+});

--- a/packages/pi-extension/tsconfig.json
+++ b/packages/pi-extension/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "types": ["node"],
+    "rootDir": "."
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -324,6 +324,28 @@ importers:
         specifier: ^4.1.9
         version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0))
 
+  packages/pi-extension:
+    dependencies:
+      '@opentelemetry/api':
+        specifier: ^1.9.0
+        version: 1.9.1
+      '@opentelemetry/core':
+        specifier: ^1.30.0
+        version: 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-trace-otlp-http':
+        specifier: ^0.57.0
+        version: 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources':
+        specifier: ^1.30.0
+        version: 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base':
+        specifier: ^1.30.0
+        version: 1.30.1(@opentelemetry/api@1.9.1)
+    devDependencies:
+      '@lmnr-ai/types':
+        specifier: workspace:*
+        version: link:../types
+
   packages/types:
     devDependencies:
       '@opentelemetry/sdk-trace-base':
@@ -964,6 +986,10 @@ packages:
     resolution: {integrity: sha512-FFx7YnaYJlIjqWW/AG/yAZ0L/NEY724PipXXXQLdtZPbLwBGbUMTGL1i/esI56TWfTUXxhLfpgrnWJCG8aUJyg==}
     engines: {node: '>=8.0.0'}
 
+  '@opentelemetry/api-logs@0.57.2':
+    resolution: {integrity: sha512-uIX52NnTM0iBh84MShlpouI7UKqkZ7MrUszTmaypHBu4r7NofznSnQRfJ+uUeDtQDj6w8eFGg5KBLDAwAPz1+A==}
+    engines: {node: '>=14'}
+
   '@opentelemetry/api@1.9.0':
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
     engines: {node: '>=8.0.0'}
@@ -981,6 +1007,12 @@ packages:
   '@opentelemetry/context-async-hooks@2.8.0':
     resolution: {integrity: sha512-/3FIraneMcng67SUJCxvyInk/oxzwsxyadufk0wwfOBLf5wqtAGX4MoQASwSbndBPeARzBryUM9Azr5kHIdWLw==}
     engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/core@1.30.1':
+    resolution: {integrity: sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==}
+    engines: {node: '>=14'}
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
 
@@ -1050,6 +1082,12 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
+  '@opentelemetry/exporter-trace-otlp-http@0.57.2':
+    resolution: {integrity: sha512-sB/gkSYFu+0w2dVQ0PWY9fAMl172PKMZ/JrHkkW8dmjCL0CYkmXeE+ssqIL/yBUTPOvpLIpenX5T9RwXRBW/3g==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
   '@opentelemetry/exporter-trace-otlp-proto@0.219.0':
     resolution: {integrity: sha512-lF/LUBfhOFmxJa+SQsLN7ziV4MHa2pyKgOM6JNehSOfU+npjM4gwm9oIKEJrzrWcexMcqydiyoFy0XCb1Ql3wQ==}
     engines: {node: ^18.19.0 || >=20.6.0}
@@ -1080,6 +1118,12 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
+  '@opentelemetry/otlp-exporter-base@0.57.2':
+    resolution: {integrity: sha512-XdxEzL23Urhidyebg5E6jZoaiW5ygP/mRjxLHixogbqwDy2Faduzb5N0o/Oi+XTIJu+iyxXdVORjXax+Qgfxag==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
   '@opentelemetry/otlp-grpc-exporter-base@0.219.0':
     resolution: {integrity: sha512-iIk/s8QQu39zpTrRRmsW/Eg3SE2+Hg8tLWepr2FLRgmwUpNd0IpCTLJEHJ77hpt4hgIS8MAh44UYI4xQPZwWlw==}
     engines: {node: ^18.19.0 || >=20.6.0}
@@ -1089,6 +1133,12 @@ packages:
   '@opentelemetry/otlp-transformer@0.219.0':
     resolution: {integrity: sha512-aaYKAyXhw9VchKZVGOopD3Gw/kPsyrX2c6IQ0AW32mTjqmZOh5Y6Gf5OYqTNqVktAeBjmFinhyFaCwW6GYK9YQ==}
     engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-transformer@0.57.2':
+    resolution: {integrity: sha512-48IIRj49gbQVK52jYsw70+Jv+JbahT8BqT2Th7C4H7RCM9d0gZ5sgNPoMpWldmfjvIsSgiGJtjfk9MeZvjhoig==}
+    engines: {node: '>=14'}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
@@ -1104,6 +1154,12 @@ packages:
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
 
+  '@opentelemetry/resources@1.30.1':
+    resolution: {integrity: sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
   '@opentelemetry/resources@2.8.0':
     resolution: {integrity: sha512-qmXQ27ilDbUK/vGMqwL8D4/rhn76C+sherM4wTbjlfknR8Nvfc/hCxjRJPhkzZzUsPiNg16SA31NxMabwttRjg==}
     engines: {node: ^18.19.0 || >=20.6.0}
@@ -1115,6 +1171,18 @@ packages:
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.4.0 <1.10.0'
+
+  '@opentelemetry/sdk-logs@0.57.2':
+    resolution: {integrity: sha512-TXFHJ5c+BKggWbdEQ/inpgIzEmS2BGQowLE9UhsMd7YYlUfBQJ4uax0VF/B5NYigdM/75OoJGhAV3upEhK+3gg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.4.0 <1.10.0'
+
+  '@opentelemetry/sdk-metrics@1.30.1':
+    resolution: {integrity: sha512-q9zcZ0Okl8jRgmy7eNW3Ku1XSgg3sDLa5evHZpCwjspw7E8Is4K/haRPDJrBcX3YSn/Y7gUvFnByNYEKQNbNog==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
 
   '@opentelemetry/sdk-metrics@2.8.0':
     resolution: {integrity: sha512-UDBGaj6W0Rgy5rTTaoxs8gVGF/aGkAKyjurJv7se6wjRxJu7FoquTLT/vt54DZfo4crbprYfhX/SOK9+BPw1qg==}
@@ -1128,6 +1196,12 @@ packages:
     peerDependencies:
       '@opentelemetry/api': '>=1.3.0 <1.10.0'
 
+  '@opentelemetry/sdk-trace-base@1.30.1':
+    resolution: {integrity: sha512-jVPgBbH1gCy2Lb7X0AVQ8XAfgg0pJ4nvl8/IiQA6nxOsPvS+0zMJaFSs2ltXe0J6C8dqjcnpyqINDJmU30+uOg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
   '@opentelemetry/sdk-trace-base@2.8.0':
     resolution: {integrity: sha512-mhU4jp+vW0mGbFRd+GeXHvmfA4aDqWjBjLC3pE5XMpLs0IE2ryYb019Ts2AQrOq67gaTF25D91+fgvEHDZEnuQ==}
     engines: {node: ^18.19.0 || >=20.6.0}
@@ -1139,6 +1213,10 @@ packages:
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/semantic-conventions@1.28.0':
+    resolution: {integrity: sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==}
+    engines: {node: '>=14'}
 
   '@opentelemetry/semantic-conventions@1.40.0':
     resolution: {integrity: sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==}
@@ -4059,6 +4137,10 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.1
 
+  '@opentelemetry/api-logs@0.57.2':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+
   '@opentelemetry/api@1.9.0': {}
 
   '@opentelemetry/api@1.9.1': {}
@@ -4072,6 +4154,11 @@ snapshots:
   '@opentelemetry/context-async-hooks@2.8.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
+
+  '@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/semantic-conventions': 1.28.0
 
   '@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -4172,6 +4259,15 @@ snapshots:
       '@opentelemetry/resources': 2.8.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.8.0(@opentelemetry/api@1.9.1)
 
+  '@opentelemetry/exporter-trace-otlp-http@0.57.2(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.1)
+
   '@opentelemetry/exporter-trace-otlp-proto@0.219.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
@@ -4213,6 +4309,12 @@ snapshots:
       '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/otlp-transformer': 0.219.0(@opentelemetry/api@1.9.1)
 
+  '@opentelemetry/otlp-exporter-base@0.57.2(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.57.2(@opentelemetry/api@1.9.1)
+
   '@opentelemetry/otlp-grpc-exporter-base@0.219.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@grpc/grpc-js': 1.14.4
@@ -4231,6 +4333,17 @@ snapshots:
       '@opentelemetry/sdk-metrics': 2.8.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.8.0(@opentelemetry/api@1.9.1)
 
+  '@opentelemetry/otlp-transformer@0.57.2(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.57.2
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.1)
+      protobufjs: 7.6.4
+
   '@opentelemetry/propagator-b3@2.8.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
@@ -4240,6 +4353,12 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/resources@1.30.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.28.0
 
   '@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -4254,6 +4373,19 @@ snapshots:
       '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/resources': 2.8.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
+
+  '@opentelemetry/sdk-logs@0.57.2(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.57.2
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/sdk-metrics@1.30.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.1)
 
   '@opentelemetry/sdk-metrics@2.8.0(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -4293,6 +4425,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.28.0
+
   '@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
@@ -4306,6 +4445,8 @@ snapshots:
       '@opentelemetry/context-async-hooks': 2.8.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.8.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/semantic-conventions@1.28.0': {}
 
   '@opentelemetry/semantic-conventions@1.40.0': {}
 


### PR DESCRIPTION
## What

Adds the Laminar observability extension for the [pi coding agent](https://pi.dev) as a new workspace package: **`packages/pi-extension`** (`@lmnr-ai/pi-extension`). It emits one Laminar trace per pi agent run — granular LLM + tool spans, live over OTLP/HTTP — fully fail-open.

## Design decisions

- **Build-free.** pi runs the TypeScript entry (`src/index.ts`) directly via jiti, and harbor uploads/runs the source in place in sandboxes. No build step ⇒ the shipped `src` is exactly what runs, with no `dist`-vs-`src` drift. `pnpm -r build` cleanly skips it.
- **Reuse `@lmnr-ai/types`, not the SDK.** Runtime deps stay limited to raw OpenTelemetry (deliberately independent of `@lmnr-ai/lmnr`'s heavy instrumentation runtime, so it stays light enough to upload into a sandbox). We reuse shared *type* definitions — `SpanType`, `DebugSessionFile` — from the zero-dep `@lmnr-ai/types` as **type-only `devDependency`** imports.
  - These are erased at runtime, so the sandbox upload path never needs `@lmnr-ai/types` (a runtime `workspace:*` dep would resolve to a pnpm symlink that breaks once the extension dir is uploaded). **Verified** by running the e2e tests with `@lmnr-ai/types` removed from `node_modules` — all pass.
- **Independent releases.** New `publish-pi-extension` job keyed on `pi-extension-*` tags; that prefix is excluded from `publish-sdk`. The extension versions independently of the SDK. `check-versions` is unaffected (it only governs `types`/`client`/`lmnr`).

## Verification

- `typecheck` clean · `lint` 0 errors · **15/15 tests pass**
- The e2e OTLP-capture test asserts the actual span tree lands: DEFAULT root + per-turn LLM spans + TOOL spans with correct nesting, token/cost attributes, and `trace_type=EVALUATION` propagation from an injected `LMNR_SPAN_CONTEXT`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New telemetry path sends project API keys and span payloads to Laminar over the network, but errors are swallowed so agent runs should not break; release workflow changes are scoped to tag prefixes.
> 
> **Overview**
> Introduces **`@lmnr-ai/pi-extension`**, a build-free pi agent package that streams **one Laminar trace per run** (root + per-turn LLM + tool spans) over OTLP/HTTP using OpenTelemetry only at runtime, with fail-open behavior when `LMNR_PROJECT_API_KEY` is missing or export fails.
> 
> The extension hooks pi lifecycle events to open/close spans in real time, map pi usage/cost to `gen_ai.*` attributes, optionally join debugger rollout sessions (`LMNR_DEBUG`), and nest under harness parents via `LMNR_SPAN_CONTEXT` (including `trace_type` such as `EVALUATION`). CI gains a **`publish-pi-extension`** job for `pi-extension-*` release tags while **`publish-sdk`** skips those tags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12f265beffdf601f12933f16d7bcdbb8243e01f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->