### PR TITLE
bump lmnr-cli version to 0.5.0

### DIFF
--- a/packages/lmnr-cli/package.json
+++ b/packages/lmnr-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lmnr-cli",
-  "version": "0.4.4",
+  "version": "0.5.0",
   "description": "CLI for the Laminar agent observability platform",
   "main": "dist/index.cjs",
   "bin": {


### PR DESCRIPTION
node engine is now requires 22.12.0 due to commander 15

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Package version bump only; no code, auth, or data-handling changes.
> 
> **Overview**
> Bumps the published `lmnr-cli` package version from `0.4.4` to `0.5.0`. No other files or runtime behavior change in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e4e518d372167fe4223fa613f82b07930a7d49f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->