### PR TITLE
feat(cli): update SQL schema 

### DIFF
--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -75,6 +75,19 @@ export class LaminarClient {
   }
 
   /**
+   * The fully-resolved API origin every resource fetches from, e.g.
+   * `http://localhost:8000`. Already normalized: trailing slash removed, any
+   * port embedded in `baseUrl` stripped, and the effective port appended.
+   *
+   * Exposed so callers can name the real address in diagnostics instead of
+   * rebuilding it from `baseUrl` + `port` — that reconstruction drifts from
+   * this normalization and prints things like `http://host:8000:9000`.
+   */
+  public get apiBaseUrl(): string {
+    return this.baseUrl;
+  }
+
+  /**
    * Normalize the constructor's auth inputs into a {@link LaminarAuth} union.
    * Precedence: an explicit `auth` wins; otherwise the legacy
    * `projectApiKey` (+ optional `cliUserProjectId`) is mapped — a present

--- a/packages/client/src/resources/sql.ts
+++ b/packages/client/src/resources/sql.ts
@@ -1,3 +1,5 @@
+import type { SqlSchema } from "@lmnr-ai/types";
+
 import { BaseResource, type LaminarAuth } from "./index";
 
 export class SqlResource extends BaseResource {
@@ -25,5 +27,25 @@ export class SqlResource extends BaseResource {
     }
 
     return (await response.json()).data as Array<Record<string, any>>;
+  }
+
+  /**
+   * Fetch the queryable tables, columns, and enums. Server-rendered from
+   * app-server's `query_engine::schema`, so it is the same source that backs
+   * the MCP `query_laminar_sql` tool description — never a client-side copy.
+   */
+  public async schema(): Promise<SqlSchema> {
+    const response = await fetch(`${this.baseHttpUrl}${this.apiPrefix}/sql/schema`, {
+      method: "GET",
+      headers: {
+        ...this.headers(),
+      },
+    });
+
+    if (!response.ok) {
+      await this.handleError(response);
+    }
+
+    return (await response.json()) as SqlSchema;
   }
 }

--- a/packages/lmnr-cli/package.json
+++ b/packages/lmnr-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lmnr-cli",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "CLI for the Laminar agent observability platform",
   "main": "dist/index.cjs",
   "bin": {

--- a/packages/lmnr-cli/src/commands/sql/schema.test.ts
+++ b/packages/lmnr-cli/src/commands/sql/schema.test.ts
@@ -1,0 +1,88 @@
+import type { SqlSchema } from "@lmnr-ai/types";
+import { describe, expect, it } from "vitest";
+
+import { renderSqlSchema } from "./schema";
+
+const schema: SqlSchema = {
+  tables: [
+    {
+      name: "spans",
+      description: "Individual spans within traces.",
+      columns: [
+        { name: "span_id", type: "UUID", description: "Unique id of the span" },
+        {
+          name: "duration",
+          type: "Decimal(18,9)",
+          description: "Duration in seconds",
+        },
+        {
+          name: "events",
+          type: "Array(Tuple(timestamp Int64, name String, attributes String))",
+          description: "Span events",
+        },
+      ],
+    },
+  ],
+  enums: [
+    {
+      name: "span_type",
+      values: [
+        "DEFAULT",
+        "LLM",
+        "EXECUTOR",
+        "EVALUATOR",
+        "EVALUATION",
+        "TOOL",
+        "HUMAN_EVALUATOR",
+        "CACHED",
+        "UNKNOWN",
+      ],
+    },
+    { name: "status", values: ["success", "error"] },
+  ],
+};
+
+void describe("renderSqlSchema", () => {
+  void it("renders every table with its columns and types", () => {
+    const out = renderSqlSchema(schema);
+
+    expect(out).toContain("  spans");
+    expect(out).toContain("span_id (UUID)");
+    expect(out).toContain("duration (Decimal(18,9))");
+    expect(out).toContain(
+      "events (Array(Tuple(timestamp Int64, name String, attributes String)))",
+    );
+  });
+
+  // The user-facing contract is fields and types only; prose lives in the docs.
+  void it("omits column descriptions", () => {
+    const out = renderSqlSchema(schema);
+
+    expect(out).not.toContain("Unique id of the span");
+    expect(out).not.toContain("Individual spans within traces");
+  });
+
+  void it("renders enum values quoted", () => {
+    const out = renderSqlSchema(schema);
+
+    expect(out).toContain("span_type: 'DEFAULT',");
+    expect(out).toContain("status: 'success', 'error'");
+  });
+
+  // A 9-value enum used to render as one 100+ char line.
+  void it("keeps every line inside the terminal width", () => {
+    const tooLong = renderSqlSchema(schema)
+      .split("\n")
+      .filter((line) => line.length > 80);
+
+    expect(tooLong).toEqual([]);
+  });
+
+  void it("warns that project_id cannot be referenced", () => {
+    expect(renderSqlSchema(schema)).toContain("project_id");
+  });
+
+  void it("does not throw on an empty schema", () => {
+    expect(() => renderSqlSchema({ tables: [], enums: [] })).not.toThrow();
+  });
+});

--- a/packages/lmnr-cli/src/commands/sql/schema.test.ts
+++ b/packages/lmnr-cli/src/commands/sql/schema.test.ts
@@ -1,3 +1,4 @@
+import { LaminarClient } from "@lmnr-ai/client";
 import type { SqlSchema } from "@lmnr-ai/types";
 import { describe, expect, it } from "vitest";
 
@@ -91,34 +92,44 @@ void describe("renderSqlSchema", () => {
 // 8000` is the documented self-host form). The failure message used to print
 // the host alone, which named a URL that looked right when the port was the
 // actual miss.
+// Driven through a REAL LaminarClient so the message is pinned to the origin
+// the client actually fetches. An earlier version rebuilt the URL from
+// `baseUrl` + `port` and drifted from the client's normalization.
 void describe("handleSqlSchema failure message", () => {
-  const failingClient = {
-    sql: { schema: () => Promise.reject(new Error("fetch failed")) },
-  } as unknown as Parameters<typeof handleSqlSchema>[0];
+  const failing = (baseUrl?: string, port?: number) => {
+    const client = new LaminarClient({
+      baseUrl,
+      port,
+      auth: { type: "apiKey", key: "test-key" },
+    });
+    client.sql.schema = () => Promise.reject(new Error("fetch failed"));
+    return client;
+  };
 
-  void it("includes the --port flag in the URL", async () => {
+  void it("names the host and port that were fetched", async () => {
     await expect(
-      handleSqlSchema(failingClient, { baseUrl: "http://localhost", port: 8000 }),
+      handleSqlSchema(failing("http://localhost", 8000), {}),
     ).rejects.toThrow("http://localhost:8000");
   });
 
-  void it("falls back to LMNR_HTTP_PORT when no flag is given", async () => {
-    process.env.LMNR_HTTP_PORT = "8123";
-    try {
-      await expect(
-        handleSqlSchema(failingClient, { baseUrl: "http://localhost" }),
-      ).rejects.toThrow("http://localhost:8123");
-    } finally {
-      delete process.env.LMNR_HTTP_PORT;
-    }
+  // The client strips a port already present in baseUrl before appending the
+  // effective one. Rebuilding the URL instead printed `localhost:8000:9000`.
+  void it("does not double the port when baseUrl already carries one", async () => {
+    await expect(
+      handleSqlSchema(failing("http://localhost:8000", 9000), {}),
+    ).rejects.toThrow("http://localhost:9000");
   });
 
-  // No port resolvable → no `:port` on the host. The `:` that follows the URL
-  // in the message is this handler's own `${url}: ${error}` separator, so match
-  // on `:<digits>` rather than a bare colon.
-  void it("appends no port when none is resolvable", async () => {
+  // Likewise a trailing slash, which otherwise rendered as `http://host/:8000`.
+  void it("does not leave a slash before the port", async () => {
     await expect(
-      handleSqlSchema(failingClient, { baseUrl: "https://api.lmnr.ai" }),
-    ).rejects.toThrow(/from https:\/\/api\.lmnr\.ai: /);
+      handleSqlSchema(failing("http://localhost/", 8000), {}),
+    ).rejects.toThrow("http://localhost:8000");
+  });
+
+  void it("shows the default port when none is given", async () => {
+    await expect(
+      handleSqlSchema(failing("https://api.lmnr.ai"), {}),
+    ).rejects.toThrow("https://api.lmnr.ai:443");
   });
 });

--- a/packages/lmnr-cli/src/commands/sql/schema.test.ts
+++ b/packages/lmnr-cli/src/commands/sql/schema.test.ts
@@ -1,7 +1,7 @@
 import type { SqlSchema } from "@lmnr-ai/types";
 import { describe, expect, it } from "vitest";
 
-import { renderSqlSchema } from "./schema";
+import { handleSqlSchema, renderSqlSchema } from "./schema";
 
 const schema: SqlSchema = {
   tables: [
@@ -84,5 +84,41 @@ void describe("renderSqlSchema", () => {
 
   void it("does not throw on an empty schema", () => {
     expect(() => renderSqlSchema({ tables: [], enums: [] })).not.toThrow();
+  });
+});
+
+// The CLI keeps host and port separate (`--base-url http://localhost --port
+// 8000` is the documented self-host form). The failure message used to print
+// the host alone, which named a URL that looked right when the port was the
+// actual miss.
+void describe("handleSqlSchema failure message", () => {
+  const failingClient = {
+    sql: { schema: () => Promise.reject(new Error("fetch failed")) },
+  } as unknown as Parameters<typeof handleSqlSchema>[0];
+
+  void it("includes the --port flag in the URL", async () => {
+    await expect(
+      handleSqlSchema(failingClient, { baseUrl: "http://localhost", port: 8000 }),
+    ).rejects.toThrow("http://localhost:8000");
+  });
+
+  void it("falls back to LMNR_HTTP_PORT when no flag is given", async () => {
+    process.env.LMNR_HTTP_PORT = "8123";
+    try {
+      await expect(
+        handleSqlSchema(failingClient, { baseUrl: "http://localhost" }),
+      ).rejects.toThrow("http://localhost:8123");
+    } finally {
+      delete process.env.LMNR_HTTP_PORT;
+    }
+  });
+
+  // No port resolvable → no `:port` on the host. The `:` that follows the URL
+  // in the message is this handler's own `${url}: ${error}` separator, so match
+  // on `:<digits>` rather than a bare colon.
+  void it("appends no port when none is resolvable", async () => {
+    await expect(
+      handleSqlSchema(failingClient, { baseUrl: "https://api.lmnr.ai" }),
+    ).rejects.toThrow(/from https:\/\/api\.lmnr\.ai: /);
   });
 });

--- a/packages/lmnr-cli/src/commands/sql/schema.ts
+++ b/packages/lmnr-cli/src/commands/sql/schema.ts
@@ -1,7 +1,6 @@
 import type { LaminarClient } from "@lmnr-ai/client";
 import { errorMessage, type SqlSchema } from "@lmnr-ai/types";
 
-import { envHttpPort, resolveBaseUrl } from "../../auth/resolve";
 import type { GlobalOpts } from "../../auth/with-client";
 import { schemaFetchFailed } from "../../errors";
 import { outputJson, printData } from "../../utils/output";
@@ -91,12 +90,12 @@ export const handleSqlSchema = async (
     // exactly when the user is already misconfigured (a stale LMNR_BASE_URL in
     // a project `.env` is the common case).
     //
-    // Host and port are separate everywhere in the CLI (`--base-url
-    // http://localhost --port 8000` is the documented self-host form), so the
-    // message must splice the port back on. Naming the host alone points at a
-    // URL that looks correct when the port is the actual miss.
-    const port = opts.port ?? envHttpPort();
-    const url = `${resolveBaseUrl(opts.baseUrl)}${port ? `:${port}` : ""}`;
+    // Read the origin off the client rather than rebuilding it from
+    // `baseUrl` + `port`: the client strips a trailing slash and any port
+    // already in `baseUrl` before appending the effective one, so
+    // reconstruction drifts (`http://host:8000:9000`) and names an address
+    // that was never fetched.
+    const url = client.apiBaseUrl;
     throw schemaFetchFailed(
       `Could not fetch the SQL schema from ${url}: ${errorMessage(err)}. ` +
       "Check your connection, or that --base-url / --port (LMNR_BASE_URL / " +

--- a/packages/lmnr-cli/src/commands/sql/schema.ts
+++ b/packages/lmnr-cli/src/commands/sql/schema.ts
@@ -1,7 +1,7 @@
 import type { LaminarClient } from "@lmnr-ai/client";
 import { errorMessage, type SqlSchema } from "@lmnr-ai/types";
 
-import { resolveBaseUrl } from "../../auth/resolve";
+import { envHttpPort, resolveBaseUrl } from "../../auth/resolve";
 import type { GlobalOpts } from "../../auth/with-client";
 import { schemaFetchFailed } from "../../errors";
 import { outputJson, printData } from "../../utils/output";
@@ -90,11 +90,17 @@ export const handleSqlSchema = async (
     // A bare `fetch failed` names neither the host nor the fix, and this is
     // exactly when the user is already misconfigured (a stale LMNR_BASE_URL in
     // a project `.env` is the common case).
-    const url = resolveBaseUrl(opts.baseUrl);
+    //
+    // Host and port are separate everywhere in the CLI (`--base-url
+    // http://localhost --port 8000` is the documented self-host form), so the
+    // message must splice the port back on. Naming the host alone points at a
+    // URL that looks correct when the port is the actual miss.
+    const port = opts.port ?? envHttpPort();
+    const url = `${resolveBaseUrl(opts.baseUrl)}${port ? `:${port}` : ""}`;
     throw schemaFetchFailed(
       `Could not fetch the SQL schema from ${url}: ${errorMessage(err)}. ` +
-      "Check your connection, or that --base-url / LMNR_BASE_URL points at a " +
-      "reachable Laminar API.",
+      "Check your connection, or that --base-url / --port (LMNR_BASE_URL / " +
+      "LMNR_HTTP_PORT) point at a reachable Laminar API.",
     );
   }
 

--- a/packages/lmnr-cli/src/commands/sql/schema.ts
+++ b/packages/lmnr-cli/src/commands/sql/schema.ts
@@ -1,48 +1,109 @@
 export const SQL_SCHEMA_HELP = `
+Queries are scoped to your project automatically. There is no project_id
+column — referencing it is rejected.
+
 Available tables:
   spans
-    span_id (UUID), name (String), span_type (String: DEFAULT|LLM|TOOL),
-    start_time (DateTime64), end_time (DateTime64), duration (Float64),
-    input_cost (Float64), output_cost (Float64), total_cost (Float64),
-    input_tokens (Int64), output_tokens (Int64), total_tokens (Int64),
+    span_id (UUID), trace_id (UUID), parent_span_id (UUID),
+    name (String), path (String),
+    span_type (String enum span_type), status (String enum status),
+    start_time (DateTime64(9,'UTC')), end_time (DateTime64(9,'UTC')),
+    duration (Decimal(18,9)),
+    input (String), output (String),
     request_model (String), response_model (String), model (String),
-    trace_id (UUID), provider (String), path (String),
-    input (String), output (String), status (String),
-    parent_span_id (UUID), attributes (String), tags (Array(String))
+    provider (String),
+    input_tokens (Int64), output_tokens (Int64), total_tokens (Int64),
+    input_cost (Float64), output_cost (Float64), total_cost (Float64),
+    attributes (String), tags (Array(String)), tool_definitions (String),
+    events (Array(Tuple(timestamp Int64, name String, attributes String)))
 
   traces
-    id (UUID), start_time (DateTime64), end_time (DateTime64),
+    id (UUID), trace_type (String enum trace_type), metadata (String),
+    start_time (DateTime64(9,'UTC')), end_time (DateTime64(9,'UTC')),
+    duration (Float64),
     input_tokens (Int64), output_tokens (Int64), total_tokens (Int64),
+    cache_read_input_tokens (UInt64), cache_creation_input_tokens (UInt64),
+    reasoning_tokens (UInt64),
     input_cost (Float64), output_cost (Float64), total_cost (Float64),
-    duration (Float64), metadata (String), session_id (String),
-    user_id (String), status (String), top_span_id (UUID),
-    top_span_name (String), top_span_type (String), trace_type (String),
-    tags (Array(String)), has_browser_session (Bool)
+    status (String enum status), user_id (String), session_id (String),
+    top_span_id (UUID), top_span_name (String),
+    top_span_type (String enum span_type),
+    tags (Array(String)), trace_tags (Array(String)),
+    span_names (Array(String)), agent_input (String),
+    has_browser_session (Bool)
+
+  trace_outputs
+    trace_id (UUID), start_time (DateTime64(9,'UTC')),
+    agent_output (Array(String))
+
+  evaluation_datapoints
+    id (UUID), evaluation_id (UUID), trace_id (UUID),
+    created_at (DateTime64(9,'UTC')), updated_at (DateTime64(9,'UTC')),
+    data (String), target (String), metadata (String),
+    executor_output (String), index (UInt64), group_id (String),
+    scores (String), dataset_id (UUID), dataset_datapoint_id (UUID),
+    dataset_datapoint_created_at (DateTime64(9,'UTC')),
+    start_time (DateTime64(9,'UTC')), end_time (DateTime64(9,'UTC')),
+    duration (Decimal(18,9)),
+    input_cost (Float64), output_cost (Float64), total_cost (Float64),
+    input_tokens (Int64), output_tokens (Int64), total_tokens (Int64),
+    trace_status (LowCardinality(String) enum status),
+    trace_metadata (String), trace_tags (Array(String)), top_span_id (UUID),
+    trace_spans (Array(Tuple(name String, duration Float64, type String)))
+
+  dataset_datapoints
+    id (UUID), created_at (DateTime64(9,'UTC')), dataset_id (UUID),
+    data (String), target (String), metadata (String)
+
+  dataset_datapoint_versions
+    id (UUID), created_at (DateTime64(9,'UTC')), dataset_id (UUID),
+    data (String), target (String), metadata (String)
+
+  logs
+    log_id (UUID), time (DateTime64(9,'UTC')),
+    observed_time (DateTime64(9,'UTC')),
+    severity_number (UInt8), severity_text (String), body (String),
+    attributes (String), trace_id (UUID), span_id (UUID),
+    flags (UInt32), event_name (String)
 
   signal_events
     id (UUID), signal_id (UUID), trace_id (UUID), run_id (UUID),
-    name (String), payload (String), timestamp (DateTime64),
+    name (String), payload (String), timestamp (DateTime64(9,'UTC')),
     severity (UInt8: 0=INFO|1=WARNING|2=CRITICAL), summary (String),
     clusters (Array(UUID))
 
   clusters
     id (UUID), signal_id (UUID), name (String),
-    level (UInt8), parent_id (UUID), num_signal_events (UInt32),
-    num_children_clusters (UInt16),
-    created_at (DateTime64), updated_at (DateTime64)
+    level (UInt8), parent_id (UUID),
+    num_signal_events (UInt32), num_children_clusters (UInt16),
+    created_at (DateTime64(9,'UTC')), updated_at (DateTime64(9,'UTC'))
 
   signal_runs
     signal_id (UUID), job_id (UUID), trigger_id (UUID), run_id (UUID),
-    trace_id (UUID), status (String), event_id (UUID), updated_at (DateTime64)
+    trace_id (UUID), status (String enum signal_run_status),
+    mode (String enum signal_run_mode), event_id (UUID),
+    error_message (String), updated_at (DateTime64(9,'UTC')),
+    input_tokens (UInt32), cache_read_tokens (UInt32),
+    output_tokens (UInt32)
 
-  evaluation_datapoints
-    id (UUID), evaluation_id (UUID), data (String), target (String),
-    metadata (String), executor_output (String), index (UInt64),
-    trace_id (UUID), group_id (String), scores (String),
-    created_at (DateTime64), dataset_id (UUID),
-    dataset_datapoint_id (UUID), dataset_datapoint_created_at (DateTime64)
+  labeling_queue_items
+    id (UUID), queue_id (UUID), payload (String), metadata (String),
+    status (UInt8: 0=unlabeled|1=approved), edit (String),
+    created_at (DateTime64(3,'UTC')), updated_at (DateTime64(3,'UTC'))
 
-  dataset_datapoints
-    id (UUID), created_at (DateTime64), dataset_id (UUID),
-    data (String), target (String), metadata (String)
+Enums:
+  span_type: 'DEFAULT', 'LLM', 'EXECUTOR', 'EVALUATOR', 'EVALUATION', 'TOOL',
+             'HUMAN_EVALUATOR', 'CACHED', 'UNKNOWN'
+  trace_type: 'DEFAULT', 'EVALUATION', 'PLAYGROUND'
+  status: 'success', 'error'
+  signal_run_status: 'PENDING', 'COMPLETED', 'FAILED', 'UNKNOWN'
+  signal_run_mode: 'BATCH', 'REALTIME', 'UNKNOWN'
+
+Joins:
+  spans.trace_id = traces.id
+  signal_events.trace_id = traces.id
+  trace_outputs.trace_id = traces.id
+  has(signal_events.clusters, clusters.id)
+  clusters.parent_id = toUUID('00000000-0000-0000-0000-000000000000') for
+    top-level clusters (nil UUID, not SQL NULL)
 `;

--- a/packages/lmnr-cli/src/commands/sql/schema.ts
+++ b/packages/lmnr-cli/src/commands/sql/schema.ts
@@ -1,109 +1,107 @@
-export const SQL_SCHEMA_HELP = `
-Queries are scoped to your project automatically. There is no project_id
-column — referencing it is rejected.
+import type { LaminarClient } from "@lmnr-ai/client";
+import { errorMessage, type SqlSchema } from "@lmnr-ai/types";
 
-Available tables:
-  spans
-    span_id (UUID), trace_id (UUID), parent_span_id (UUID),
-    name (String), path (String),
-    span_type (String enum span_type), status (String enum status),
-    start_time (DateTime64(9,'UTC')), end_time (DateTime64(9,'UTC')),
-    duration (Decimal(18,9)),
-    input (String), output (String),
-    request_model (String), response_model (String), model (String),
-    provider (String),
-    input_tokens (Int64), output_tokens (Int64), total_tokens (Int64),
-    input_cost (Float64), output_cost (Float64), total_cost (Float64),
-    attributes (String), tags (Array(String)), tool_definitions (String),
-    events (Array(Tuple(timestamp Int64, name String, attributes String)))
+import { resolveBaseUrl } from "../../auth/resolve";
+import type { GlobalOpts } from "../../auth/with-client";
+import { schemaFetchFailed } from "../../errors";
+import { outputJson, printData } from "../../utils/output";
 
-  traces
-    id (UUID), trace_type (String enum trace_type), metadata (String),
-    start_time (DateTime64(9,'UTC')), end_time (DateTime64(9,'UTC')),
-    duration (Float64),
-    input_tokens (Int64), output_tokens (Int64), total_tokens (Int64),
-    cache_read_input_tokens (UInt64), cache_creation_input_tokens (UInt64),
-    reasoning_tokens (UInt64),
-    input_cost (Float64), output_cost (Float64), total_cost (Float64),
-    status (String enum status), user_id (String), session_id (String),
-    top_span_id (UUID), top_span_name (String),
-    top_span_type (String enum span_type),
-    tags (Array(String)), trace_tags (Array(String)),
-    span_names (Array(String)), agent_input (String),
-    has_browser_session (Bool)
+/** Max width before a column list wraps onto a continuation line. */
+const WRAP_WIDTH = 76;
+const INDENT = "    ";
 
-  trace_outputs
-    trace_id (UUID), start_time (DateTime64(9,'UTC')),
-    agent_output (Array(String))
+/**
+ * Wrap `parts` into comma-separated lines at `WRAP_WIDTH`, so a wide table
+ * stays readable in a terminal without truncating anything.
+ */
+const wrapList = (parts: string[]): string[] => {
+  const lines: string[] = [];
+  let current = "";
 
-  evaluation_datapoints
-    id (UUID), evaluation_id (UUID), trace_id (UUID),
-    created_at (DateTime64(9,'UTC')), updated_at (DateTime64(9,'UTC')),
-    data (String), target (String), metadata (String),
-    executor_output (String), index (UInt64), group_id (String),
-    scores (String), dataset_id (UUID), dataset_datapoint_id (UUID),
-    dataset_datapoint_created_at (DateTime64(9,'UTC')),
-    start_time (DateTime64(9,'UTC')), end_time (DateTime64(9,'UTC')),
-    duration (Decimal(18,9)),
-    input_cost (Float64), output_cost (Float64), total_cost (Float64),
-    input_tokens (Int64), output_tokens (Int64), total_tokens (Int64),
-    trace_status (LowCardinality(String) enum status),
-    trace_metadata (String), trace_tags (Array(String)), top_span_id (UUID),
-    trace_spans (Array(Tuple(name String, duration Float64, type String)))
+  for (const [i, part] of parts.entries()) {
+    const piece = i === parts.length - 1 ? part : `${part},`;
+    if (current === "") {
+      current = piece;
+    } else if (`${current} ${piece}`.length + INDENT.length <= WRAP_WIDTH) {
+      current = `${current} ${piece}`;
+    } else {
+      lines.push(current);
+      current = piece;
+    }
+  }
+  if (current !== "") lines.push(current);
 
-  dataset_datapoints
-    id (UUID), created_at (DateTime64(9,'UTC')), dataset_id (UUID),
-    data (String), target (String), metadata (String)
+  return lines;
+};
 
-  dataset_datapoint_versions
-    id (UUID), created_at (DateTime64(9,'UTC')), dataset_id (UUID),
-    data (String), target (String), metadata (String)
+/**
+ * Render the server's schema as the human/agent-facing text block. Column
+ * descriptions are deliberately dropped — the CLI surface is a list of fields
+ * and their types; prose belongs in the docs.
+ */
+export const renderSqlSchema = (schema: SqlSchema): string => {
+  const out: string[] = [
+    "",
+    "Queries are scoped to your project automatically. There is no project_id",
+    "column — referencing it is rejected.",
+    "",
+    "Available tables:",
+  ];
 
-  logs
-    log_id (UUID), time (DateTime64(9,'UTC')),
-    observed_time (DateTime64(9,'UTC')),
-    severity_number (UInt8), severity_text (String), body (String),
-    attributes (String), trace_id (UUID), span_id (UUID),
-    flags (UInt32), event_name (String)
+  for (const table of schema.tables) {
+    out.push(`  ${table.name}`);
+    const cols = table.columns.map((c) => `${c.name} (${c.type})`);
+    out.push(...wrapList(cols).map((line) => `${INDENT}${line}`));
+    out.push("");
+  }
 
-  signal_events
-    id (UUID), signal_id (UUID), trace_id (UUID), run_id (UUID),
-    name (String), payload (String), timestamp (DateTime64(9,'UTC')),
-    severity (UInt8: 0=INFO|1=WARNING|2=CRITICAL), summary (String),
-    clusters (Array(UUID))
+  if (schema.enums.length > 0) {
+    out.push("Enums:");
+    for (const e of schema.enums) {
+      // Hang the continuation under the values, not under the enum name, so a
+      // long list (span_type has 9) stays inside the terminal width.
+      const [first, ...rest] = wrapList(e.values.map((v) => `'${v}'`));
+      out.push(`  ${e.name}: ${first}`);
+      const hang = " ".repeat(`  ${e.name}: `.length);
+      out.push(...rest.map((line) => `${hang}${line}`));
+    }
+    out.push("");
+  }
 
-  clusters
-    id (UUID), signal_id (UUID), name (String),
-    level (UInt8), parent_id (UUID),
-    num_signal_events (UInt32), num_children_clusters (UInt16),
-    created_at (DateTime64(9,'UTC')), updated_at (DateTime64(9,'UTC'))
+  return out.join("\n");
+};
 
-  signal_runs
-    signal_id (UUID), job_id (UUID), trigger_id (UUID), run_id (UUID),
-    trace_id (UUID), status (String enum signal_run_status),
-    mode (String enum signal_run_mode), event_id (UUID),
-    error_message (String), updated_at (DateTime64(9,'UTC')),
-    input_tokens (UInt32), cache_read_tokens (UInt32),
-    output_tokens (UInt32)
+/**
+ * Print the schema the SERVER reports. Pure handler — `withProjectClient` owns
+ * the client and error envelope.
+ *
+ * There is no bundled fallback on purpose: a local copy is what drifted last
+ * time (it advertised columns that did not exist), so an unreachable API is an
+ * error, not a reason to print a stale guess.
+ */
+export const handleSqlSchema = async (
+  client: LaminarClient,
+  opts: GlobalOpts,
+): Promise<void> => {
+  let schema: SqlSchema;
+  try {
+    schema = await client.sql.schema();
+  } catch (err) {
+    // A bare `fetch failed` names neither the host nor the fix, and this is
+    // exactly when the user is already misconfigured (a stale LMNR_BASE_URL in
+    // a project `.env` is the common case).
+    const url = resolveBaseUrl(opts.baseUrl);
+    throw schemaFetchFailed(
+      `Could not fetch the SQL schema from ${url}: ${errorMessage(err)}. ` +
+      "Check your connection, or that --base-url / LMNR_BASE_URL points at a " +
+      "reachable Laminar API.",
+    );
+  }
 
-  labeling_queue_items
-    id (UUID), queue_id (UUID), payload (String), metadata (String),
-    status (UInt8: 0=unlabeled|1=approved), edit (String),
-    created_at (DateTime64(3,'UTC')), updated_at (DateTime64(3,'UTC'))
+  if (opts.json) {
+    outputJson(schema);
+    return;
+  }
 
-Enums:
-  span_type: 'DEFAULT', 'LLM', 'EXECUTOR', 'EVALUATOR', 'EVALUATION', 'TOOL',
-             'HUMAN_EVALUATOR', 'CACHED', 'UNKNOWN'
-  trace_type: 'DEFAULT', 'EVALUATION', 'PLAYGROUND'
-  status: 'success', 'error'
-  signal_run_status: 'PENDING', 'COMPLETED', 'FAILED', 'UNKNOWN'
-  signal_run_mode: 'BATCH', 'REALTIME', 'UNKNOWN'
-
-Joins:
-  spans.trace_id = traces.id
-  signal_events.trace_id = traces.id
-  trace_outputs.trace_id = traces.id
-  has(signal_events.clusters, clusters.id)
-  clusters.parent_id = toUUID('00000000-0000-0000-0000-000000000000') for
-    top-level clusters (nil UUID, not SQL NULL)
-`;
+  printData(renderSqlSchema(schema));
+};

--- a/packages/lmnr-cli/src/errors.ts
+++ b/packages/lmnr-cli/src/errors.ts
@@ -37,6 +37,7 @@ export const setupKeyFailed = (m: string) => new CliError("setup_key_failed", 9,
 export const mintFailed = (m: string) => new CliError("mint_failed", 9, m);
 export const configWriteFailed = (m: string) => new CliError("config_write_failed", 8, m);
 export const unsupportedAgent = (m: string) => new CliError("unsupported_agent", 13, m);
+export const schemaFetchFailed = (m: string) => new CliError("schema_fetch_failed", 15, m);
 
 /**
  * Bare exit codes for the two sites that DON'T go through `failWith`: each emits

--- a/packages/lmnr-cli/src/index.ts
+++ b/packages/lmnr-cli/src/index.ts
@@ -28,7 +28,7 @@ import { handleProjectMintKey } from "./commands/project/mint-key";
 import { handleSetup } from "./commands/setup";
 import { handleSkillAdd, handleSkillUpdate } from "./commands/skill";
 import { handleSqlQuery } from "./commands/sql";
-import { SQL_SCHEMA_HELP } from "./commands/sql/schema";
+import { handleSqlSchema } from "./commands/sql/schema";
 import { handleStatus } from "./commands/status";
 import { pc } from "./utils/colors";
 import { loadLocalEnv } from "./utils/env-file";
@@ -193,8 +193,10 @@ async function main() {
     .action(withProjectClient(handleSqlQuery))
     .addHelpText(
       "after",
-      SQL_SCHEMA_HELP +
       `
+Run \`lmnr-cli sql schema\` for the tables and columns you can query. The
+schema is served by the API, so it always matches the running server.
+
 When a debug session is active in this directory, the command (and its args) is
 recorded into that session as a \`command\` block so a reviewer sees what ran.
 The raw query string is uploaded. Attach agent reasoning with --reasoning.
@@ -216,9 +218,21 @@ Examples:
   sqlCmd
     .command("schema")
     .description("Show available tables and their columns")
-    .action(() => {
-      process.stdout.write(SQL_SCHEMA_HELP);
-    });
+    .action(withProjectClient(handleSqlSchema))
+    .addHelpText(
+      "after",
+      `
+Fetched from the API, so it reflects the server you are pointed at rather than
+a copy bundled with this CLI. Requires login and network access.
+
+Use --json for the raw payload ({ tables, enums }), which is easier to parse
+than the default text rendering.
+
+Examples:
+  $ lmnr-cli sql schema
+  $ lmnr-cli sql schema --json
+`,
+    );
 
   const askCmd = program
     .command("ask")

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -4,5 +4,6 @@ export * from "./debug-session";
 export * from "./evaluation";
 export * from "./initialize-options";
 export * from "./session-block";
+export * from "./sql-schema";
 export * from "./tracing";
 export * from "./utils";

--- a/packages/types/src/sql-schema.ts
+++ b/packages/types/src/sql-schema.ts
@@ -18,7 +18,10 @@ export interface SqlSchemaColumn {
   description: string;
 }
 
-/** One logical table. The caller writes this name; the engine rewrites it to a project-scoped view. */
+/**
+ * One logical table. The caller writes this name; the engine rewrites it to a
+ * project-scoped view.
+ */
 export interface SqlSchemaTable {
   name: string;
   description: string;

--- a/packages/types/src/sql-schema.ts
+++ b/packages/types/src/sql-schema.ts
@@ -1,0 +1,38 @@
+/**
+ * Shared contract for `GET /v1/sql/schema` (and its `/v1/cli` twin) — the
+ * logical tables, columns, and enums the SQL engine exposes.
+ *
+ * The server serializes this straight from app-server's
+ * `query_engine::schema` consts, which also render the MCP `query_laminar_sql`
+ * tool description and the Platform Agent prompt. That is the point: the CLI
+ * used to carry a hand-maintained copy, and it drifted badly enough to
+ * advertise columns that did not exist. Do NOT reintroduce a local copy —
+ * `lmnr-cli sql schema` renders whatever the server returns.
+ */
+
+/** One column of a queryable table. `type` is the ClickHouse type as a string. */
+export interface SqlSchemaColumn {
+  name: string;
+  /** ClickHouse type, e.g. `UUID`, `DateTime64(9,'UTC')`, `String (enum status)`. */
+  type: string;
+  description: string;
+}
+
+/** One logical table. The caller writes this name; the engine rewrites it to a project-scoped view. */
+export interface SqlSchemaTable {
+  name: string;
+  description: string;
+  columns: SqlSchemaColumn[];
+}
+
+/** A constrained column and the literals it accepts. */
+export interface SqlSchemaEnum {
+  name: string;
+  values: string[];
+}
+
+/** Full response body of the schema endpoint. */
+export interface SqlSchema {
+  tables: SqlSchemaTable[];
+  enums: SqlSchemaEnum[];
+}


### PR DESCRIPTION
## Why

`lmnr-cli sql schema` shipped a hand-maintained copy of the SQL schema, and it had drifted badly from production. Agents write queries from that text, so every gap is a query that fails or silently misses data.

Two commits: the first corrects the copy, the second deletes it so it cannot drift again.

## 1. Correct the schema (`1248684`)

Verified empirically — a live row queried from all 10 tables across 36 projects, every column type read with `toTypeName(...)`.

- **4 missing tables**: `trace_outputs`, `logs`, `labeling_queue_items`, `dataset_datapoint_versions`
- **~25 missing columns**, including all the denormalized trace data on `evaluation_datapoints`
- **Wrong types**: `spans.duration` and `evaluation_datapoints.duration` are `Decimal(18, 9)`, not `Float64`. `traces.duration` really is `Float64` — the three are not consistent.
- **Wrong enum**: `span_type` listed 3 of its 9 values

## 2. Fetch it instead (`f07c049`)

`sql schema` now calls `GET /v1/cli/sql/schema` (lmnr-ai/lmnr#2192) and renders the response. The server serializes the same const tables that render the MCP `query_laminar_sql` tool description and the Platform Agent prompt — one source, three consumers.

- `@lmnr-ai/types` — `SqlSchema` wire contract
- `@lmnr-ai/client` — `client.sql.schema()`
- `lmnr-cli` — `handleSqlSchema` + `renderSqlSchema`, through `withProjectClient`

### Behavior changes worth a look

**`sql schema` now requires login and network access.** There is deliberately no bundled fallback: a stale local copy is exactly the bug being removed, so an unreachable API is an error rather than a reason to print a guess. This is a real regression for a discovery command that used to work offline — flagging it explicitly since it is a judgment call, not an oversight.

It fails with error code `schema_fetch_failed`, exit 15, and names the URL it tried:

```
$ lmnr-cli sql schema --json
{"error":"Could not fetch the SQL schema from http://localhost: fetch failed.
          Check your connection, or that --base-url / LMNR_BASE_URL points at
          a reachable Laminar API."}
```

That wording is deliberate. A bare `fetch failed` names neither the host nor the fix, and this fires exactly when the user is already misconfigured — a stale `LMNR_BASE_URL` in a project `.env` is the common case.

**`sql query --help` no longer inlines the schema.** It would be stale-by-construction. It points at `sql schema` instead.

**`sql schema --json`** emits the raw `{tables, enums}` payload, which keeps the per-column descriptions the text rendering drops.

## Verification

- End-to-end against the **real** payload: dumped the exact JSON the Rust endpoint emits from the compiled code, served it, and ran the built CLI against it. All 11 tables and 5 enums render correctly; `--json` round-trips with descriptions intact. This caught two real bugs — enum lines overflowing the terminal width, and `labeling_queue_items` timestamps being wrong in `schema.rs`.
- Failure path verified: unreachable API exits 15 with the message above, in both text and `--json` mode.
- 6 new unit tests for `renderSqlSchema`, including a line-width regression test.
- `pnpm --filter lmnr-cli test` — **211 pass, 0 fail** (25 files)
- `pnpm -r lint` — 0 errors

### A note on the test suite

I reported "9 pre-existing failures" earlier in this branch's life. That was wrong in an important way. The failures were real, but the cause was environmental, not code: `tsx` was broken in the worktree (a stale pnpm shim pointing at a removed `tsx@4.21.0`), and both integration suites shell out to `npx tsx`. After repairing the install, **all 211 tests pass**. No test was skipped or weakened to get there.

Worth knowing separately: `packages/lmnr-cli` uses `tsx` in its integration tests and `dev` script but does not declare it — it resolves from the root. That is what made the shim breakage possible. Not fixed here, since it is a dependency-declaration change unrelated to this PR.

Paired with lmnr-ai/lmnr#2192 (endpoint) and lmnr-ai/docs#208 (docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes a discovery command from offline to network-dependent and ties agent-facing schema text to server availability; client/API surface is additive with focused error handling.
> 
> **Overview**
> **`lmnr-cli sql schema` now loads schema from the API** instead of printing a hand-maintained string that had drifted from production. The CLI calls `client.sql.schema()` (new on `@lmnr-ai/client`), types the response with shared **`SqlSchema`** in `@lmnr-ai/types`, and renders tables/columns/enums with terminal-friendly wrapping. **`--json`** returns the raw payload (including column descriptions the text view omits).
> 
> **Operational change:** the command goes through **`withProjectClient`**, so it needs login and a reachable API—there is no offline fallback. Fetch failures use a new **`schema_fetch_failed`** error (exit 15) and message that includes the resolved URL via **`LaminarClient.apiBaseUrl`** (avoids bad `baseUrl` + `port` reconstruction in errors). **`sql query --help`** no longer inlines schema; it points users to **`sql schema`**.
> 
> CLI version **0.4.2**; unit tests cover rendering and failure URL formatting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3f5054908114af50d3bb94496341c49bcc82b99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->