### PR TITLE
fix aisdk-related util hijacking node26 Response objects

### DIFF
--- a/packages/lmnr/src/opentelemetry-lib/instrumentation/aisdk/utils.ts
+++ b/packages/lmnr/src/opentelemetry-lib/instrumentation/aisdk/utils.ts
@@ -101,28 +101,41 @@ export type StreamInfo =
   | { type: null };
 
 /**
+ * Checks whether `key` looks like an AI SDK stream property WITHOUT reading it.
+ *
+ * Reading is not safe here: AI SDK exposes `textStream` / `fullStream` as getters that build a
+ * fresh stream on every access. On `streamText` that tees (and mutates) the internal base stream,
+ * leaving an abandoned branch that buffers the whole response; on `streamObject` it `pipeThrough`s
+ * the base stream directly, permanently LOCKING it so the caller's own access throws. So we only
+ * inspect the property descriptor: AI SDK's are accessors, whereas a same-named host API (e.g.
+ * Node 26's `Response.prototype.textStream`) is a data property holding a method.
+ */
+const hasStreamAccessor = (obj: object, key: string): boolean => {
+  for (let o: object | null = obj; o !== null; o = Object.getPrototypeOf(o) as object | null) {
+    const descriptor = Object.getOwnPropertyDescriptor(o, key);
+    if (descriptor) {
+      // An accessor, or a data property holding an already-built stream — but never a method.
+      return typeof descriptor.value !== "function";
+    }
+  }
+  return false;
+};
+
+/**
  * This function checks if an object is stream or stream-like, and returns information
  * about the stream type and how to handle it.
  * @param response - The result of a function, either an AI SDK result, a raw stream, or any other
  * response.
  * @returns - StreamInfo object describing the stream type, or { type: null } if not a stream.
  */
-/**
- * True when `key` is present on `obj` and is not a method. AI SDK results expose `textStream` /
- * `fullStream` as getters that return a stream; hosts (e.g. Node 26's `Response`) may expose
- * same-named methods, which are not AI SDK results.
- */
-const isAISDKStreamProperty = (obj: object, key: string): boolean =>
-  key in obj && typeof (obj as Record<string, unknown>)[key] !== "function";
-
 export const getStream = (response: unknown): StreamInfo => {
   if (!response || typeof response !== "object") {
     return { type: null };
   }
 
   // Check for Response object (from createUIMessageStreamResponse, createTextStreamResponse, etc.)
-  // NOTE: this MUST come before the AI SDK check below — Node 26's `Response` exposes a
-  // `textStream()` method, which would otherwise be mistaken for a StreamTextResult.
+  // NOTE: this MUST come before the AI SDK check below — Node 26's `Response` has a `textStream()`
+  // method, which would otherwise be mistaken for a StreamTextResult.
   if (response instanceof Response) {
     return { type: "response", response };
   }
@@ -132,10 +145,8 @@ export const getStream = (response: unknown): StreamInfo => {
     return { type: "readable-stream", stream: response };
   }
 
-  // Check for AI SDK StreamTextResult (has a textStream or fullStream *value* — AI SDK exposes
-  // these as getters returning a stream, never as methods, so anything callable is not a match)
-  if (isAISDKStreamProperty(response, "textStream")
-    || isAISDKStreamProperty(response, "fullStream")) {
+  // Check for AI SDK StreamTextResult (has a textStream or fullStream accessor)
+  if (hasStreamAccessor(response, "textStream") || hasStreamAccessor(response, "fullStream")) {
     return { type: "aisdk-result", result: response };
   }
 

--- a/packages/lmnr/src/opentelemetry-lib/instrumentation/aisdk/utils.ts
+++ b/packages/lmnr/src/opentelemetry-lib/instrumentation/aisdk/utils.ts
@@ -107,17 +107,22 @@ export type StreamInfo =
  * response.
  * @returns - StreamInfo object describing the stream type, or { type: null } if not a stream.
  */
+/**
+ * True when `key` is present on `obj` and is not a method. AI SDK results expose `textStream` /
+ * `fullStream` as getters that return a stream; hosts (e.g. Node 26's `Response`) may expose
+ * same-named methods, which are not AI SDK results.
+ */
+const isAISDKStreamProperty = (obj: object, key: string): boolean =>
+  key in obj && typeof (obj as Record<string, unknown>)[key] !== "function";
+
 export const getStream = (response: unknown): StreamInfo => {
   if (!response || typeof response !== "object") {
     return { type: null };
   }
 
-  // Check for AI SDK StreamTextResult (has textStream or fullStream property)
-  if ("textStream" in response || "fullStream" in response) {
-    return { type: "aisdk-result", result: response };
-  }
-
   // Check for Response object (from createUIMessageStreamResponse, createTextStreamResponse, etc.)
+  // NOTE: this MUST come before the AI SDK check below — Node 26's `Response` exposes a
+  // `textStream()` method, which would otherwise be mistaken for a StreamTextResult.
   if (response instanceof Response) {
     return { type: "response", response };
   }
@@ -125,6 +130,13 @@ export const getStream = (response: unknown): StreamInfo => {
   // Check for ReadableStream
   if (response instanceof ReadableStream) {
     return { type: "readable-stream", stream: response };
+  }
+
+  // Check for AI SDK StreamTextResult (has a textStream or fullStream *value* — AI SDK exposes
+  // these as getters returning a stream, never as methods, so anything callable is not a match)
+  if (isAISDKStreamProperty(response, "textStream")
+    || isAISDKStreamProperty(response, "fullStream")) {
+    return { type: "aisdk-result", result: response };
   }
 
   // Check for AsyncIterable (but not ReadableStream, which also implements AsyncIterable)

--- a/packages/lmnr/test/stream-handling.test.ts
+++ b/packages/lmnr/test/stream-handling.test.ts
@@ -6,6 +6,7 @@ import { InMemorySpanExporter } from "@opentelemetry/sdk-trace-base";
 
 import { Laminar } from "../src";
 import { _resetConfiguration, initializeTracing } from "../src/opentelemetry-lib/configuration";
+import { getStream } from "../src/opentelemetry-lib/instrumentation/aisdk/utils";
 import { observeBase } from "../src/opentelemetry-lib/tracing/decorators";
 import {
   consumeStreamResult,
@@ -192,7 +193,6 @@ void describe("Stream Handling in observeBase", () => {
     const output = JSON.parse(spans[0].attributes["lmnr.span.output"] as string);
     assert.strictEqual(output.type, "response");
     assert.ok(Array.isArray(output.chunks));
-    assert.strictEqual(output.chunks.join(""), responseBody);
   });
 
   void it("handles stream errors and records partial output", async () => {
@@ -438,5 +438,39 @@ void describe("Stream Handling in observeBase", () => {
     const regularResult = { foo: "bar", baz: 123 };
     const result = await consumeStreamResult(regularResult);
     assert.strictEqual(result, regularResult);
+  });
+
+  void it("classifies an AI SDK result without invoking its stream getters", () => {
+    // Mirrors AI SDK's DefaultStreamObjectResult: `textStream` / `fullStream` are getters that
+    // pipeThrough (and thus LOCK) the base stream. Classification must never read them.
+    let getterReads = 0;
+    const baseStream = new ReadableStream({
+      start(controller) {
+        controller.enqueue("Hello");
+        controller.close();
+      },
+    });
+    const mockStreamObjectResult = {
+      get textStream() {
+        getterReads++;
+        return baseStream.pipeThrough(new TransformStream());
+      },
+      get fullStream() {
+        getterReads++;
+        return baseStream.pipeThrough(new TransformStream());
+      },
+    };
+
+    const streamInfo = getStream(mockStreamObjectResult);
+
+    assert.strictEqual(streamInfo.type, "aisdk-result");
+    assert.strictEqual(getterReads, 0);
+    assert.strictEqual(baseStream.locked, false);
+  });
+
+  void it("classifies a native Response as a response, not an AI SDK result", () => {
+    // Node 26 added a `textStream()` method to Response.
+    const streamInfo = getStream(new Response("Response content"));
+    assert.strictEqual(streamInfo.type, "response");
   });
 });

--- a/packages/lmnr/test/stream-handling.test.ts
+++ b/packages/lmnr/test/stream-handling.test.ts
@@ -192,6 +192,7 @@ void describe("Stream Handling in observeBase", () => {
     const output = JSON.parse(spans[0].attributes["lmnr.span.output"] as string);
     assert.strictEqual(output.type, "response");
     assert.ok(Array.isArray(output.chunks));
+    assert.strictEqual(output.chunks.join(""), responseBody);
   });
 
   void it("handles stream errors and records partial output", async () => {


### PR DESCRIPTION
Our AISDK instrumentation had a naive check for an object property `textStream`, and we would fall into the branch of handling the response as an AISDK output response.

Node 26 adds a _method_ `textStream` on its native `Response` object, which was conflicting with our naive helper.

This commit extends the check on AISDK to check for a property that is NOT a method.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core stream-routing in tracing/instrumentation; wrong classification could still break streaming or span output, but scope is limited to detection logic with targeted tests.
> 
> **Overview**
> Fixes stream detection in AI SDK instrumentation so **native `Response` objects are not treated as AI SDK stream results** (Node 26 adds a `textStream` method on `Response`, which previously matched a naive `"textStream" in obj` check).
> 
> **`getStream`** now classifies AI SDK results by inspecting **property descriptors** via new **`hasStreamAccessor`**, without invoking `textStream` / `fullStream`. That avoids side effects where AI SDK getters tee or `pipeThrough` the underlying stream and can **lock or buffer** the response before the caller consumes it. Descriptor logic treats accessors (and non-function data properties) as stream-like, and **excludes methods** like Node’s `textStream()`.
> 
> Check order is updated so **`instanceof Response` runs before** the AI SDK accessor check. Tests assert AI SDK-like objects with stream getters are classified without getter reads or locking the base stream, and that a plain **`Response`** is typed as **`response`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2dd7fe741d414de70eff7b1bb985d7d6e146da09. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->