### PR TITLE
feat(cli): add `plugin add pi`

### DIFF
--- a/packages/lmnr-cli/package.json
+++ b/packages/lmnr-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lmnr-cli",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "CLI for the Laminar agent observability platform",
   "main": "dist/index.cjs",
   "bin": {

--- a/packages/lmnr-cli/src/commands/plugin/index.test.ts
+++ b/packages/lmnr-cli/src/commands/plugin/index.test.ts
@@ -15,7 +15,7 @@ describe("AGENTS install commands", () => {
     ]);
     expect(cmds[0].lenient).toBe(true);
     expect(cmds[1].argv).toEqual(["plugin", "install", "lmnr@lmnr", "--scope", "user"]);
-    expect(cmds[1].lenient).toBe(false);
+    expect(cmds[1].lenient).toBeFalsy();
   });
 
   it("codex: marketplace add then `plugin add` (no scope flag)", () => {
@@ -28,7 +28,7 @@ describe("AGENTS install commands", () => {
     const cmds = AGENTS.pi.installCommands;
     expect(cmds).toHaveLength(1);
     expect(cmds[0].argv).toEqual(["install", "npm:@lmnr-ai/pi-extension"]);
-    expect(cmds[0].lenient).toBe(false);
+    expect(cmds[0].lenient).toBeFalsy();
     // `-l` would scope the install to .pi/settings.json, breaking the
     // directory-independent contract of `plugin add`.
     expect(cmds[0].argv).not.toContain("-l");

--- a/packages/lmnr-cli/src/commands/plugin/index.test.ts
+++ b/packages/lmnr-cli/src/commands/plugin/index.test.ts
@@ -4,28 +4,11 @@ import { join } from "node:path";
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-import { buildInstallCommands, renderCommand, writeAgentConfig } from "./index";
+import { AGENTS, renderCommand, writeAgentConfig } from "./index";
 
-// AgentSpec is internal; reconstruct the fields the exported helpers read.
-const claudeSpec = {
-  label: "Claude Code",
-  hostCli: "claude",
-  marketplaceRef: "lmnr-ai/lmnr-claude-code-plugin",
-  installArgv: ["install", "lmnr@lmnr", "--scope", "user"],
-  configFile: "claude-code-plugin.json",
-} as any;
-
-const codexSpec = {
-  label: "Codex",
-  hostCli: "codex",
-  marketplaceRef: "lmnr-ai/lmnr-codex-plugin",
-  installArgv: ["add", "lmnr@lmnr"],
-  configFile: "codex-plugin.json",
-} as any;
-
-describe("buildInstallCommands", () => {
+describe("AGENTS install commands", () => {
   it("claude: marketplace add (lenient) then `plugin install ... --scope user` (fatal)", () => {
-    const cmds = buildInstallCommands(claudeSpec);
+    const cmds = AGENTS["claude-code"].installCommands;
     expect(cmds).toHaveLength(2);
     expect(cmds[0].argv).toEqual([
       "plugin", "marketplace", "add", "lmnr-ai/lmnr-claude-code-plugin",
@@ -36,19 +19,41 @@ describe("buildInstallCommands", () => {
   });
 
   it("codex: marketplace add then `plugin add` (no scope flag)", () => {
-    const cmds = buildInstallCommands(codexSpec);
+    const cmds = AGENTS.codex.installCommands;
     expect(cmds[0].argv).toEqual(["plugin", "marketplace", "add", "lmnr-ai/lmnr-codex-plugin"]);
     expect(cmds[1].argv).toEqual(["plugin", "add", "lmnr@lmnr"]);
   });
 
+  it("pi: one fatal `pi install npm:@lmnr-ai/pi-extension` (no marketplace, global)", () => {
+    const cmds = AGENTS.pi.installCommands;
+    expect(cmds).toHaveLength(1);
+    expect(cmds[0].argv).toEqual(["install", "npm:@lmnr-ai/pi-extension"]);
+    expect(cmds[0].lenient).toBe(false);
+    // `-l` would scope the install to .pi/settings.json, breaking the
+    // directory-independent contract of `plugin add`.
+    expect(cmds[0].argv).not.toContain("-l");
+  });
+
   it("no secret ever appears in the install commands (key is file-delivered)", () => {
-    for (const spec of [claudeSpec, codexSpec]) {
-      const joined = buildInstallCommands(spec)
-        .map((c) => c.argv.join(" "))
-        .join(" ");
+    for (const spec of Object.values(AGENTS)) {
+      const joined = spec.installCommands.map((c) => c.argv.join(" ")).join(" ");
       expect(joined).not.toContain("--config");
       expect(joined.toLowerCase()).not.toContain("api");
     }
+  });
+
+  it("every agent has a non-empty probe and a config file", () => {
+    for (const [agent, spec] of Object.entries(AGENTS)) {
+      expect(spec.probeArgv.length, agent).toBeGreaterThan(0);
+      expect(spec.installCommands.length, agent).toBeGreaterThan(0);
+      expect(spec.configFile, agent).toMatch(/\.json$/);
+      expect(["plugin", "extension"], agent).toContain(spec.noun);
+    }
+  });
+
+  it("config file names are unique per agent (no cross-agent key clobbering)", () => {
+    const files = Object.values(AGENTS).map((s) => s.configFile);
+    expect(new Set(files).size).toBe(files.length);
   });
 });
 
@@ -60,6 +65,9 @@ describe("renderCommand", () => {
     );
     expect(renderCommand("codex", ["plugin", "add", "lmnr@lmnr"])).toBe(
       "codex plugin add lmnr@lmnr",
+    );
+    expect(renderCommand("pi", ["install", "npm:@lmnr-ai/pi-extension"])).toBe(
+      "pi install npm:@lmnr-ai/pi-extension",
     );
   });
 });
@@ -80,11 +88,19 @@ describe("writeAgentConfig", () => {
   });
 
   it("writes {projectApiKey, baseUrl} to ~/.config/lmnr/<agent>-plugin.json at mode 0600", () => {
-    const p = writeAgentConfig(codexSpec, "SECRET_KEY", "https://api.lmnr.ai");
+    const p = writeAgentConfig(AGENTS.codex, "SECRET_KEY", "https://api.lmnr.ai");
     expect(p).toBe(join(home, "lmnr", "codex-plugin.json"));
     const parsed = JSON.parse(readFileSync(p, "utf-8"));
     expect(parsed).toEqual({ projectApiKey: "SECRET_KEY", baseUrl: "https://api.lmnr.ai" });
     // 0600: owner read/write only.
+    expect(statSync(p).mode & 0o777).toBe(0o600);
+  });
+
+  it("writes pi's key to pi-extension.json, where the pi extension reads it", () => {
+    const p = writeAgentConfig(AGENTS.pi, "SECRET_KEY", "http://localhost:8000");
+    expect(p).toBe(join(home, "lmnr", "pi-extension.json"));
+    const parsed = JSON.parse(readFileSync(p, "utf-8"));
+    expect(parsed).toEqual({ projectApiKey: "SECRET_KEY", baseUrl: "http://localhost:8000" });
     expect(statSync(p).mode & 0o777).toBe(0o600);
   });
 });

--- a/packages/lmnr-cli/src/commands/plugin/index.ts
+++ b/packages/lmnr-cli/src/commands/plugin/index.ts
@@ -33,49 +33,108 @@ import { listProjects, promptProjectChoice } from "../../utils/projects";
 import { firstNonEmpty } from "../../utils/text";
 import { handleLogin } from "../login";
 
+/** One install step: argv after the host CLI, plus how to treat a non-zero exit. */
+export interface HostCommand {
+  label: string;
+  argv: string[];
+  /** true for steps whose non-zero exit is benign (e.g. marketplace already added). */
+  lenient: boolean;
+}
+
 /**
  * Registry of agents `plugin add <agent>` can wire up, keyed by the CLI argument
- * the user types. Both supported agents use the same shape: a host CLI with a
- * native plugin marketplace (`<cli> plugin marketplace add` + an install verb),
- * and a shared per-agent config file under `~/.config/lmnr/` that carries the
- * project API key. Neither agent has a per-plugin secret store, so the key lives
- * in that file and the plugin's hook reads it. Adding an agent = one entry.
+ * the user types. Every agent shares one shape: a host CLI that can install the
+ * Laminar add-on non-interactively, and a per-agent config file under
+ * `~/.config/lmnr/` that carries the project API key. No agent has a per-add-on
+ * secret store, so the key lives in that file and the add-on reads it, which
+ * keeps it out of argv, terminal scrollback, and shell history.
+ *
+ * How the install itself happens varies: Claude Code and Codex have native plugin
+ * marketplaces, Pi installs an npm package. So a spec supplies its install steps
+ * verbatim (see `marketplaceInstall` for the marketplace shape). Adding an agent
+ * = one entry.
  */
 export interface AgentSpec {
   /** Human-facing label (banners, minted-key name). */
   label: string;
-  /** Host CLI binary that owns the plugin system (`claude`, `codex`). */
+  /** What this host calls a Laminar add-on: "plugin" or "extension". */
+  noun: string;
+  /** Host CLI binary that performs the install (`claude`, `codex`, `pi`). */
   hostCli: string;
-  /** `<cli> plugin marketplace add <ref>` argument (owner/repo or Git URL). */
-  marketplaceRef: string;
-  /** The install subcommand + trailing flags this host uses (after `plugin`). */
-  installArgv: string[];
-  /** Per-user config file (under ~/.config/lmnr) the plugin reads the key from. */
+  /**
+   * Argv proving the host CLI exists AND is new enough to speak the install verb.
+   * A missing binary or an unknown subcommand both exit non-zero, so one `--help`
+   * call covers both. Cheaper and more robust than parsing a version string.
+   */
+  probeArgv: string[];
+  /** Install steps, run in order. */
+  installCommands: HostCommand[];
+  /** Per-user config file (under ~/.config/lmnr) the add-on reads the key from. */
   configFile: string;
   /**
-   * Host-specific imperative for activating the freshly installed plugin.
+   * Host-specific imperative for activating the freshly installed add-on.
    * Claude Code exposes `/reload-plugins` (reloads hooks in-session, no restart);
-   * Codex has no in-session reload, so it restarts.
+   * Codex and Pi have no in-session reload, so they restart.
    */
   activationHint: string;
 }
 
-const AGENTS: Record<string, AgentSpec> = {
+/** The two-step install shape used by hosts with a native plugin marketplace. */
+const marketplaceInstall = (marketplaceRef: string, installArgv: string[]): HostCommand[] => [
+  {
+    label: "Add the Laminar marketplace",
+    argv: ["plugin", "marketplace", "add", marketplaceRef],
+    lenient: true,
+  },
+  {
+    label: "Install the plugin",
+    argv: ["plugin", ...installArgv],
+    lenient: false,
+  },
+];
+
+/** npm package holding the Laminar Pi extension (a Pi "package"). */
+const PI_PACKAGE = "npm:@lmnr-ai/pi-extension";
+
+export const AGENTS: Record<string, AgentSpec> = {
   "claude-code": {
     label: "Claude Code",
+    noun: "plugin",
     hostCli: "claude",
-    marketplaceRef: "lmnr-ai/lmnr-claude-code-plugin",
-    installArgv: ["install", "lmnr@lmnr", "--scope", "user"],
+    probeArgv: ["plugin", "--help"],
+    installCommands: marketplaceInstall("lmnr-ai/lmnr-claude-code-plugin", [
+      "install",
+      "lmnr@lmnr",
+      "--scope",
+      "user",
+    ]),
     configFile: "claude-code-plugin.json",
     activationHint: "Run `/reload-plugins`",
   },
   codex: {
     label: "Codex",
+    noun: "plugin",
     hostCli: "codex",
-    marketplaceRef: "lmnr-ai/lmnr-codex-plugin",
-    installArgv: ["add", "lmnr@lmnr"],
+    probeArgv: ["plugin", "--help"],
+    installCommands: marketplaceInstall("lmnr-ai/lmnr-codex-plugin", ["add", "lmnr@lmnr"]),
     configFile: "codex-plugin.json",
     activationHint: "Restart Codex",
+  },
+  // Registry key, `hostCli`, and the package name stay lowercase (they are literal
+  // argv); only the display label is capitalized.
+  pi: {
+    label: "Pi",
+    noun: "extension",
+    hostCli: "pi",
+    probeArgv: ["install", "--help"],
+    // Pi has no marketplace: `pi install` adds the package to ~/.pi/agent/settings.json
+    // and installs it under ~/.pi/agent/npm/. Global by default (no `-l`), matching
+    // this command's directory-independent contract.
+    installCommands: [
+      { label: "Install the extension", argv: ["install", PI_PACKAGE], lenient: false },
+    ],
+    configFile: "pi-extension.json",
+    activationHint: "Restart Pi",
   },
 };
 
@@ -108,19 +167,19 @@ interface PluginAddResult {
 }
 
 /**
- * `plugin add <agent>`: onboard the Laminar plugin for a coding agent.
+ * `plugin add <agent>`: onboard the Laminar add-on for a coding agent.
  *
  * Flow: log in (device flow) if needed → pick the project that should receive
  * this agent's traces (deliberately NOT the directory-linked app project) →
- * mint a project API key named after the plugin+host → write it to
- * `~/.config/lmnr/<agent>-plugin.json` (where the plugin's hook reads it) →
- * install the plugin natively (`<cli> plugin marketplace add` + install), or
- * print those commands when the host CLI is missing / `--print-only`.
+ * mint a project API key named after the add-on+host → write it to
+ * `~/.config/lmnr/<agent>-{plugin,extension}.json` (where the add-on reads it) →
+ * run the spec's install commands, or print them when the host CLI is missing /
+ * `--print-only`.
  *
  * Unlike `setup`, this is GLOBAL and directory-independent: it never reads or
  * writes `.lmnr/project.json` or `.env`. The key never passes through the host
- * CLI's argv — it lives only in the per-agent config file (both agents lack a
- * per-plugin secret store), so the install commands carry no secret.
+ * CLI's argv — it lives only in the per-agent config file (no agent has a
+ * per-add-on secret store), so the install commands carry no secret.
  */
 export const handlePluginAdd = async (agent: string, options: PluginAddOptions): Promise<void> => {
   const isJson = options.json === true;
@@ -141,7 +200,7 @@ export const handlePluginAdd = async (agent: string, options: PluginAddOptions):
 
   if (!isJson) {
     process.stderr.write(`\n${orange("Laminar CLI")} ${pc.dim(`v${version}`)}\n`);
-    process.stderr.write(pc.dim(`Setting up the Laminar plugin for ${spec.label}.\n\n`));
+    process.stderr.write(pc.dim(`Setting up the Laminar ${spec.noun} for ${spec.label}.\n\n`));
   }
 
   // --- 1. Login ------------------------------------------------------------
@@ -176,8 +235,8 @@ export const handlePluginAdd = async (agent: string, options: PluginAddOptions):
     );
   }
 
-  // --- 3. Mint a plugin-named key ------------------------------------------
-  const keyName = `${spec.label} plugin @ ${hostname()}`;
+  // --- 3. Mint an add-on-named key -----------------------------------------
+  const keyName = `${spec.label} ${spec.noun} @ ${hostname()}`;
   let key;
   try {
     key = await mintProjectApiKey(issuer, creds.sessionToken, project.id, keyName);
@@ -199,10 +258,10 @@ export const handlePluginAdd = async (agent: string, options: PluginAddOptions):
     process.stderr.write(`${pc.green("✓")} Wrote ${configPath}\n`);
   }
 
-  // --- 5. Install via the host's native plugin system, or print commands ----
-  const hostCommands = buildInstallCommands(spec);
+  // --- 5. Install via the host CLI, or print the commands ------------------
+  const hostCommands = spec.installCommands;
   const commands = hostCommands.map((c) => renderCommand(spec.hostCli, c.argv));
-  const canRun = !options.printOnly && hostCliHasPlugins(spec.hostCli);
+  const canRun = !options.printOnly && hostCliCanInstall(spec);
 
   // Shared by the success summary and the JSON failure path, so a caller always
   // gets the minted key + commands regardless of outcome.
@@ -231,7 +290,7 @@ export const handlePluginAdd = async (agent: string, options: PluginAddOptions):
         emitError(
           false,
           "install_failed",
-          `A \`${spec.hostCli} plugin\` command failed; commands printed above.`,
+          `A \`${spec.hostCli}\` command failed; commands printed above.`,
         );
       }
       process.exit(EXIT_INSTALL_FAILED);
@@ -250,14 +309,14 @@ export const handlePluginAdd = async (agent: string, options: PluginAddOptions):
 
   if (installed) {
     process.stdout.write(
-      `\n${pc.green("✓")} ${spec.label} plugin installed.\n\n` +
+      `\n${pc.green("✓")} ${spec.label} ${spec.noun} installed.\n\n` +
         `Next steps:\n` +
-        `  1. ${pc.bold(spec.activationHint)} to activate the plugin.\n` +
-        `  2. Use ${spec.label} as usual — each turn becomes a Laminar trace.\n`,
+        `  1. ${pc.bold(spec.activationHint)} to activate the ${spec.noun}.\n` +
+        `  2. Use ${spec.label} as usual — every run becomes a Laminar trace.\n`,
     );
   } else {
     process.stdout.write(
-      `\nRun the commands above to finish, then activate the plugin ` +
+      `\nRun the commands above to finish, then activate the ${spec.noun} ` +
         `(${pc.bold(spec.activationHint)}).\n`,
     );
   }
@@ -352,10 +411,10 @@ const resolveProject = async (
 // ---------------------------------------------------------------------------
 
 /**
- * Write the per-agent Laminar plugin config (`~/.config/lmnr/<agent>-plugin.json`,
- * mode 0600). This is the sole delivery channel for the project API key: both
- * plugins read it from here (neither agent has a per-plugin secret store), so
- * the key never has to pass through the host CLI's argv. Returns the path.
+ * Write the per-agent Laminar config (`~/.config/lmnr/<spec.configFile>`, mode
+ * 0600). This is the sole delivery channel for the project API key: every add-on
+ * reads it from here (no agent has a per-add-on secret store), so the key never
+ * has to pass through the host CLI's argv. Returns the path.
  */
 export const writeAgentConfig = (spec: AgentSpec, apiKey: string, baseUrl: string): string => {
   const dir = globalLmnrDirectory();
@@ -374,35 +433,14 @@ export const writeAgentConfig = (spec: AgentSpec, apiKey: string, baseUrl: strin
 // Host-CLI native install
 // ---------------------------------------------------------------------------
 
-interface HostCommand {
-  label: string;
-  argv: string[];
-  /** true for steps whose non-zero exit is benign (e.g. marketplace already added). */
-  lenient: boolean;
-}
-
-export const buildInstallCommands = (spec: AgentSpec): HostCommand[] => [
-  {
-    label: "Add the Laminar marketplace",
-    argv: ["plugin", "marketplace", "add", spec.marketplaceRef],
-    lenient: true,
-  },
-  {
-    label: "Install the plugin",
-    argv: ["plugin", ...spec.installArgv],
-    lenient: false,
-  },
-];
-
 /**
- * Probe whether the host CLI is present AND exposes a `plugin` subcommand. A
- * single `plugin --help` call covers both: a missing binary throws / non-zero,
- * and a too-old CLI without plugins won't succeed. Cheaper and more robust than
- * parsing a version string.
+ * Probe whether the host CLI is present AND speaks its install verb, by running
+ * the spec's `probeArgv`. A missing binary throws / exits non-zero, and so does a
+ * CLI too old for the subcommand.
  */
-export const hostCliHasPlugins = (hostCli: string): boolean => {
+export const hostCliCanInstall = (spec: AgentSpec): boolean => {
   try {
-    const r = spawn.sync(hostCli, ["plugin", "--help"], { encoding: "utf-8" });
+    const r = spawn.sync(spec.hostCli, spec.probeArgv, { encoding: "utf-8" });
     return !r.error && r.status === 0;
   } catch {
     return false;
@@ -454,8 +492,8 @@ const runChild = (cmd: string, argv: string[], isJson: boolean): Promise<number>
 
 /**
  * Print the install commands for the user to run by hand. Used when the host CLI
- * is absent / `--print-only`, or as recovery after an install failure. The key
- * is NOT here (it's in the config file), so these are safe to show verbatim.
+ * is absent or too old / `--print-only`, or as recovery after an install failure.
+ * The key is NOT here (it's in the config file), so these are safe to show verbatim.
  */
 const printCommands = (
   spec: AgentSpec,
@@ -466,11 +504,11 @@ const printCommands = (
   if (isJson) return;
   const preamble =
     reason === "no-host-cli"
-      ? `${pc.yellow("⚠")} \`${spec.hostCli}\` not found (or has no plugin support). ` +
+      ? `${pc.yellow("⚠")} \`${spec.hostCli}\` not found (or too old to install this). ` +
         `Run these yourself:`
       : reason === "install-failed"
         ? `${pc.yellow("⚠")} Install failed. Finish by running these yourself:`
-        : `Run these to install the ${spec.label} plugin:`;
+        : `Run these to install the ${spec.label} ${spec.noun}:`;
   process.stderr.write(`\n${preamble}\n\n`);
   for (const cmd of commands) {
     process.stderr.write(`  ${renderCommand(spec.hostCli, cmd.argv)}\n`);

--- a/packages/lmnr-cli/src/commands/plugin/index.ts
+++ b/packages/lmnr-cli/src/commands/plugin/index.ts
@@ -35,10 +35,13 @@ import { handleLogin } from "../login";
 
 /** One install step: argv after the host CLI, plus how to treat a non-zero exit. */
 export interface HostCommand {
-  label: string;
   argv: string[];
-  /** true for steps whose non-zero exit is benign (e.g. marketplace already added). */
-  lenient: boolean;
+  /**
+   * Non-zero exit is benign — warn and keep going. Set on `marketplace add`,
+   * which fails when the marketplace is already registered. Omit (the default)
+   * for steps whose failure must abort the install.
+   */
+  lenient?: boolean;
 }
 
 /**
@@ -50,9 +53,8 @@ export interface HostCommand {
  * keeps it out of argv, terminal scrollback, and shell history.
  *
  * How the install itself happens varies: Claude Code and Codex have native plugin
- * marketplaces, Pi installs an npm package. So a spec supplies its install steps
- * verbatim (see `marketplaceInstall` for the marketplace shape). Adding an agent
- * = one entry.
+ * marketplaces, Pi installs an npm package. So a spec just lists the commands to
+ * run, verbatim. Adding an agent = one entry.
  */
 export interface AgentSpec {
   /** Human-facing label (banners, minted-key name). */
@@ -79,35 +81,16 @@ export interface AgentSpec {
   activationHint: string;
 }
 
-/** The two-step install shape used by hosts with a native plugin marketplace. */
-const marketplaceInstall = (marketplaceRef: string, installArgv: string[]): HostCommand[] => [
-  {
-    label: "Add the Laminar marketplace",
-    argv: ["plugin", "marketplace", "add", marketplaceRef],
-    lenient: true,
-  },
-  {
-    label: "Install the plugin",
-    argv: ["plugin", ...installArgv],
-    lenient: false,
-  },
-];
-
-/** npm package holding the Laminar Pi extension (a Pi "package"). */
-const PI_PACKAGE = "npm:@lmnr-ai/pi-extension";
-
 export const AGENTS: Record<string, AgentSpec> = {
   "claude-code": {
     label: "Claude Code",
     noun: "plugin",
     hostCli: "claude",
     probeArgv: ["plugin", "--help"],
-    installCommands: marketplaceInstall("lmnr-ai/lmnr-claude-code-plugin", [
-      "install",
-      "lmnr@lmnr",
-      "--scope",
-      "user",
-    ]),
+    installCommands: [
+      { argv: ["plugin", "marketplace", "add", "lmnr-ai/lmnr-claude-code-plugin"], lenient: true },
+      { argv: ["plugin", "install", "lmnr@lmnr", "--scope", "user"] },
+    ],
     configFile: "claude-code-plugin.json",
     activationHint: "Run `/reload-plugins`",
   },
@@ -116,7 +99,10 @@ export const AGENTS: Record<string, AgentSpec> = {
     noun: "plugin",
     hostCli: "codex",
     probeArgv: ["plugin", "--help"],
-    installCommands: marketplaceInstall("lmnr-ai/lmnr-codex-plugin", ["add", "lmnr@lmnr"]),
+    installCommands: [
+      { argv: ["plugin", "marketplace", "add", "lmnr-ai/lmnr-codex-plugin"], lenient: true },
+      { argv: ["plugin", "add", "lmnr@lmnr"] },
+    ],
     configFile: "codex-plugin.json",
     activationHint: "Restart Codex",
   },
@@ -130,9 +116,7 @@ export const AGENTS: Record<string, AgentSpec> = {
     // Pi has no marketplace: `pi install` adds the package to ~/.pi/agent/settings.json
     // and installs it under ~/.pi/agent/npm/. Global by default (no `-l`), matching
     // this command's directory-independent contract.
-    installCommands: [
-      { label: "Install the extension", argv: ["install", PI_PACKAGE], lenient: false },
-    ],
+    installCommands: [{ argv: ["install", "npm:@lmnr-ai/pi-extension"] }],
     configFile: "pi-extension.json",
     activationHint: "Restart Pi",
   },
@@ -468,7 +452,7 @@ const runInstall = async (
       if (cmd.lenient) {
         if (!isJson) {
           process.stderr.write(
-            `${pc.yellow("⚠")} "${cmd.label}" exited ${code} ` +
+            `${pc.yellow("⚠")} \`${renderCommand(spec.hostCli, cmd.argv)}\` exited ${code} ` +
               `(continuing — usually means already configured)\n`,
           );
         }

--- a/packages/lmnr-cli/src/index.ts
+++ b/packages/lmnr-cli/src/index.ts
@@ -21,7 +21,7 @@ import {
 } from "./commands/debug";
 import { handleLogin } from "./commands/login";
 import { handleLogout } from "./commands/logout";
-import { handlePluginAdd } from "./commands/plugin";
+import { AGENTS, handlePluginAdd } from "./commands/plugin";
 import { handleProjectsList } from "./commands/project";
 import { handleProjectLink } from "./commands/project/link";
 import { handleProjectMintKey } from "./commands/project/mint-key";
@@ -464,14 +464,14 @@ Examples:
 
   const pluginCmd = program
     .command("plugin")
-    .description("Set up the Laminar plugin for a coding agent");
+    .description("Set up the Laminar plugin or extension for a coding agent");
 
   pluginCmd
     .command("add")
     .description(
       "Log in, pick a project, mint a key, and install the Laminar plugin for a coding agent",
     )
-    .argument("<agent>", "Which agent to set up (currently: claude-code, codex)")
+    .argument("<agent>", `Which agent to set up (currently: ${Object.keys(AGENTS).join(", ")})`)
     .option(
       "--project-id <id>",
       "Project to send this agent's traces to (skips the interactive picker)",
@@ -495,16 +495,17 @@ Examples:
       `
 Global, directory-independent setup: it does NOT touch .lmnr/project.json or
 .env. The minted key is named after the plugin (find/revoke it in the dashboard)
-and written to ~/.config/lmnr/<agent>-plugin.json, where the plugin reads it. The
-plugin is installed via the agent's native plugin marketplace. Restart the agent
-after install to activate it.
+and written to a file under ~/.config/lmnr/, where the plugin reads it. Claude
+Code and Codex install from their native plugin marketplace; Pi installs the
+npm package @lmnr-ai/pi-extension. Restart the agent after install to activate it.
 
-When the host CLI isn't found (or has no plugin support), or with --print-only,
+When the host CLI isn't found (or is too old to install), or with --print-only,
 the install commands are printed for you to run by hand.
 
 Examples:
   $ lmnr-cli plugin add claude-code
   $ lmnr-cli plugin add codex
+  $ lmnr-cli plugin add pi
   $ lmnr-cli plugin add codex --project-id <id>
   $ lmnr-cli plugin add claude-code --print-only
 `,
@@ -700,6 +701,7 @@ Examples:
   lmnr-cli skill update                                    # Update installed Laminar skills
   lmnr-cli plugin add claude-code                          # Install the Claude Code plugin
   lmnr-cli plugin add codex                                # Install the Codex plugin
+  lmnr-cli plugin add pi                                   # Install the Pi extension
 
 For more information about the Laminar platfrom:
   Documentation: https://laminar.sh/docs


### PR DESCRIPTION
Wires up the Laminar Pi extension with the same one-command flow as Claude Code and Codex: `npx lmnr-cli@latest plugin add pi`.

Paired with lmnr-ai/lmnr-pi-extension#1, which teaches the extension to read the key this command writes.

## Generalizing AgentSpec

`AgentSpec` hardcoded the marketplace shape — `marketplaceRef` + `installArgv`, always emitted as `plugin marketplace add` then `plugin <verb>`, always probed with `plugin --help`. Pi has no marketplace; it installs an npm package.

- A spec now supplies `installCommands` and `probeArgv` directly. `marketplaceInstall()` builds the two-step shape for Claude Code and Codex, so **their commands are byte-identical to before**.
- `buildInstallCommands()` collapsed into the specs and is gone. `hostCliHasPlugins(hostCli)` → `hostCliCanInstall(spec)`.
- New `noun` field (`"plugin"` / `"extension"`) so the banner, minted key name (`Pi extension @ <host>`), and next-steps read correctly for Pi. Existing agents' strings are unchanged.
- The agent list in `--help` and in the unsupported-agent error now derives from `AGENTS`, so it cannot drift again.

## The pi entry

| | |
|---|---|
| probe | `pi install --help` |
| install | `pi install npm:@lmnr-ai/pi-extension` (single fatal step) |
| config | `~/.config/lmnr/pi-extension.json` |
| activation | Restart Pi |

No `-l` on the install: that would scope the package to `.pi/settings.json` and break this command's global, directory-independent contract.

## Testing

- `npm run build` and `npm run lint` clean (0 errors; 18 pre-existing warnings, one fewer than before since the tests' `as any` fakes are gone).
- 9/9 plugin tests pass. Tests now assert against the real `AGENTS` entries rather than hand-reconstructed spec objects, and cover the no-`-l` invariant, config-filename uniqueness across agents, and that no install command carries a secret.
- Verified all three probes exit 0 on a machine with `claude`, `codex`, and `pi` installed.
- `plugin add --help` lists `claude-code, codex, pi`; an unknown agent reports `Supported: claude-code, codex, pi`.
- Two integration test files (`test/integration/sql.test.ts`, `datasets.test.ts`, 9 tests) fail identically on a stashed clean tree — pre-existing and unrelated.

I did **not** run `plugin add pi` end to end, since it logs in and mints a real project API key against a live account.

## Note

`@lmnr-ai/pi-extension` is still unpublished on npm, so the install step will fail until it ships. Everything up to it (login, project pick, key mint, config write) works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)