### PR TITLE
cli: llm profiles in signals

### DIFF
--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -4,6 +4,7 @@ import { DatasetsResource } from "./resources/datasets";
 import { EvalsResource } from "./resources/evals";
 import { EvaluatorsResource } from "./resources/evaluators";
 import { type LaminarAuth } from "./resources/index";
+import { LlmProfilesResource } from "./resources/llm-profiles";
 import { RolloutSessionsResource } from "./resources/rollout-sessions";
 import { SignalsResource } from "./resources/signals";
 import { SqlResource } from "./resources/sql";
@@ -20,6 +21,7 @@ export class LaminarClient {
   private _datasets: DatasetsResource;
   private _evals: EvalsResource;
   private _evaluators: EvaluatorsResource;
+  private _llmProfiles: LlmProfilesResource;
   private _rolloutSessions: RolloutSessionsResource;
   private _signals: SignalsResource;
   private _sql: SqlResource;
@@ -79,6 +81,7 @@ export class LaminarClient {
     this._datasets = new DatasetsResource(this.baseUrl, this.auth);
     this._evals = new EvalsResource(this.baseUrl, this.auth);
     this._evaluators = new EvaluatorsResource(this.baseUrl, this.auth);
+    this._llmProfiles = new LlmProfilesResource(this.baseUrl, this.auth);
     this._rolloutSessions = new RolloutSessionsResource(
       this.baseUrl,
       this.auth,
@@ -161,6 +164,10 @@ export class LaminarClient {
 
   public get evaluators() {
     return this._evaluators;
+  }
+
+  public get llmProfiles() {
+    return this._llmProfiles;
   }
 
   public get signals() {

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -193,6 +193,11 @@ export class LaminarClient {
 
 export type { CliProject, ProjectKeyProbe } from "./resources/cli";
 export type { LaminarAuth } from "./resources/index";
+export type {
+  CreateLlmProfileOptions,
+  LlmProfileSecretsInput,
+  UpdateLlmProfileOptions,
+} from "./resources/llm-profiles";
 export {
   type CacheOutcome,
   RolloutSessionsResource,

--- a/packages/client/src/resources/llm-profiles.ts
+++ b/packages/client/src/resources/llm-profiles.ts
@@ -1,0 +1,60 @@
+import { type LlmProfileOption } from "@lmnr-ai/types";
+
+import { BaseResource, type LaminarAuth } from ".";
+
+/**
+ * Workspace LLM profile discovery for the CLI. Hits
+ * `GET /v1/cli/llm-profiles`, which returns the caller's project's workspace
+ * profiles (id + name + provider + models) so `lmnr-cli signal create
+ * --llm-profile <name> --model <name>` can be discovered offline.
+ *
+ * Self-hosted only: on Laminar Cloud the server 404s with
+ * `{error: "LLM profiles are not available on Laminar Cloud"}`.
+ */
+export class LlmProfilesResource extends BaseResource {
+  constructor(baseHttpUrl: string, auth: LaminarAuth) {
+    super(baseHttpUrl, auth);
+  }
+
+  /**
+   * Errors come back as `{error: string}` (matches the signals surface) with
+   * user-facing text, so unwrap the envelope before raising rather than
+   * showing the raw JSON body.
+   */
+  private async raiseLlmProfileError(response: Response): Promise<never> {
+    const body = await response.text();
+    let message = body;
+    try {
+      const parsed = JSON.parse(body) as { error?: unknown };
+      if (typeof parsed?.error === "string" && parsed.error.length > 0) {
+        message = parsed.error;
+      }
+    } catch {
+      // Not JSON (proxy error page etc.) — use it as-is.
+    }
+    throw new Error(`${response.status} ${message}`);
+  }
+
+  /**
+   * Every workspace LLM profile visible to the caller, ordered
+   * case-insensitively by name. Empty array on a workspace with no profiles.
+   */
+  public async list(): Promise<LlmProfileOption[]> {
+    const response = await fetch(
+      `${this.baseHttpUrl}${this.apiPrefix}/llm-profiles`,
+      {
+        method: "GET",
+        headers: this.headers(),
+      },
+    );
+    if (!response.ok) {
+      await this.raiseLlmProfileError(response);
+    }
+    // Coerce a missing/non-array `llmProfiles` to [] so callers can .map/.length
+    // it; a malformed 2xx body is exceptional, not the normal empty case.
+    const body = (await response.json()) as {
+      llmProfiles?: LlmProfileOption[];
+    };
+    return Array.isArray(body?.llmProfiles) ? body.llmProfiles : [];
+  }
+}

--- a/packages/client/src/resources/llm-profiles.ts
+++ b/packages/client/src/resources/llm-profiles.ts
@@ -1,15 +1,49 @@
-import { type LlmProfileOption } from "@lmnr-ai/types";
+import {
+  type LlmProfile,
+  type LlmProfileConfig,
+  type LlmProfileProvider,
+} from "@lmnr-ai/types";
 
 import { BaseResource, type LaminarAuth } from ".";
 
 /**
- * Workspace LLM profile discovery for the CLI. Hits
- * `GET /v1/cli/llm-profiles`, which returns the caller's project's workspace
- * profiles (id + name + provider + models) so `lmnr-cli signal create
- * --llm-profile <name> --model <name>` can be discovered offline.
- *
- * Self-hosted only: on Laminar Cloud the server 404s with
- * `{error: "LLM profiles are not available on Laminar Cloud"}`.
+ * Plaintext secrets for create/update. On update this is an OVERLAY: an
+ * omitted key keeps the stored secret, so credentials never need re-sending.
+ */
+export interface LlmProfileSecretsInput {
+  apiKey?: string;
+  secretAccessKey?: string;
+  token?: string;
+  /** Values for the `custom` provider's `config.headerNames`. */
+  headers?: Record<string, string>;
+}
+
+export interface CreateLlmProfileOptions {
+  name: string;
+  provider: LlmProfileProvider;
+  /** Omitted `auth` defaults to `{type: "api_key"}`. */
+  config?: Partial<LlmProfileConfig>;
+  secrets?: LlmProfileSecretsInput;
+  models: string[];
+}
+
+/**
+ * A partial patch: omitted fields keep their stored value. `models` replaces
+ * the whole list when present; `config` is required when `provider` changes.
+ */
+export interface UpdateLlmProfileOptions {
+  name?: string;
+  provider?: LlmProfileProvider;
+  config?: Partial<LlmProfileConfig>;
+  secrets?: LlmProfileSecretsInput;
+  models?: string[];
+}
+
+/**
+ * Workspace LLM profile CRUD over the CLI user-token surface
+ * (`/v1/cli/llm-profiles`). Validation is entirely server-side; error messages
+ * come back user-ready. Self-hosted only: on Laminar Cloud every route 404s
+ * with `{error: "LLM profiles are not available on this deployment"}`.
  */
 export class LlmProfilesResource extends BaseResource {
   constructor(baseHttpUrl: string, auth: LaminarAuth) {
@@ -35,26 +69,61 @@ export class LlmProfilesResource extends BaseResource {
     throw new Error(`${response.status} ${message}`);
   }
 
-  /**
-   * Every workspace LLM profile visible to the caller, ordered
-   * case-insensitively by name. Empty array on a workspace with no profiles.
-   */
-  public async list(): Promise<LlmProfileOption[]> {
+  private async request(
+    method: string,
+    path: string,
+    body?: unknown,
+  ): Promise<Response> {
     const response = await fetch(
-      `${this.baseHttpUrl}${this.apiPrefix}/llm-profiles`,
+      `${this.baseHttpUrl}${this.apiPrefix}/llm-profiles${path}`,
       {
-        method: "GET",
+        method,
         headers: this.headers(),
+        ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
       },
     );
     if (!response.ok) {
       await this.raiseLlmProfileError(response);
     }
+    return response;
+  }
+
+  /**
+   * Every workspace LLM profile visible to the caller, ordered
+   * case-insensitively by name. Empty array on a workspace with no profiles.
+   */
+  public async list(): Promise<LlmProfile[]> {
+    const response = await this.request("GET", "");
     // Coerce a missing/non-array `llmProfiles` to [] so callers can .map/.length
     // it; a malformed 2xx body is exceptional, not the normal empty case.
-    const body = (await response.json()) as {
-      llmProfiles?: LlmProfileOption[];
-    };
+    const body = (await response.json()) as { llmProfiles?: LlmProfile[] };
     return Array.isArray(body?.llmProfiles) ? body.llmProfiles : [];
+  }
+
+  public async get(profileId: string): Promise<LlmProfile> {
+    const response = await this.request("GET", `/${profileId}`);
+    return response.json() as Promise<LlmProfile>;
+  }
+
+  public async create(options: CreateLlmProfileOptions): Promise<LlmProfile> {
+    const response = await this.request("POST", "", options);
+    return response.json() as Promise<LlmProfile>;
+  }
+
+  public async update(
+    profileId: string,
+    options: UpdateLlmProfileOptions,
+  ): Promise<LlmProfile> {
+    const response = await this.request("PATCH", `/${profileId}`, options);
+    return response.json() as Promise<LlmProfile>;
+  }
+
+  /**
+   * Deletes the profile and returns it. The server refuses (409) when any
+   * signal still routes through the profile.
+   */
+  public async delete(profileId: string): Promise<LlmProfile> {
+    const response = await this.request("DELETE", `/${profileId}`);
+    return response.json() as Promise<LlmProfile>;
   }
 }

--- a/packages/client/src/resources/signals.ts
+++ b/packages/client/src/resources/signals.ts
@@ -21,11 +21,20 @@ export interface CreateSignalOptions {
   filters?: SignalFilter[];
   /** Defaults to `"realtime"`. */
   mode?: SignalMode;
+  /**
+   * Workspace LLM profile name. Required together with `model` on self-hosted
+   * deployments; rejected on Laminar Cloud (the server has env-configured LLMs).
+   */
+  llmProfile?: string;
+  /** One of the profile's models. Required together with `llmProfile`. */
+  model?: string;
 }
 
 /**
  * A partial patch. Every field is optional and an ABSENT field leaves the stored
  * value alone. `sampleRate: null` clears sampling, `filters: []` clears filters.
+ * `llmProfile` + `model` must be sent together to re-route; the wire has no
+ * shape for clearing the route back to the server's env LLM.
  */
 export interface UpdateSignalOptions {
   prompt?: string;
@@ -35,6 +44,8 @@ export interface UpdateSignalOptions {
   trigger?: SignalTrigger;
   filters?: SignalFilter[];
   mode?: SignalMode;
+  llmProfile?: string;
+  model?: string;
 }
 
 /** Signals CRUD over the CLI user-token surface (`/v1/cli/signals`). */

--- a/packages/client/src/resources/signals.ts
+++ b/packages/client/src/resources/signals.ts
@@ -22,18 +22,19 @@ export interface CreateSignalOptions {
   /** Defaults to `"realtime"`. */
   mode?: SignalMode;
   /**
-   * Workspace LLM profile name. Required together with `model` on self-hosted
-   * deployments; rejected on Laminar Cloud (the server has env-configured LLMs).
+   * Workspace LLM profile id (discover via `llmProfiles.list()`). Required
+   * together with `model` on self-hosted deployments; rejected on Laminar
+   * Cloud (the server has env-configured LLMs).
    */
-  llmProfile?: string;
-  /** One of the profile's models. Required together with `llmProfile`. */
+  llmProfileId?: string;
+  /** One of the profile's models. Required together with `llmProfileId`. */
   model?: string;
 }
 
 /**
  * A partial patch. Every field is optional and an ABSENT field leaves the stored
  * value alone. `sampleRate: null` clears sampling, `filters: []` clears filters.
- * `llmProfile` + `model` must be sent together to re-route; the wire has no
+ * `llmProfileId` + `model` must be sent together to re-route; the wire has no
  * shape for clearing the route back to the server's env LLM.
  */
 export interface UpdateSignalOptions {
@@ -44,7 +45,7 @@ export interface UpdateSignalOptions {
   trigger?: SignalTrigger;
   filters?: SignalFilter[];
   mode?: SignalMode;
-  llmProfile?: string;
+  llmProfileId?: string;
   model?: string;
 }
 

--- a/packages/lmnr-cli/CLAUDE.md
+++ b/packages/lmnr-cli/CLAUDE.md
@@ -56,6 +56,33 @@ This is a CLI for the Laminar agent observability platform.
   `raiseSignalError` instead of `BaseResource.handleError`: signal routes answer
   `{error: "<message>"}` with user-facing text, and the shared handler would
   print the raw JSON body at the user (`409 {"error":"..."}`).
+- **`--llm-profile <name>` + `--model <name>` are self-hosted only and pass
+  through untouched.** Both are wire fields in the signals create/update body,
+  they must be sent together (server rejects a half pair with a user-facing
+  400), on Laminar Cloud any pair is rejected with `"LLM profiles are not
+  available on Laminar Cloud"`, and on self-hosted `create` both are REQUIRED.
+  All of that is enforced in `signals/service.rs::resolve_llm_route` and the
+  messages are surfaced verbatim by `raiseSignalError` — do NOT duplicate any
+  of these rules in `validate.ts`. The wire has no shape for CLEARING the route
+  back to the server's env LLM on update; do not invent one.
+
+# LLM profiles (`src/commands/llm-profile/`)
+
+- **The command is discovery-only** (`lmnr-cli llm-profile list`, aliased to
+  `llm-profiles`): it lists the caller's project's workspace profiles with the
+  models each declares so users can feed the printed `Name` / `Models` into
+  `signal create --llm-profile <name> --model <name>`. There is no create /
+  update / delete — profile management lives in the frontend (Settings → LLM
+  profiles), which owns the encryption workflow.
+- Self-hosted only: on Laminar Cloud the server 404s with
+  `{error: "LLM profiles are not available on Laminar Cloud"}` (same envelope
+  the signals routes use). `LlmProfilesResource.raiseLlmProfileError` unwraps
+  it for the same reason `SignalsResource` does — the raw JSON body is not
+  user-facing text.
+- The endpoint is `GET /v1/cli/llm-profiles`, `CliProjectAuth`-scoped, backed
+  by `db::llm_profiles::list_workspace_llm_profile_options` (mirrors the
+  frontend's `listProjectLlmProfileOptions` picker payload — no config, no
+  secrets, no role check beyond project access).
 
 # Package Boundaries
 - `lmnr-cli` is the standalone CLI (`npx lmnr-cli@latest`). It depends on

--- a/packages/lmnr-cli/CLAUDE.md
+++ b/packages/lmnr-cli/CLAUDE.md
@@ -56,33 +56,50 @@ This is a CLI for the Laminar agent observability platform.
   `raiseSignalError` instead of `BaseResource.handleError`: signal routes answer
   `{error: "<message>"}` with user-facing text, and the shared handler would
   print the raw JSON body at the user (`409 {"error":"..."}`).
-- **`--llm-profile <name>` + `--model <name>` are self-hosted only and pass
-  through untouched.** Both are wire fields in the signals create/update body,
-  they must be sent together (server rejects a half pair with a user-facing
-  400), on Laminar Cloud any pair is rejected with `"LLM profiles are not
-  available on Laminar Cloud"`, and on self-hosted `create` both are REQUIRED.
-  All of that is enforced in `signals/service.rs::resolve_llm_route` and the
-  messages are surfaced verbatim by `raiseSignalError` — do NOT duplicate any
-  of these rules in `validate.ts`. The wire has no shape for CLEARING the route
-  back to the server's env LLM on update; do not invent one.
+- **`--llm-profile-id <uuid>` + `--model <name>` are self-hosted only and pass
+  through untouched** (wire fields `llmProfileId` / `model` in the signals
+  create/update body). They must be sent together (server rejects a half pair
+  with a user-facing 400), on Laminar Cloud any pair is rejected, and on
+  self-hosted `create` both are REQUIRED. All of that is enforced in
+  `signals/service.rs::resolve_llm_route` and the messages are surfaced
+  verbatim by `raiseSignalError` — do NOT duplicate any of these rules in
+  `validate.ts`. The wire has no shape for CLEARING the route back to the
+  server's env LLM on update; do not invent one. Responses echo `llmProfileId`
+  + `llmProfileName` (display only) + `model`.
 
 # LLM profiles (`src/commands/llm-profile/`)
 
-- **The command is discovery-only** (`lmnr-cli llm-profile list`, aliased to
-  `llm-profiles`): it lists the caller's project's workspace profiles with the
-  models each declares so users can feed the printed `Name` / `Models` into
-  `signal create --llm-profile <name> --model <name>`. There is no create /
-  update / delete — profile management lives in the frontend (Settings → LLM
-  profiles), which owns the encryption workflow.
-- Self-hosted only: on Laminar Cloud the server 404s with
-  `{error: "LLM profiles are not available on Laminar Cloud"}` (same envelope
+- Full CRUD (`list` / `get <id>` / `create <name>` / `update <id>` /
+  `delete <id>`, group aliased to `llm-profiles`), backed by
+  `/v1/cli/llm-profiles[/{id}]` (`api::v1::cli::llm_profiles`,
+  `CliProjectAuth`; shares `llm/profiles/service.rs` with the frontend routes).
+  Profiles are addressed by UUID everywhere; `list` prints the `ID` column that
+  feeds `signal create --llm-profile-id <id> --model <name>` and the other
+  subcommands.
+- **The CLI does NO validation of provider shapes** — `flags.ts` only maps
+  flags onto the flat `{name, provider, config, secrets, models}` wire body.
+  Which flags a provider needs, url shapes, secret completeness, duplicate
+  names, and in-use (RESTRICT FK) refusals are all server-side and surfaced
+  verbatim. Auth is derived from the flags: `--access-key-id` → `aws_keys`,
+  `--token` → `bearer_token`, else omitted (server defaults to `api_key`).
+- **The provider endpoint flag is `--provider-base-url`, NOT `--base-url`.**
+  The group-level `--base-url` is the Laminar API URL and
+  `optsWithGlobals()` would let a subcommand flag of the same name shadow it —
+  breaking `buildLaminarClient`. Keep the names distinct.
+- **Update semantics come from the server**: omitted fields keep stored values,
+  secrets are an overlay (an omitted secret keeps the stored one — credentials
+  never need re-sending), but `config` is a WHOLE-object replace (any config
+  flag requires re-passing every config field the provider needs) and
+  `--model` replaces the whole model list. `buildProfileConfigAndSecrets`
+  returns `undefined` for config/secrets when none of their flags were passed
+  so the patch omits them — do not send `{}` there.
+- Secrets are write-only: reads return `first3***last3` masks plus custom
+  header names (`LlmProfileSecretMasks`), which `printProfile` shows as-is.
+- Self-hosted only: on Laminar Cloud the server 404s every route with
+  `{error: "LLM profiles are not available on this deployment"}` (same envelope
   the signals routes use). `LlmProfilesResource.raiseLlmProfileError` unwraps
   it for the same reason `SignalsResource` does — the raw JSON body is not
   user-facing text.
-- The endpoint is `GET /v1/cli/llm-profiles`, `CliProjectAuth`-scoped, backed
-  by `db::llm_profiles::list_workspace_llm_profile_options` (mirrors the
-  frontend's `listProjectLlmProfileOptions` picker payload — no config, no
-  secrets, no role check beyond project access).
 
 # Package Boundaries
 - `lmnr-cli` is the standalone CLI (`npx lmnr-cli@latest`). It depends on

--- a/packages/lmnr-cli/src/commands/llm-profile/flags.test.ts
+++ b/packages/lmnr-cli/src/commands/llm-profile/flags.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+
+import { buildProfileConfigAndSecrets, parseHeaderFlag } from "./flags";
+
+void describe("parseHeaderFlag", () => {
+  void it("splits on the first = so the value may contain more", () => {
+    expect(parseHeaderFlag("X-Api-Key=abc=def")).toEqual([
+      "X-Api-Key",
+      "abc=def",
+    ]);
+    expect(parseHeaderFlag(" X-Team =ops")).toEqual(["X-Team", "ops"]);
+  });
+
+  void it("rejects a missing name or missing =", () => {
+    expect(() => parseHeaderFlag("no-equals")).toThrow("Name=Value");
+    expect(() => parseHeaderFlag("=value-only")).toThrow("Name=Value");
+  });
+});
+
+void describe("buildProfileConfigAndSecrets", () => {
+  void it("returns neither object when no shape flag was passed", () => {
+    // Update must send nothing so the server keeps the stored config/secrets.
+    expect(buildProfileConfigAndSecrets({})).toEqual({});
+  });
+
+  void it("derives aws_keys auth and splits secret from config", () => {
+    expect(
+      buildProfileConfigAndSecrets({
+        accessKeyId: "AKIA123",
+        secretAccessKey: "shhh",
+        region: "eu-west-1",
+      }),
+    ).toEqual({
+      config: {
+        auth: { type: "aws_keys", accessKeyId: "AKIA123" },
+        region: "eu-west-1",
+      },
+      secrets: { secretAccessKey: "shhh" },
+    });
+  });
+
+  void it("derives bearer_token auth from --token", () => {
+    expect(
+      buildProfileConfigAndSecrets({ token: "tok", region: "us-east-1" }),
+    ).toEqual({
+      config: { auth: { type: "bearer_token" }, region: "us-east-1" },
+      secrets: { token: "tok" },
+    });
+  });
+
+  void it("omits auth for plain api-key providers (server default)", () => {
+    expect(buildProfileConfigAndSecrets({ apiKey: "sk-1" })).toEqual({
+      secrets: { apiKey: "sk-1" },
+    });
+  });
+
+  void it("puts header names in config and values in secrets", () => {
+    expect(
+      buildProfileConfigAndSecrets({
+        providerBaseUrl: "https://gw.example.com",
+        apiKey: "sk-1",
+        header: ["X-A=1", "X-B=2"],
+      }),
+    ).toEqual({
+      config: {
+        baseUrl: "https://gw.example.com",
+        headerNames: ["X-A", "X-B"],
+      },
+      secrets: { apiKey: "sk-1", headers: { "X-A": "1", "X-B": "2" } },
+    });
+  });
+});

--- a/packages/lmnr-cli/src/commands/llm-profile/flags.ts
+++ b/packages/lmnr-cli/src/commands/llm-profile/flags.ts
@@ -1,0 +1,94 @@
+import type { LlmProfileSecretsInput } from "@lmnr-ai/client";
+import type { LlmProfileAuth, LlmProfileConfig } from "@lmnr-ai/types";
+
+/**
+ * Provider-shape flags shared by `llm-profile create` and `update`. Validation
+ * (which flags a provider needs, url shapes, secret completeness) is entirely
+ * server-side; the CLI only assembles the wire body and surfaces errors
+ * verbatim.
+ */
+export type LlmProfileShapeOpts = {
+  provider?: string;
+  /** Repeatable; the profile's model list (replaced wholesale on update). */
+  model?: string[];
+  apiKey?: string;
+  /** Bedrock AWS-keys auth (with --secret-access-key). */
+  accessKeyId?: string;
+  secretAccessKey?: string;
+  /** Bedrock bearer-token auth. */
+  token?: string;
+  /** Bedrock region. */
+  region?: string;
+  /** Azure resource id (alternative to --provider-base-url). */
+  resourceId?: string;
+  /**
+   * Provider endpoint for azure/custom. Named apart from the group-level
+   * --base-url, which is the Laminar API URL.
+   */
+  providerBaseUrl?: string;
+  apiVersion?: string;
+  /** Repeatable `Name=Value` custom headers (custom provider). */
+  header?: string[];
+};
+
+/** `Name=Value` (first `=` splits; the value may contain more of them). */
+export const parseHeaderFlag = (raw: string): [string, string] => {
+  const eq = raw.indexOf("=");
+  if (eq <= 0) {
+    throw new Error(`--header must be Name=Value, got "${raw}"`);
+  }
+  return [raw.slice(0, eq).trim(), raw.slice(eq + 1)];
+};
+
+/**
+ * Map the shape flags onto the wire `config` / `secrets` objects. Either is
+ * `undefined` when none of its flags were passed, so update sends nothing and
+ * keeps the stored value (config is a whole-object replace server-side, secrets
+ * an overlay). Auth is derived: `--access-key-id` → aws_keys, `--token` →
+ * bearer_token, else omitted (server defaults to api_key).
+ */
+export const buildProfileConfigAndSecrets = (
+  opts: LlmProfileShapeOpts,
+): {
+  config?: Partial<LlmProfileConfig>;
+  secrets?: LlmProfileSecretsInput;
+} => {
+  const headers: Record<string, string> = {};
+  for (const raw of opts.header ?? []) {
+    const [name, value] = parseHeaderFlag(raw);
+    headers[name] = value;
+  }
+  const headerNames = Object.keys(headers);
+
+  const auth: LlmProfileAuth | undefined =
+    opts.accessKeyId !== undefined
+      ? { type: "aws_keys", accessKeyId: opts.accessKeyId }
+      : opts.token !== undefined
+        ? { type: "bearer_token" }
+        : undefined;
+
+  const config: Partial<LlmProfileConfig> = {
+    ...(auth !== undefined ? { auth } : {}),
+    ...(opts.region !== undefined ? { region: opts.region } : {}),
+    ...(opts.resourceId !== undefined ? { resourceId: opts.resourceId } : {}),
+    ...(opts.providerBaseUrl !== undefined
+      ? { baseUrl: opts.providerBaseUrl }
+      : {}),
+    ...(opts.apiVersion !== undefined ? { apiVersion: opts.apiVersion } : {}),
+    ...(headerNames.length > 0 ? { headerNames } : {}),
+  };
+
+  const secrets: LlmProfileSecretsInput = {
+    ...(opts.apiKey !== undefined ? { apiKey: opts.apiKey } : {}),
+    ...(opts.secretAccessKey !== undefined
+      ? { secretAccessKey: opts.secretAccessKey }
+      : {}),
+    ...(opts.token !== undefined ? { token: opts.token } : {}),
+    ...(headerNames.length > 0 ? { headers } : {}),
+  };
+
+  return {
+    ...(Object.keys(config).length > 0 ? { config } : {}),
+    ...(Object.keys(secrets).length > 0 ? { secrets } : {}),
+  };
+};

--- a/packages/lmnr-cli/src/commands/llm-profile/index.ts
+++ b/packages/lmnr-cli/src/commands/llm-profile/index.ts
@@ -1,0 +1,43 @@
+import type { LaminarClient } from "@lmnr-ai/client";
+
+import type { GlobalOpts } from "../../auth/with-client";
+import { initializeLogger } from "../../utils/logger";
+import { outputJson } from "../../utils/output";
+import { renderTable } from "../../utils/table";
+
+const logger = initializeLogger();
+
+/**
+ * `lmnr-cli llm-profile list` — dumps the caller's project's workspace LLM
+ * profiles with the models they declare, ordered case-insensitively by name.
+ * The point is to feed `signal create --llm-profile <name> --model <name>`
+ * without having to click through the UI.
+ *
+ * Self-hosted only: on Laminar Cloud the server 404s with
+ * `LLM profiles are not available on Laminar Cloud`, surfaced verbatim via the
+ * client's error-envelope unwrapping.
+ */
+export const handleLlmProfileList = async (
+  client: LaminarClient,
+  opts: GlobalOpts,
+): Promise<void> => {
+  const profiles = await client.llmProfiles.list();
+
+  if (opts.json) {
+    outputJson(profiles);
+    return;
+  }
+  if (profiles.length === 0) {
+    logger.info(
+      "No LLM profiles in this workspace. Create one in Settings → LLM profiles.",
+    );
+    return;
+  }
+
+  const rows = profiles.map((p) => [
+    p.name,
+    p.provider,
+    p.models.length === 0 ? "-" : p.models.join(", "),
+  ]);
+  logger.info(renderTable(["Name", "Provider", "Models"], rows));
+};

--- a/packages/lmnr-cli/src/commands/llm-profile/index.ts
+++ b/packages/lmnr-cli/src/commands/llm-profile/index.ts
@@ -27,30 +27,32 @@ const printProfile = (profile: LlmProfile): void => {
   logger.info(`  provider:     ${profile.provider}`);
   logger.info(`  auth:         ${profile.config.auth.type}`);
   const { config, secrets } = profile;
+  // `!= null` throughout: config omits absent fields on the wire, but the
+  // secret masks arrive as explicit `null` — both must stay unprinted.
   if (config.auth.type === "aws_keys") {
     logger.info(`  access key:   ${config.auth.accessKeyId}`);
   }
-  if (config.region !== undefined) {
+  if (config.region != null) {
     logger.info(`  region:       ${config.region}`);
   }
-  if (config.resourceId !== undefined) {
+  if (config.resourceId != null) {
     logger.info(`  resource id:  ${config.resourceId}`);
   }
-  if (config.baseUrl !== undefined) {
+  if (config.baseUrl != null) {
     logger.info(`  base url:     ${config.baseUrl}`);
   }
-  if (config.apiVersion !== undefined) {
+  if (config.apiVersion != null) {
     logger.info(`  api version:  ${config.apiVersion}`);
   }
   logger.info(`  models:       ${profile.models.join(", ") || "-"}`);
   // Secrets are write-only; the server returns first3***last3 masks.
-  if (secrets.apiKey !== undefined) {
+  if (secrets.apiKey != null) {
     logger.info(`  api key:      ${secrets.apiKey}`);
   }
-  if (secrets.secretAccessKey !== undefined) {
+  if (secrets.secretAccessKey != null) {
     logger.info(`  secret key:   ${secrets.secretAccessKey}`);
   }
-  if (secrets.token !== undefined) {
+  if (secrets.token != null) {
     logger.info(`  token:        ${secrets.token}`);
   }
   if (secrets.headers.length > 0) {

--- a/packages/lmnr-cli/src/commands/llm-profile/index.ts
+++ b/packages/lmnr-cli/src/commands/llm-profile/index.ts
@@ -1,21 +1,74 @@
-import type { LaminarClient } from "@lmnr-ai/client";
+import type {
+  CreateLlmProfileOptions,
+  LaminarClient,
+  UpdateLlmProfileOptions,
+} from "@lmnr-ai/client";
+import type { LlmProfile, LlmProfileProvider } from "@lmnr-ai/types";
 
 import type { GlobalOpts } from "../../auth/with-client";
 import { initializeLogger } from "../../utils/logger";
 import { outputJson } from "../../utils/output";
 import { renderTable } from "../../utils/table";
+import {
+  buildProfileConfigAndSecrets,
+  type LlmProfileShapeOpts,
+} from "./flags";
 
 const logger = initializeLogger();
 
+type LlmProfileCreateOpts = GlobalOpts & LlmProfileShapeOpts;
+type LlmProfileUpdateOpts = GlobalOpts &
+  LlmProfileShapeOpts & {
+    name?: string;
+  };
+
+const printProfile = (profile: LlmProfile): void => {
+  logger.info(`${profile.name} (${profile.id})`);
+  logger.info(`  provider:     ${profile.provider}`);
+  logger.info(`  auth:         ${profile.config.auth.type}`);
+  const { config, secrets } = profile;
+  if (config.auth.type === "aws_keys") {
+    logger.info(`  access key:   ${config.auth.accessKeyId}`);
+  }
+  if (config.region !== undefined) {
+    logger.info(`  region:       ${config.region}`);
+  }
+  if (config.resourceId !== undefined) {
+    logger.info(`  resource id:  ${config.resourceId}`);
+  }
+  if (config.baseUrl !== undefined) {
+    logger.info(`  base url:     ${config.baseUrl}`);
+  }
+  if (config.apiVersion !== undefined) {
+    logger.info(`  api version:  ${config.apiVersion}`);
+  }
+  logger.info(`  models:       ${profile.models.join(", ") || "-"}`);
+  // Secrets are write-only; the server returns first3***last3 masks.
+  if (secrets.apiKey !== undefined) {
+    logger.info(`  api key:      ${secrets.apiKey}`);
+  }
+  if (secrets.secretAccessKey !== undefined) {
+    logger.info(`  secret key:   ${secrets.secretAccessKey}`);
+  }
+  if (secrets.token !== undefined) {
+    logger.info(`  token:        ${secrets.token}`);
+  }
+  if (secrets.headers.length > 0) {
+    logger.info(`  headers:      ${secrets.headers.join(", ")}`);
+  }
+  logger.info(`  created:      ${profile.createdAt}`);
+  logger.info(`  updated:      ${profile.updatedAt}`);
+};
+
 /**
- * `lmnr-cli llm-profile list` — dumps the caller's project's workspace LLM
- * profiles with the models they declare, ordered case-insensitively by name.
- * The point is to feed `signal create --llm-profile <name> --model <name>`
- * without having to click through the UI.
+ * `lmnr-cli llm-profile list` — the caller's project's workspace LLM profiles,
+ * ordered case-insensitively by name. The printed IDs feed
+ * `signal create --llm-profile-id <id> --model <name>` and the other
+ * llm-profile subcommands.
  *
  * Self-hosted only: on Laminar Cloud the server 404s with
- * `LLM profiles are not available on Laminar Cloud`, surfaced verbatim via the
- * client's error-envelope unwrapping.
+ * `LLM profiles are not available on this deployment`, surfaced verbatim via
+ * the client's error-envelope unwrapping (same for every subcommand here).
  */
 export const handleLlmProfileList = async (
   client: LaminarClient,
@@ -29,15 +82,112 @@ export const handleLlmProfileList = async (
   }
   if (profiles.length === 0) {
     logger.info(
-      "No LLM profiles in this workspace. Create one in Settings → LLM profiles.",
+      "No LLM profiles in this workspace. Create one with " +
+        "`lmnr-cli llm-profile create` or in Settings → LLM profiles.",
     );
     return;
   }
 
   const rows = profiles.map((p) => [
+    p.id,
     p.name,
     p.provider,
     p.models.length === 0 ? "-" : p.models.join(", "),
   ]);
-  logger.info(renderTable(["Name", "Provider", "Models"], rows));
+  logger.info(renderTable(["ID", "Name", "Provider", "Models"], rows));
+};
+
+/** `lmnr-cli llm-profile get <profile-id>` */
+export const handleLlmProfileGet = async (
+  client: LaminarClient,
+  profileId: string,
+  opts: GlobalOpts,
+): Promise<void> => {
+  const profile = await client.llmProfiles.get(profileId);
+  if (opts.json) {
+    outputJson(profile);
+    return;
+  }
+  printProfile(profile);
+};
+
+/** `lmnr-cli llm-profile create <name>` */
+export const handleLlmProfileCreate = async (
+  client: LaminarClient,
+  name: string,
+  opts: LlmProfileCreateOpts,
+): Promise<void> => {
+  if (opts.provider === undefined) {
+    throw new Error("--provider is required.");
+  }
+  const { config, secrets } = buildProfileConfigAndSecrets(opts);
+  const body: CreateLlmProfileOptions = {
+    name,
+    provider: opts.provider as LlmProfileProvider,
+    ...(config !== undefined ? { config } : {}),
+    ...(secrets !== undefined ? { secrets } : {}),
+    models: opts.model ?? [],
+  };
+
+  const profile = await client.llmProfiles.create(body);
+  if (opts.json) {
+    outputJson(profile);
+    return;
+  }
+  logger.info(`Created LLM profile "${profile.name}".`);
+  printProfile(profile);
+};
+
+/**
+ * `lmnr-cli llm-profile update <profile-id>` — partial patch. Omitted flags
+ * keep stored values; secrets are an overlay (an omitted secret keeps the
+ * stored one). Any config flag sends a WHOLE new config, so re-pass every
+ * config field the provider needs. --model replaces the whole model list.
+ */
+export const handleLlmProfileUpdate = async (
+  client: LaminarClient,
+  profileId: string,
+  opts: LlmProfileUpdateOpts,
+): Promise<void> => {
+  const { config, secrets } = buildProfileConfigAndSecrets(opts);
+  const patch: UpdateLlmProfileOptions = {
+    ...(opts.name !== undefined ? { name: opts.name } : {}),
+    ...(opts.provider !== undefined
+      ? { provider: opts.provider as LlmProfileProvider }
+      : {}),
+    ...(config !== undefined ? { config } : {}),
+    ...(secrets !== undefined ? { secrets } : {}),
+    ...(opts.model !== undefined ? { models: opts.model } : {}),
+  };
+
+  if (Object.keys(patch).length === 0) {
+    throw new Error(
+      "Nothing to update. Pass at least one of --name, --provider, --model, " +
+        "--api-key, --access-key-id, --secret-access-key, --token, --region, " +
+        "--resource-id, --provider-base-url, --api-version, --header.",
+    );
+  }
+
+  const profile = await client.llmProfiles.update(profileId, patch);
+  if (opts.json) {
+    outputJson(profile);
+    return;
+  }
+  logger.info(`Updated LLM profile "${profile.name}".`);
+  printProfile(profile);
+};
+
+/** `lmnr-cli llm-profile delete <profile-id>` */
+export const handleLlmProfileDelete = async (
+  client: LaminarClient,
+  profileId: string,
+  opts: GlobalOpts,
+): Promise<void> => {
+  // The server refuses (409) while any signal routes through the profile.
+  const profile = await client.llmProfiles.delete(profileId);
+  if (opts.json) {
+    outputJson(profile);
+    return;
+  }
+  logger.info(`Deleted LLM profile "${profile.name}" (${profile.id}).`);
 };

--- a/packages/lmnr-cli/src/commands/signal/index.ts
+++ b/packages/lmnr-cli/src/commands/signal/index.ts
@@ -26,6 +26,10 @@ type SignalCreateOpts = GlobalOpts & {
   mode?: string;
   sampleRate?: string;
   disabled?: boolean;
+  /** Workspace LLM profile name; self-hosted only, pass with --model. */
+  llmProfile?: string;
+  /** Model to use from --llm-profile; self-hosted only, pass with --llm-profile. */
+  model?: string;
 };
 
 type SignalUpdateOpts = GlobalOpts & {
@@ -42,6 +46,8 @@ type SignalUpdateOpts = GlobalOpts & {
   sampling?: boolean;
   disabled?: boolean;
   /** commander's `--no-disabled` → `disabled: false`, i.e. re-enable. */
+  llmProfile?: string;
+  model?: string;
 };
 
 /** In the same words `--trigger` accepts, so output can be fed back in. */
@@ -68,6 +74,10 @@ const printSignal = (signal: Signal): void => {
   logger.info(`  mode:         ${signal.mode}`);
   logger.info(`  sample rate:  ${signal.sampleRate ?? "none"}`);
   logger.info(`  status:       ${signal.disabled ? "disabled" : "active"}`);
+  // `env` = the server routes the signal through its process-level LLM_PROVIDER
+  // (legacy signals, or every signal on Laminar Cloud).
+  logger.info(`  llm profile:  ${signal.llmProfile ?? "env"}`);
+  logger.info(`  model:        ${signal.model ?? "env default"}`);
 };
 
 /**
@@ -175,6 +185,10 @@ export const handleSignalCreate = async (
       ? { sampleRate: parseSampleRate(opts.sampleRate) }
       : {}),
     ...(opts.disabled ? { disabled: true } : {}),
+    // Pair-completeness / feature-gating / workspace membership are all
+    // enforced server-side; `raiseSignalError` surfaces the verbatim message.
+    ...(opts.llmProfile !== undefined ? { llmProfile: opts.llmProfile } : {}),
+    ...(opts.model !== undefined ? { model: opts.model } : {}),
   });
 
   if (opts.json) {
@@ -223,13 +237,17 @@ export const handleSignalUpdate = async (
       : {}),
     ...(opts.filters === false ? { filters: [] } : {}),
     ...(opts.mode !== undefined ? { mode: parseMode(opts.mode) } : {}),
+    // Absent = leave stored route; a half pair is rejected server-side. There
+    // is no wire shape for clearing the route back to env.
+    ...(opts.llmProfile !== undefined ? { llmProfile: opts.llmProfile } : {}),
+    ...(opts.model !== undefined ? { model: opts.model } : {}),
   };
 
   if (Object.keys(patch).length === 0) {
     throw new Error(
       "Nothing to update. Pass at least one of --prompt, --schema, --trigger, " +
         "--filter, --no-filters, --mode, --sample-rate, --no-sampling, " +
-        "--disabled, --no-disabled.",
+        "--disabled, --no-disabled, --llm-profile, --model.",
     );
   }
 

--- a/packages/lmnr-cli/src/commands/signal/index.ts
+++ b/packages/lmnr-cli/src/commands/signal/index.ts
@@ -26,9 +26,9 @@ type SignalCreateOpts = GlobalOpts & {
   mode?: string;
   sampleRate?: string;
   disabled?: boolean;
-  /** Workspace LLM profile name; self-hosted only, pass with --model. */
-  llmProfile?: string;
-  /** Model to use from --llm-profile; self-hosted only, pass with --llm-profile. */
+  /** Workspace LLM profile id; self-hosted only, pass with --model. */
+  llmProfileId?: string;
+  /** Model from the profile; self-hosted only, pass with --llm-profile-id. */
   model?: string;
 };
 
@@ -46,7 +46,7 @@ type SignalUpdateOpts = GlobalOpts & {
   sampling?: boolean;
   disabled?: boolean;
   /** commander's `--no-disabled` → `disabled: false`, i.e. re-enable. */
-  llmProfile?: string;
+  llmProfileId?: string;
   model?: string;
 };
 
@@ -76,7 +76,11 @@ const printSignal = (signal: Signal): void => {
   logger.info(`  status:       ${signal.disabled ? "disabled" : "active"}`);
   // `env` = the server routes the signal through its process-level LLM_PROVIDER
   // (legacy signals, or every signal on Laminar Cloud).
-  logger.info(`  llm profile:  ${signal.llmProfile ?? "env"}`);
+  const profile =
+    signal.llmProfileId === null
+      ? "env"
+      : `${signal.llmProfileName ?? "?"} (${signal.llmProfileId})`;
+  logger.info(`  llm profile:  ${profile}`);
   logger.info(`  model:        ${signal.model ?? "env default"}`);
 };
 
@@ -187,7 +191,9 @@ export const handleSignalCreate = async (
     ...(opts.disabled ? { disabled: true } : {}),
     // Pair-completeness / feature-gating / workspace membership are all
     // enforced server-side; `raiseSignalError` surfaces the verbatim message.
-    ...(opts.llmProfile !== undefined ? { llmProfile: opts.llmProfile } : {}),
+    ...(opts.llmProfileId !== undefined
+      ? { llmProfileId: opts.llmProfileId }
+      : {}),
     ...(opts.model !== undefined ? { model: opts.model } : {}),
   });
 
@@ -239,7 +245,9 @@ export const handleSignalUpdate = async (
     ...(opts.mode !== undefined ? { mode: parseMode(opts.mode) } : {}),
     // Absent = leave stored route; a half pair is rejected server-side. There
     // is no wire shape for clearing the route back to env.
-    ...(opts.llmProfile !== undefined ? { llmProfile: opts.llmProfile } : {}),
+    ...(opts.llmProfileId !== undefined
+      ? { llmProfileId: opts.llmProfileId }
+      : {}),
     ...(opts.model !== undefined ? { model: opts.model } : {}),
   };
 
@@ -247,7 +255,7 @@ export const handleSignalUpdate = async (
     throw new Error(
       "Nothing to update. Pass at least one of --prompt, --schema, --trigger, " +
         "--filter, --no-filters, --mode, --sample-rate, --no-sampling, " +
-        "--disabled, --no-disabled, --llm-profile, --model.",
+        "--disabled, --no-disabled, --llm-profile-id, --model.",
     );
   }
 

--- a/packages/lmnr-cli/src/index.ts
+++ b/packages/lmnr-cli/src/index.ts
@@ -23,7 +23,13 @@ import {
   handleDebugSessionSetName,
   handleDebugSessionSummary,
 } from "./commands/debug";
-import { handleLlmProfileList } from "./commands/llm-profile";
+import {
+  handleLlmProfileCreate,
+  handleLlmProfileDelete,
+  handleLlmProfileGet,
+  handleLlmProfileList,
+  handleLlmProfileUpdate,
+} from "./commands/llm-profile";
 import { handleLogin } from "./commands/login";
 import { handleLogout } from "./commands/logout";
 import { AGENTS, handlePluginAdd } from "./commands/plugin";
@@ -342,15 +348,15 @@ FILTER (matched anywhere in the trace) are different things.
     )
     .option("--disabled", "Create the signal deactivated")
     .option(
-      "--llm-profile <name>",
-      "Workspace LLM profile name to run the signal on (self-hosted only). " +
+      "--llm-profile-id <id>",
+      "Workspace LLM profile id to run the signal on (self-hosted only). " +
         "Required together with --model on self-hosted; rejected on Laminar Cloud. " +
-        "Discover names with `lmnr-cli llm-profile list`",
+        "Discover ids with `lmnr-cli llm-profile list`",
     )
     .option(
       "--model <name>",
-      "Model to use from --llm-profile (self-hosted only). " +
-        "Required together with --llm-profile",
+      "Model to use from the profile (self-hosted only). " +
+        "Required together with --llm-profile-id",
     )
     .action(withProjectClient(handleSignalCreate))
     .addHelpText(
@@ -365,9 +371,9 @@ Payload schema rules (identical to the UI):
   - every field is required
 ${TRIGGER_HELP}
 LLM profile (self-hosted only):
-  --llm-profile <name> and --model <name> together pick a workspace LLM
+  --llm-profile-id <id> and --model <name> together pick a workspace LLM
   profile and one of its models to run the signal on. Both are REQUIRED on
-  self-hosted deployments and REJECTED on Laminar Cloud. Discover profiles
+  self-hosted deployments and REJECTED on Laminar Cloud. Discover profile ids
   with \`lmnr-cli llm-profile list\`.
 
 Examples:
@@ -386,7 +392,7 @@ Examples:
   $ lmnr-cli signal create "Refund requests" \\
       --prompt "Detect refund asks." \\
       --schema '{"properties":{"reason":{"type":"string","description":"Refund reason"}}}' \\
-      --llm-profile prod-openai --model gpt-4o
+      --llm-profile-id 3f6c9f1e-8f4b-4b0e-9d3a-2f4f4a6d8b11 --model gpt-4o
 `,
     );
 
@@ -425,14 +431,14 @@ Examples:
     .option("--disabled", "Deactivate the signal")
     .option("--no-disabled", "Reactivate the signal")
     .option(
-      "--llm-profile <name>",
-      "Re-route the signal onto a workspace LLM profile (self-hosted only). " +
-        "Must be paired with --model. There is no flag to clear the route " +
-        "back to the server's env LLM.",
+      "--llm-profile-id <id>",
+      "Re-route the signal onto a workspace LLM profile by id (self-hosted " +
+        "only). Must be paired with --model. There is no flag to clear the " +
+        "route back to the server's env LLM.",
     )
     .option(
       "--model <name>",
-      "Model to use from --llm-profile. Must be paired with --llm-profile",
+      "Model to use from the profile. Must be paired with --llm-profile-id",
     )
     .action(withProjectClient(handleSignalUpdate))
     .addHelpText(
@@ -441,8 +447,8 @@ Examples:
 This is a PARTIAL update: any flag you omit keeps its stored value, so changing
 the prompt will not clear sampling, reactivate a disabled signal, or alter when
 it fires. --trigger, --filter, and --mode are independent — changing one leaves
-the other two alone. --filter REPLACES the whole filter set. --llm-profile and
---model must be passed together to re-route the signal (self-hosted only).
+the other two alone. --filter REPLACES the whole filter set. --llm-profile-id
+and --model must be passed together to re-route the signal (self-hosted only).
 ${TRIGGER_HELP}
 Examples:
   $ lmnr-cli signal update "Refund requests" --prompt "Detect refund asks only"
@@ -454,7 +460,7 @@ Examples:
       --filter '{"column":"total_token_count","operator":"gt","value":"5000"}'
   $ lmnr-cli signal update "Refund requests" --no-filters
   $ lmnr-cli signal update "Refund requests" \\
-      --llm-profile prod-openai --model gpt-4o-mini
+      --llm-profile-id 3f6c9f1e-8f4b-4b0e-9d3a-2f4f4a6d8b11 --model gpt-4o-mini
   $ lmnr-cli signal update "Refund requests" --mode realtime
   $ lmnr-cli signal update "Refund requests" \\
       --trigger span-name --span-name agent.run --span-name worker.step
@@ -482,7 +488,7 @@ Examples:
     .command("llm-profile")
     .alias("llm-profiles")
     .description(
-      "Inspect the workspace LLM profiles signals can run on (self-hosted only)",
+      "Manage the workspace LLM profiles signals can run on (self-hosted only)",
     )
     .option(
       "--project-id <id>",
@@ -500,6 +506,49 @@ Examples:
     )
     .option("--json", "Output structured JSON to stdout");
 
+  /**
+   * Provider-shape flags shared by `create` and `update`. Which combination a
+   * provider needs is validated server-side; the flags only assemble the body.
+   * The provider endpoint flag is `--provider-base-url` because `--base-url`
+   * (group level) is the Laminar API URL and `optsWithGlobals` would shadow it.
+   */
+  const addProfileShapeOptions = (cmd: Command): Command =>
+    cmd
+      .option(
+        "--model <name>",
+        "Model the profile declares (repeatable). On update, REPLACES the " +
+          "whole model list",
+        collectFlag,
+      )
+      .option("--api-key <key>", "API key (all providers except Bedrock)")
+      .option(
+        "--access-key-id <id>",
+        "AWS access key id (Bedrock; selects AWS-keys auth, " +
+          "pair with --secret-access-key)",
+      )
+      .option("--secret-access-key <key>", "AWS secret access key (Bedrock)")
+      .option(
+        "--token <token>",
+        "Bearer token (Bedrock; selects bearer-token auth)",
+      )
+      .option("--region <region>", "AWS region (Bedrock)")
+      .option(
+        "--resource-id <id>",
+        "Azure resource id (alternative to --provider-base-url)",
+      )
+      .option(
+        "--provider-base-url <url>",
+        "Provider endpoint URL (Azure alternative to --resource-id; " +
+          "required for custom). NOT the Laminar API URL — that is --base-url",
+      )
+      .option("--api-version <version>", "Azure API version")
+      .option(
+        "--header <name=value>",
+        "Custom header for the custom provider (repeatable). Names are " +
+          "stored in the profile config, values as secrets",
+        collectFlag,
+      );
+
   llmProfileCmd
     .command("list")
     .description(
@@ -511,15 +560,116 @@ Examples:
       `
 LLM profiles are workspace-scoped provider + credentials + models pairings a
 signal can be pinned to. Self-hosted only: on Laminar Cloud the server rejects
-the request with "LLM profiles are not available on Laminar Cloud".
+the request with "LLM profiles are not available on this deployment".
 
-Feed the printed \`Name\` and one of its \`Models\` to
-\`lmnr-cli signal create --llm-profile <name> --model <name>\`
-or \`lmnr-cli signal update ... --llm-profile <name> --model <name>\`.
+Feed the printed \`ID\` and one of its \`Models\` to
+\`lmnr-cli signal create --llm-profile-id <id> --model <name>\`
+or \`lmnr-cli signal update ... --llm-profile-id <id> --model <name>\`.
 
 Examples:
   $ lmnr-cli llm-profile list
   $ lmnr-cli llm-profile list --json
+`,
+    );
+
+  llmProfileCmd
+    .command("get")
+    .description("Show one LLM profile (secrets appear as masks)")
+    .argument("<profile-id>", "Profile id (see `lmnr-cli llm-profile list`)")
+    .action(withProjectClient(handleLlmProfileGet))
+    .addHelpText(
+      "after",
+      `
+Secrets are write-only: the server returns a first3***last3 mask per stored
+value plus custom header names, never the plaintext.
+
+Examples:
+  $ lmnr-cli llm-profile get 3f6c9f1e-8f4b-4b0e-9d3a-2f4f4a6d8b11
+  $ lmnr-cli llm-profile get 3f6c9f1e-8f4b-4b0e-9d3a-2f4f4a6d8b11 --json
+`,
+    );
+
+  addProfileShapeOptions(
+    llmProfileCmd
+      .command("create")
+      .description("Create a workspace LLM profile")
+      .argument("<name>", "Profile name (unique per workspace)")
+      .requiredOption(
+        "--provider <provider>",
+        "openai_completions | openai_responses | gemini | bedrock | " +
+          "azure_chat_completions | azure_responses | azure_anthropic | custom",
+      ),
+  )
+    .action(withProjectClient(handleLlmProfileCreate))
+    .addHelpText(
+      "after",
+      `
+Per-provider flags (everything else is rejected server-side):
+  openai_*, gemini:        --api-key
+  azure_*:                 --api-key + exactly one of --resource-id /
+                           --provider-base-url; optional --api-version
+  bedrock:                 --region + either --access-key-id with
+                           --secret-access-key, or --token
+  custom (OpenAI-compat):  --api-key + --provider-base-url;
+                           optional --header <name=value> (repeatable)
+
+Examples:
+  $ lmnr-cli llm-profile create prod-openai --provider openai_responses \\
+      --api-key sk-... --model gpt-4o --model gpt-4o-mini
+
+  $ lmnr-cli llm-profile create bedrock-eu --provider bedrock \\
+      --region eu-west-1 --access-key-id AKIA... --secret-access-key ... \\
+      --model anthropic.claude-3-5-sonnet-20240620-v1:0
+
+  $ lmnr-cli llm-profile create gateway --provider custom \\
+      --provider-base-url https://gw.internal.example.com --api-key key \\
+      --header X-Team=ml --model gpt-4o
+`,
+    );
+
+  addProfileShapeOptions(
+    llmProfileCmd
+      .command("update")
+      .description("Update an LLM profile (only the flags you pass change)")
+      .argument("<profile-id>", "Profile id (see `lmnr-cli llm-profile list`)")
+      .option("--name <name>", "Rename the profile")
+      .option(
+        "--provider <provider>",
+        "Change the provider (requires re-passing the config flags)",
+      ),
+  )
+    .action(withProjectClient(handleLlmProfileUpdate))
+    .addHelpText(
+      "after",
+      `
+Partial update with two caveats:
+  - Any config flag (--region, --resource-id, --provider-base-url,
+    --api-version, --header, --access-key-id, --token) sends a WHOLE new
+    config, so re-pass every config field the provider needs.
+  - --model REPLACES the whole model list. Removing a model that a signal is
+    pinned to is refused.
+Omitted secrets keep their stored values, so credentials never need re-sending.
+
+Examples:
+  $ lmnr-cli llm-profile update 3f6c9f1e-... --name staging-openai
+  $ lmnr-cli llm-profile update 3f6c9f1e-... --api-key sk-new
+  $ lmnr-cli llm-profile update 3f6c9f1e-... --model gpt-4o --model o3-mini
+`,
+    );
+
+  llmProfileCmd
+    .command("delete")
+    .description("Delete an LLM profile (refused while a signal uses it)")
+    .argument("<profile-id>", "Profile id (see `lmnr-cli llm-profile list`)")
+    .action(withProjectClient(handleLlmProfileDelete))
+    .addHelpText(
+      "after",
+      `
+Deletion is permanent. The server refuses while any signal still routes
+through the profile — re-route or delete those signals first.
+
+Examples:
+  $ lmnr-cli llm-profile delete 3f6c9f1e-8f4b-4b0e-9d3a-2f4f4a6d8b11
 `,
     );
 

--- a/packages/lmnr-cli/src/index.ts
+++ b/packages/lmnr-cli/src/index.ts
@@ -23,6 +23,7 @@ import {
   handleDebugSessionSetName,
   handleDebugSessionSummary,
 } from "./commands/debug";
+import { handleLlmProfileList } from "./commands/llm-profile";
 import { handleLogin } from "./commands/login";
 import { handleLogout } from "./commands/logout";
 import { AGENTS, handlePluginAdd } from "./commands/plugin";
@@ -340,6 +341,17 @@ FILTER (matched anywhere in the trace) are different things.
       "Evaluate only this percent of matching traces (1-95). Omitted → no sampling",
     )
     .option("--disabled", "Create the signal deactivated")
+    .option(
+      "--llm-profile <name>",
+      "Workspace LLM profile name to run the signal on (self-hosted only). " +
+        "Required together with --model on self-hosted; rejected on Laminar Cloud. " +
+        "Discover names with `lmnr-cli llm-profile list`",
+    )
+    .option(
+      "--model <name>",
+      "Model to use from --llm-profile (self-hosted only). " +
+        "Required together with --llm-profile",
+    )
     .action(withProjectClient(handleSignalCreate))
     .addHelpText(
       "after",
@@ -352,6 +364,12 @@ Payload schema rules (identical to the UI):
   - field types: "string", "number", "boolean" (enum: "string" + "enum": [...])
   - every field is required
 ${TRIGGER_HELP}
+LLM profile (self-hosted only):
+  --llm-profile <name> and --model <name> together pick a workspace LLM
+  profile and one of its models to run the signal on. Both are REQUIRED on
+  self-hosted deployments and REJECTED on Laminar Cloud. Discover profiles
+  with \`lmnr-cli llm-profile list\`.
+
 Examples:
   $ lmnr-cli signal create "Refund requests" \\
       --prompt "Detect when the user asks for a refund. Extract the reason." \\
@@ -364,6 +382,11 @@ Examples:
       --trigger span-name --span-name agent.run \\
       --filter '{"column":"status","operator":"eq","value":"error"}' \\
       --mode realtime --sample-rate 25 --json
+
+  $ lmnr-cli signal create "Refund requests" \\
+      --prompt "Detect refund asks." \\
+      --schema '{"properties":{"reason":{"type":"string","description":"Refund reason"}}}' \\
+      --llm-profile prod-openai --model gpt-4o
 `,
     );
 
@@ -401,6 +424,16 @@ Examples:
     .option("--no-sampling", "Clear sampling (evaluate every matching trace)")
     .option("--disabled", "Deactivate the signal")
     .option("--no-disabled", "Reactivate the signal")
+    .option(
+      "--llm-profile <name>",
+      "Re-route the signal onto a workspace LLM profile (self-hosted only). " +
+        "Must be paired with --model. There is no flag to clear the route " +
+        "back to the server's env LLM.",
+    )
+    .option(
+      "--model <name>",
+      "Model to use from --llm-profile. Must be paired with --llm-profile",
+    )
     .action(withProjectClient(handleSignalUpdate))
     .addHelpText(
       "after",
@@ -408,7 +441,8 @@ Examples:
 This is a PARTIAL update: any flag you omit keeps its stored value, so changing
 the prompt will not clear sampling, reactivate a disabled signal, or alter when
 it fires. --trigger, --filter, and --mode are independent — changing one leaves
-the other two alone. --filter REPLACES the whole filter set.
+the other two alone. --filter REPLACES the whole filter set. --llm-profile and
+--model must be passed together to re-route the signal (self-hosted only).
 ${TRIGGER_HELP}
 Examples:
   $ lmnr-cli signal update "Refund requests" --prompt "Detect refund asks only"
@@ -419,6 +453,8 @@ Examples:
   $ lmnr-cli signal update "Refund requests" \\
       --filter '{"column":"total_token_count","operator":"gt","value":"5000"}'
   $ lmnr-cli signal update "Refund requests" --no-filters
+  $ lmnr-cli signal update "Refund requests" \\
+      --llm-profile prod-openai --model gpt-4o-mini
   $ lmnr-cli signal update "Refund requests" --mode realtime
   $ lmnr-cli signal update "Refund requests" \\
       --trigger span-name --span-name agent.run --span-name worker.step
@@ -439,6 +475,51 @@ event it produced (in ClickHouse). A name must match exactly one signal.
 Examples:
   $ lmnr-cli signal delete "Refund requests"
   $ lmnr-cli signal delete 29b937f1-7e3c-4768-a5e3-7e891c2d7d0a --json
+`,
+    );
+
+  const llmProfileCmd = program
+    .command("llm-profile")
+    .alias("llm-profiles")
+    .description(
+      "Inspect the workspace LLM profiles signals can run on (self-hosted only)",
+    )
+    .option(
+      "--project-id <id>",
+      "Target project id. Defaults to the linked .lmnr/project.json. " +
+        "Run `lmnr-cli login` first.",
+    )
+    .option(
+      "--base-url <url>",
+      "Base URL for the Laminar API. Defaults to https://api.lmnr.ai or LMNR_BASE_URL env variable",
+    )
+    .option(
+      "--port <port>",
+      "Port for the Laminar API. Defaults to 443",
+      (val) => parseInt(val, 10),
+    )
+    .option("--json", "Output structured JSON to stdout");
+
+  llmProfileCmd
+    .command("list")
+    .description(
+      "List the workspace LLM profiles with the models each declares",
+    )
+    .action(withProjectClient(handleLlmProfileList))
+    .addHelpText(
+      "after",
+      `
+LLM profiles are workspace-scoped provider + credentials + models pairings a
+signal can be pinned to. Self-hosted only: on Laminar Cloud the server rejects
+the request with "LLM profiles are not available on Laminar Cloud".
+
+Feed the printed \`Name\` and one of its \`Models\` to
+\`lmnr-cli signal create --llm-profile <name> --model <name>\`
+or \`lmnr-cli signal update ... --llm-profile <name> --model <name>\`.
+
+Examples:
+  $ lmnr-cli llm-profile list
+  $ lmnr-cli llm-profile list --json
 `,
     );
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -3,6 +3,7 @@ export * from "./debug";
 export * from "./debug-session";
 export * from "./evaluation";
 export * from "./initialize-options";
+export * from "./llm-profiles";
 export * from "./session-block";
 export * from "./signals";
 export * from "./sql-schema";

--- a/packages/types/src/llm-profiles.ts
+++ b/packages/types/src/llm-profiles.ts
@@ -1,11 +1,66 @@
 /**
- * A workspace LLM profile as surfaced by the CLI discovery endpoint
- * (`GET /v1/cli/llm-profiles`). Self-hosted only; on Laminar Cloud the endpoint
- * 404s with `{error: "LLM profiles are not available on Laminar Cloud"}`.
+ * Workspace LLM profile wire shapes (`/v1/cli/llm-profiles`, mirrored from
+ * app-server's `LlmProfileResponse`). Self-hosted only; on Laminar Cloud every
+ * route 404s with `{error: "LLM profiles are not available on this deployment"}`.
  */
-export interface LlmProfileOption {
+
+export type LlmProfileProvider =
+  | "openai_completions"
+  | "openai_responses"
+  | "gemini"
+  | "bedrock"
+  | "azure_chat_completions"
+  | "azure_responses"
+  | "azure_anthropic"
+  | "custom";
+
+/**
+ * How the profile authenticates. `api_key` for every provider except Bedrock,
+ * which takes AWS keys (secret arrives separately in `secrets`) or a bearer
+ * token.
+ */
+export type LlmProfileAuth =
+  | { type: "api_key" }
+  | { type: "aws_keys"; accessKeyId: string }
+  | { type: "bearer_token" };
+
+/**
+ * Non-secret provider options. The server normalizes per provider: absent
+ * fields are omitted on the wire, never `null`.
+ */
+export interface LlmProfileConfig {
+  auth: LlmProfileAuth;
+  /** Bedrock. */
+  region?: string;
+  /** Azure: exactly one of `resourceId` / `baseUrl`. */
+  resourceId?: string;
+  /** Azure (alternative to `resourceId`) or `custom` (required). */
+  baseUrl?: string;
+  /** Azure. */
+  apiVersion?: string;
+  /** `custom`: header names whose values live in `secrets.headers`. */
+  headerNames?: string[];
+}
+
+/**
+ * What reads return instead of secrets: a `first3***last3` mask per stored
+ * value (fully starred when short) and custom header names only.
+ */
+export interface LlmProfileSecretMasks {
+  apiKey?: string;
+  secretAccessKey?: string;
+  token?: string;
+  headers: string[];
+}
+
+export interface LlmProfile {
   id: string;
+  workspaceId: string;
   name: string;
-  provider: string;
+  provider: LlmProfileProvider;
+  config: LlmProfileConfig;
   models: string[];
+  secrets: LlmProfileSecretMasks;
+  createdAt: string;
+  updatedAt: string;
 }

--- a/packages/types/src/llm-profiles.ts
+++ b/packages/types/src/llm-profiles.ts
@@ -44,12 +44,13 @@ export interface LlmProfileConfig {
 
 /**
  * What reads return instead of secrets: a `first3***last3` mask per stored
- * value (fully starred when short) and custom header names only.
+ * value (fully starred when short) and custom header names only. Absent slots
+ * arrive as explicit `null` (the server does not omit them).
  */
 export interface LlmProfileSecretMasks {
-  apiKey?: string;
-  secretAccessKey?: string;
-  token?: string;
+  apiKey?: string | null;
+  secretAccessKey?: string | null;
+  token?: string | null;
   headers: string[];
 }
 

--- a/packages/types/src/llm-profiles.ts
+++ b/packages/types/src/llm-profiles.ts
@@ -1,0 +1,11 @@
+/**
+ * A workspace LLM profile as surfaced by the CLI discovery endpoint
+ * (`GET /v1/cli/llm-profiles`). Self-hosted only; on Laminar Cloud the endpoint
+ * 404s with `{error: "LLM profiles are not available on Laminar Cloud"}`.
+ */
+export interface LlmProfileOption {
+  id: string;
+  name: string;
+  provider: string;
+  models: string[];
+}

--- a/packages/types/src/signals.ts
+++ b/packages/types/src/signals.ts
@@ -47,8 +47,10 @@ export interface Signal {
   trigger: SignalTrigger;
   filters: SignalFilter[];
   mode: SignalMode;
-  /** Workspace profile name; `null` = runs on the server's env LLM. */
-  llmProfile: string | null;
-  /** Model pinned within `llmProfile`; `null` alongside `llmProfile`. */
+  /** Workspace LLM profile id; `null` = runs on the server's env LLM. */
+  llmProfileId: string | null;
+  /** Display name of `llmProfileId`; `null` alongside it. */
+  llmProfileName: string | null;
+  /** Model pinned within the profile; `null` alongside `llmProfileId`. */
   model: string | null;
 }

--- a/packages/types/src/signals.ts
+++ b/packages/types/src/signals.ts
@@ -47,4 +47,8 @@ export interface Signal {
   trigger: SignalTrigger;
   filters: SignalFilter[];
   mode: SignalMode;
+  /** Workspace profile name; `null` = runs on the server's env LLM. */
+  llmProfile: string | null;
+  /** Model pinned within `llmProfile`; `null` alongside `llmProfile`. */
+  model: string | null;
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces credential-bearing create/update paths and changes how signals select LLMs on self-hosted deployments; validation is server-side but misconfigured profiles could affect signal execution.
> 
> **Overview**
> Adds **self-hosted workspace LLM profile** management end-to-end in the JS SDK and CLI, and lets **signals** pin which profile and model they run on.
> 
> `@lmnr-ai/types` gains `LlmProfile` wire shapes; `@lmnr-ai/client` exposes `client.llmProfiles` (list/get/create/update/delete on `/v1/cli/llm-profiles`) with `{error}` envelope handling like signals. Signal create/update types accept optional `llmProfileId` and `model`; the `Signal` type now echoes `llmProfileId`, `llmProfileName`, and `model`.
> 
> **`lmnr-cli llm-profile`** (`llm-profiles`) is a new command group that maps provider flags onto `config`/`secrets` (server validates shapes; secrets are an overlay on update). **`signal create` / `update`** add `--llm-profile-id` and `--model` (passed through; pairing and cloud vs self-hosted rules stay server-side). Signal output shows the resolved LLM route; CLI docs describe self-hosted-only behavior and that updates cannot clear routing back to env LLM.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 283a4dd7abf8fb474312fec6a5aa9748c6f41fa8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->