### PR TITLE
feat: signal versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@lmnr-ai/lmnr-ts",
   "private": true,
-  "version": "0.8.45",
+  "version": "0.8.46",
   "description": "Laminar AI TypeScript SDK",
   "scripts": {
     "typecheck": "tsc",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lmnr-ai/client",
-  "version": "0.8.45",
+  "version": "0.8.46",
   "description": "HTTP client for Laminar AI API",
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",

--- a/packages/client/src/resources/signals.ts
+++ b/packages/client/src/resources/signals.ts
@@ -4,6 +4,7 @@ import {
   type SignalMode,
   type SignalStructuredOutput,
   type SignalTrigger,
+  type SignalVersion,
 } from "@lmnr-ai/types";
 
 import { BaseResource, type LaminarAuth } from ".";
@@ -91,6 +92,26 @@ export class SignalsResource extends BaseResource {
       await this.raiseSignalError(response);
     }
     return response.json() as Promise<Signal>;
+  }
+
+  /**
+   * Historical judge definitions for `signalId`, oldest first. Distinct from
+   * `GET /signals/{id}`'s `version` field, which is only the current pointer.
+   * 404 if that id isn't in this project; an empty list only if the signal
+   * exists with no version rows.
+   */
+  public async listVersions(signalId: string): Promise<SignalVersion[]> {
+    const response = await fetch(
+      `${this.baseHttpUrl}${this.apiPrefix}/signals/${signalId}/versions`,
+      { method: "GET", headers: this.headers() },
+    );
+    if (!response.ok) {
+      await this.raiseSignalError(response);
+    }
+    // Coerce a missing/non-array `versions` to [] so callers can .map/.length it;
+    // a malformed body on a 2xx is exceptional, not the normal empty case.
+    const body = (await response.json()) as { versions?: SignalVersion[] };
+    return Array.isArray(body?.versions) ? body.versions : [];
   }
 
   public async create(options: CreateSignalOptions): Promise<Signal> {

--- a/packages/lmnr-cli/package.json
+++ b/packages/lmnr-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lmnr-cli",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "CLI for the Laminar agent observability platform",
   "main": "dist/index.cjs",
   "bin": {

--- a/packages/lmnr-cli/src/commands/signal/index.ts
+++ b/packages/lmnr-cli/src/commands/signal/index.ts
@@ -1,5 +1,10 @@
 import type { LaminarClient } from "@lmnr-ai/client";
-import type { Signal, SignalFilter, SignalTrigger } from "@lmnr-ai/types";
+import type {
+  Signal,
+  SignalFilter,
+  SignalTrigger,
+  SignalVersion,
+} from "@lmnr-ai/types";
 
 import type { GlobalOpts } from "../../auth/with-client";
 import { initializeLogger } from "../../utils/logger";
@@ -148,6 +153,42 @@ export const handleSignalGet = async (
     return;
   }
   printSignal(signal);
+};
+
+const printVersion = (entry: SignalVersion): void => {
+  logger.info(`v${entry.version}  ${entry.createdAt}`);
+  logger.info(`  prompt:  ${entry.definition?.prompt ?? ""}`);
+  const fields = Object.keys(
+    entry.definition?.structuredOutputSchema?.properties ?? {},
+  ).join(", ");
+  logger.info(`  fields:  ${fields}`);
+};
+
+/**
+ * `lmnr-cli signal versions <signal>` — historical judge definitions, oldest
+ * first. The server path is a UUID; a name is resolved the same way as get.
+ */
+export const handleSignalVersions = async (
+  client: LaminarClient,
+  ref: string,
+  opts: GlobalOpts,
+): Promise<void> => {
+  const versions = await client.signals.listVersions(
+    await resolveSignalId(client, ref),
+  );
+
+  if (opts.json) {
+    outputJson(versions);
+    return;
+  }
+  if (versions.length === 0) {
+    logger.info("No versions found.");
+    return;
+  }
+  for (const [i, entry] of versions.entries()) {
+    if (i > 0) logger.info("");
+    printVersion(entry);
+  }
 };
 
 /** `lmnr-cli signal create <name>` */

--- a/packages/lmnr-cli/src/index.ts
+++ b/packages/lmnr-cli/src/index.ts
@@ -36,6 +36,7 @@ import {
   handleSignalGet,
   handleSignalList,
   handleSignalUpdate,
+  handleSignalVersions,
 } from "./commands/signal";
 import { collectFlag } from "./commands/signal/validate";
 import { handleSkillAdd, handleSkillUpdate } from "./commands/skill";
@@ -300,6 +301,24 @@ FILTER (matched anywhere in the trace) are different things.
     .description("Show one signal with its trigger, filters, and mode")
     .argument("<signal>", "Signal id or name")
     .action(withProjectClient(handleSignalGet));
+
+  signalCmd
+    .command("versions")
+    .description("List a signal's judge-definition versions, oldest first")
+    .argument("<signal>", "Signal id or name")
+    .action(withProjectClient(handleSignalVersions))
+    .addHelpText(
+      "after",
+      `
+The version log for the judge prompt + schema. Distinct from \`signal get\`'s
+version field, which is only the current pointer. A name is resolved locally
+(the API path is an id); an ambiguous name is an error, same as get/update.
+
+Examples:
+  $ lmnr-cli signal versions "Failure Detector"
+  $ lmnr-cli signal versions 7143fab6-7a80-4d9f-81ed-4ee3d5d82254 --json
+`,
+    );
 
   signalCmd
     .command("create")

--- a/packages/lmnr/package.json
+++ b/packages/lmnr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lmnr-ai/lmnr",
-  "version": "0.8.45",
+  "version": "0.8.46",
   "description": "TypeScript SDK for Laminar AI",
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lmnr-ai/types",
-  "version": "0.8.45",
+  "version": "0.8.46",
   "description": "Shared types for Laminar AI SDK",
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",

--- a/packages/types/src/signals.ts
+++ b/packages/types/src/signals.ts
@@ -50,12 +50,23 @@ export interface Signal {
 }
 
 /**
- * Stored judge definition blob. The schema key is `structuredOutputSchema`,
- * not `structuredOutput` — that name is only on `GET /signals/{id}`.
+ * Stored version blob on `GET /signals/{id}/versions`. Schema key is
+ * `structuredOutputSchema`, not `structuredOutput` (that name is only on
+ * `GET /signals/{id}`). `trigger`/`filters` are stored Filter[] JSON
+ * (`signal_triggers.value` / `filters`), not the CLI tagged {@link SignalTrigger}.
  */
 export interface SignalDefinition {
+  name: string;
   prompt: string;
   structuredOutputSchema: SignalStructuredOutput;
+  trigger: SignalFilter[];
+  filters: SignalFilter[];
+  mode: SignalMode;
+  sampleRate: number | null;
+  disabled: boolean;
+  /** Both `null` = env-var routing. Cloud signals stay `null`. */
+  llmProfileId: string | null;
+  llmModel: string | null;
 }
 
 /**

--- a/packages/types/src/signals.ts
+++ b/packages/types/src/signals.ts
@@ -48,3 +48,22 @@ export interface Signal {
   filters: SignalFilter[];
   mode: SignalMode;
 }
+
+/**
+ * Stored judge definition blob. The schema key is `structuredOutputSchema`,
+ * not `structuredOutput` — that name is only on `GET /signals/{id}`.
+ */
+export interface SignalDefinition {
+  prompt: string;
+  structuredOutputSchema: SignalStructuredOutput;
+}
+
+/**
+ * One historical judge definition. `GET /signals/{id}`'s `version` field is
+ * only the current pointer; this is the version log.
+ */
+export interface SignalVersion {
+  version: number;
+  definition: SignalDefinition;
+  createdAt: string;
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Read-only API and CLI surface with additive types; no changes to signal create/update/delete behavior.
> 
> **Overview**
> Adds **signal version history** to the TypeScript SDK and CLI so users can inspect past judge prompts and schemas, not just the current `version` pointer on `signal get`.
> 
> **Types** introduce `SignalDefinition` and `SignalVersion`, modeling the `/signals/{id}/versions` payload (including `structuredOutputSchema` and stored filter shapes).
> 
> **Client** adds `signals.listVersions(signalId)`, calling `GET …/signals/{id}/versions` and normalizing a missing `versions` array to `[]`.
> 
> **CLI** adds `lmnr-cli signal versions <signal>` (id or resolved name), with human-readable output or `--json`, plus patch bumps (`@lmnr-ai/*` 0.8.46, `lmnr-cli` 0.5.1).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9577b365e9c0808c891366c2b432d5ef79d211c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->