### PR TITLE
Add dataset CRUD client and CLI commands

### DIFF
--- a/packages/client/src/resources/datasets.ts
+++ b/packages/client/src/resources/datasets.ts
@@ -41,11 +41,14 @@ export class DatasetsResource extends BaseResource {
 
   /** Create an empty dataset. */
   public async create(name: string): Promise<Dataset> {
-    const response = await fetch(this.baseHttpUrl + this.apiPrefix + "/datasets", {
-      method: "POST",
-      headers: this.headers(),
-      body: JSON.stringify({ name }),
-    });
+    const response = await fetch(
+      this.baseHttpUrl + this.apiPrefix + "/datasets",
+      {
+        method: "POST",
+        headers: this.headers(),
+        body: JSON.stringify({ name }),
+      },
+    );
 
     if (!response.ok) {
       await this.handleError(response);

--- a/packages/client/src/resources/datasets.ts
+++ b/packages/client/src/resources/datasets.ts
@@ -39,6 +39,67 @@ export class DatasetsResource extends BaseResource {
     return response.json() as Promise<Dataset[]>;
   }
 
+  /** Create an empty dataset. */
+  public async create(name: string): Promise<Dataset> {
+    const response = await fetch(this.baseHttpUrl + this.apiPrefix + "/datasets", {
+      method: "POST",
+      headers: this.headers(),
+      body: JSON.stringify({ name }),
+    });
+
+    if (!response.ok) {
+      await this.handleError(response);
+    }
+
+    return response.json() as Promise<Dataset>;
+  }
+
+  /** Get a dataset by its canonical UUID. */
+  public async getById(datasetId: StringUUID): Promise<Dataset> {
+    const response = await fetch(
+      `${this.baseHttpUrl}${this.apiPrefix}/datasets/${datasetId}`,
+      { method: "GET", headers: this.headers() },
+    );
+
+    if (!response.ok) {
+      await this.handleError(response);
+    }
+
+    return response.json() as Promise<Dataset>;
+  }
+
+  /** Rename a dataset. */
+  public async update(datasetId: StringUUID, name: string): Promise<Dataset> {
+    const response = await fetch(
+      `${this.baseHttpUrl}${this.apiPrefix}/datasets/${datasetId}`,
+      {
+        method: "PATCH",
+        headers: this.headers(),
+        body: JSON.stringify({ name }),
+      },
+    );
+
+    if (!response.ok) {
+      await this.handleError(response);
+    }
+
+    return response.json() as Promise<Dataset>;
+  }
+
+  /** Delete a dataset and its datapoints. */
+  public async delete(datasetId: StringUUID): Promise<Dataset> {
+    const response = await fetch(
+      `${this.baseHttpUrl}${this.apiPrefix}/datasets/${datasetId}`,
+      { method: "DELETE", headers: this.headers() },
+    );
+
+    if (!response.ok) {
+      await this.handleError(response);
+    }
+
+    return response.json() as Promise<Dataset>;
+  }
+
   /**
    * Get a dataset by name.
    *

--- a/packages/client/test/datasets-resource.test.ts
+++ b/packages/client/test/datasets-resource.test.ts
@@ -1,0 +1,78 @@
+import * as assert from "node:assert";
+import { describe, it, mock } from "node:test";
+
+import { DatasetsResource } from "../src/resources/datasets";
+
+const datasetId = "11111111-1111-1111-1111-111111111111";
+const dataset = { id: datasetId, name: "examples", createdAt: "2026-01-01T00:00:00Z" };
+
+const resource = () => new DatasetsResource(
+  "https://api.test.com",
+  { type: "userToken", token: "token", projectId: "project" },
+);
+
+void describe("DatasetsResource CRUD", () => {
+  void it("creates an empty dataset", async () => {
+    const mockFetch = mock.fn(() => ({
+      ok: true,
+      json: () => Promise.resolve(dataset),
+    }));
+    global.fetch = mockFetch as any;
+
+    assert.deepStrictEqual(await resource().create("examples"), dataset);
+    const [url, options] = mockFetch.mock.calls[0].arguments as [string, RequestInit];
+    assert.strictEqual(url, "https://api.test.com/v1/cli/datasets");
+    assert.strictEqual(options.method, "POST");
+    assert.deepStrictEqual(JSON.parse(options.body as string), { name: "examples" });
+  });
+
+  void it("gets a dataset by id", async () => {
+    const mockFetch = mock.fn(() => ({
+      ok: true,
+      json: () => Promise.resolve(dataset),
+    }));
+    global.fetch = mockFetch as any;
+
+    assert.deepStrictEqual(await resource().getById(datasetId), dataset);
+    const [url, options] = mockFetch.mock.calls[0].arguments as [string, RequestInit];
+    assert.strictEqual(url, `https://api.test.com/v1/cli/datasets/${datasetId}`);
+    assert.strictEqual(options.method, "GET");
+  });
+
+  void it("updates a dataset by id", async () => {
+    const mockFetch = mock.fn(() => ({
+      ok: true,
+      json: () => Promise.resolve({ ...dataset, name: "renamed" }),
+    }));
+    global.fetch = mockFetch as any;
+
+    await resource().update(datasetId, "renamed");
+    const [url, options] = mockFetch.mock.calls[0].arguments as [string, RequestInit];
+    assert.strictEqual(url, `https://api.test.com/v1/cli/datasets/${datasetId}`);
+    assert.strictEqual(options.method, "PATCH");
+    assert.deepStrictEqual(JSON.parse(options.body as string), { name: "renamed" });
+  });
+
+  void it("deletes a dataset by id", async () => {
+    const mockFetch = mock.fn(() => ({
+      ok: true,
+      json: () => Promise.resolve(dataset),
+    }));
+    global.fetch = mockFetch as any;
+
+    assert.deepStrictEqual(await resource().delete(datasetId), dataset);
+    const [url, options] = mockFetch.mock.calls[0].arguments as [string, RequestInit];
+    assert.strictEqual(url, `https://api.test.com/v1/cli/datasets/${datasetId}`);
+    assert.strictEqual(options.method, "DELETE");
+  });
+
+  void it("surfaces CRUD API errors", async () => {
+    global.fetch = mock.fn(() => ({
+      ok: false,
+      status: 404,
+      text: () => Promise.resolve('{"error":"Dataset not found"}'),
+    })) as any;
+
+    await assert.rejects(resource().getById(datasetId), /404.*Dataset not found/);
+  });
+});

--- a/packages/client/test/datasets-resource.test.ts
+++ b/packages/client/test/datasets-resource.test.ts
@@ -4,12 +4,18 @@ import { describe, it, mock } from "node:test";
 import { DatasetsResource } from "../src/resources/datasets";
 
 const datasetId = "11111111-1111-1111-1111-111111111111";
-const dataset = { id: datasetId, name: "examples", createdAt: "2026-01-01T00:00:00Z" };
+const dataset = {
+  id: datasetId,
+  name: "examples",
+  createdAt: "2026-01-01T00:00:00Z",
+};
 
-const resource = () => new DatasetsResource(
-  "https://api.test.com",
-  { type: "userToken", token: "token", projectId: "project" },
-);
+const resource = () =>
+  new DatasetsResource("https://api.test.com", {
+    type: "userToken",
+    token: "token",
+    projectId: "project",
+  });
 
 void describe("DatasetsResource CRUD", () => {
   void it("creates an empty dataset", async () => {
@@ -20,10 +26,15 @@ void describe("DatasetsResource CRUD", () => {
     global.fetch = mockFetch as any;
 
     assert.deepStrictEqual(await resource().create("examples"), dataset);
-    const [url, options] = mockFetch.mock.calls[0].arguments as [string, RequestInit];
+    const [url, options] = mockFetch.mock.calls[0].arguments as unknown as [
+      string,
+      RequestInit,
+    ];
     assert.strictEqual(url, "https://api.test.com/v1/cli/datasets");
     assert.strictEqual(options.method, "POST");
-    assert.deepStrictEqual(JSON.parse(options.body as string), { name: "examples" });
+    assert.deepStrictEqual(JSON.parse(options.body as string), {
+      name: "examples",
+    });
   });
 
   void it("gets a dataset by id", async () => {
@@ -34,8 +45,14 @@ void describe("DatasetsResource CRUD", () => {
     global.fetch = mockFetch as any;
 
     assert.deepStrictEqual(await resource().getById(datasetId), dataset);
-    const [url, options] = mockFetch.mock.calls[0].arguments as [string, RequestInit];
-    assert.strictEqual(url, `https://api.test.com/v1/cli/datasets/${datasetId}`);
+    const [url, options] = mockFetch.mock.calls[0].arguments as unknown as [
+      string,
+      RequestInit,
+    ];
+    assert.strictEqual(
+      url,
+      `https://api.test.com/v1/cli/datasets/${datasetId}`,
+    );
     assert.strictEqual(options.method, "GET");
   });
 
@@ -47,10 +64,18 @@ void describe("DatasetsResource CRUD", () => {
     global.fetch = mockFetch as any;
 
     await resource().update(datasetId, "renamed");
-    const [url, options] = mockFetch.mock.calls[0].arguments as [string, RequestInit];
-    assert.strictEqual(url, `https://api.test.com/v1/cli/datasets/${datasetId}`);
+    const [url, options] = mockFetch.mock.calls[0].arguments as unknown as [
+      string,
+      RequestInit,
+    ];
+    assert.strictEqual(
+      url,
+      `https://api.test.com/v1/cli/datasets/${datasetId}`,
+    );
     assert.strictEqual(options.method, "PATCH");
-    assert.deepStrictEqual(JSON.parse(options.body as string), { name: "renamed" });
+    assert.deepStrictEqual(JSON.parse(options.body as string), {
+      name: "renamed",
+    });
   });
 
   void it("deletes a dataset by id", async () => {
@@ -61,8 +86,14 @@ void describe("DatasetsResource CRUD", () => {
     global.fetch = mockFetch as any;
 
     assert.deepStrictEqual(await resource().delete(datasetId), dataset);
-    const [url, options] = mockFetch.mock.calls[0].arguments as [string, RequestInit];
-    assert.strictEqual(url, `https://api.test.com/v1/cli/datasets/${datasetId}`);
+    const [url, options] = mockFetch.mock.calls[0].arguments as unknown as [
+      string,
+      RequestInit,
+    ];
+    assert.strictEqual(
+      url,
+      `https://api.test.com/v1/cli/datasets/${datasetId}`,
+    );
     assert.strictEqual(options.method, "DELETE");
   });
 
@@ -73,6 +104,9 @@ void describe("DatasetsResource CRUD", () => {
       text: () => Promise.resolve('{"error":"Dataset not found"}'),
     })) as any;
 
-    await assert.rejects(resource().getById(datasetId), /404.*Dataset not found/);
+    await assert.rejects(
+      resource().getById(datasetId),
+      /404.*Dataset not found/,
+    );
   });
 });

--- a/packages/lmnr-cli/README.md
+++ b/packages/lmnr-cli/README.md
@@ -114,13 +114,15 @@ lmnr-cli sql schema                                      # Show available tables
 
 ### [`dataset`](src/commands/dataset/README.md) - Dataset Management
 
-List, push, pull, and create datasets in your Laminar project.
+Create, inspect, rename, delete, and transfer dataset datapoints.
 
 ```bash
-lmnr-cli dataset list --json                             # List all datasets
-lmnr-cli dataset push data.jsonl -n my-dataset --json    # Push data to a dataset
-lmnr-cli dataset pull output.jsonl -n my-dataset --json  # Pull data from a dataset
-lmnr-cli dataset create my-dataset data.jsonl -o out.jsonl
+lmnr-cli dataset list --json                              # List all datasets
+lmnr-cli dataset create my-dataset --json                 # Create an empty dataset
+lmnr-cli dataset get <dataset-id> --json                  # Get by canonical UUID
+lmnr-cli dataset update <dataset-id> --name renamed       # Rename by UUID
+lmnr-cli dataset delete <dataset-id> --json               # Delete without prompting
+lmnr-cli dataset import my-dataset data.jsonl -o out.jsonl
 ```
 
 ### `debug` - Annotate and inspect agent runs

--- a/packages/lmnr-cli/src/commands/dataset/README.md
+++ b/packages/lmnr-cli/src/commands/dataset/README.md
@@ -2,110 +2,52 @@
 
 Manage datasets in your Laminar project from the command line.
 
-## Usage
-
 ```bash
 lmnr-cli dataset <command> [options]
 ```
 
-### Global Options
+Dataset commands authenticate as the signed-in user and target the project from
+`--project-id` or the linked `.lmnr/project.json`. All commands support `--json`.
 
-These options apply to all dataset subcommands. Datasets authenticate as the
-signed-in user (run `lmnr-cli login` first) and target a project:
+## Dataset CRUD
 
-- `--project-id <id>` - Target project id (defaults to the linked `.lmnr/project.json`; run `lmnr-cli setup` to link)
-- `--base-url <url>` - Base URL for the Laminar API (default: https://api.lmnr.ai)
-- `--port <port>` - Port for the Laminar API (default: 443)
-- `--json` - Output structured JSON to stdout
-
-## Commands
-
-### `dataset list`
-
-List all datasets in your project.
+Datasets are addressed by UUID for get, update, and delete. Names do not need to
+be unique.
 
 ```bash
 lmnr-cli dataset list
-lmnr-cli dataset list --json
+lmnr-cli dataset get <dataset-id>
+lmnr-cli dataset create <name>
+lmnr-cli dataset update <dataset-id> --name <new-name>
+lmnr-cli dataset delete <dataset-id>
 ```
 
-### `dataset push`
+`create` creates an empty dataset. `delete` is non-interactive and also deletes
+the dataset's datapoints.
 
-Push datapoints to an existing dataset from local files.
+## Push and pull datapoints
+
+Push and pull retain name-or-ID lookup for compatibility:
 
 ```bash
-lmnr-cli dataset push <paths...> [options]
+lmnr-cli dataset push <paths...> --id <dataset-id>
+lmnr-cli dataset push <paths...> --name <name>
+lmnr-cli dataset pull [output-path] --id <dataset-id>
+lmnr-cli dataset pull [output-path] --name <name>
 ```
 
-**Arguments:**
-- `<paths...>` - Paths to files or directories containing data to push
+Push options include `--recursive` and `--batch-size`. Pull options include
+`--output-format <json|csv|jsonl>`, `--batch-size`, `--limit`, and `--offset`.
 
-**Options:**
-- `-n, --name <name>` - Name of the dataset (either name or id must be provided)
-- `--id <id>` - ID of the dataset (either name or id must be provided)
-- `-r, --recursive` - Recursively read files in directories
-- `--batch-size <size>` - Batch size for pushing data (default: 100)
+## Import files into a new dataset
 
-**Examples:**
-```bash
-lmnr-cli dataset push data.jsonl -n my-dataset
-lmnr-cli dataset push data/ -n my-dataset -r --json
-```
-
-### `dataset pull`
-
-Pull datapoints from a dataset to a local file or stdout.
+The former create-and-populate workflow is available as `import`:
 
 ```bash
-lmnr-cli dataset pull [output-path] [options]
+lmnr-cli dataset import <name> <paths...> -o <output-file>
+lmnr-cli dataset import examples data/ -r -o exported.jsonl
 ```
 
-**Arguments:**
-- `[output-path]` - Path to save the data. If not provided, prints to console
-
-**Options:**
-- `-n, --name <name>` - Name of the dataset (either name or id must be provided)
-- `--id <id>` - ID of the dataset (either name or id must be provided)
-- `--output-format <format>` - Output format (`json`, `csv`, `jsonl`). Inferred from file extension if not provided
-- `--batch-size <size>` - Batch size for pulling data (default: 100)
-- `--limit <limit>` - Limit number of datapoints to pull
-- `--offset <offset>` - Offset for pagination (default: 0)
-
-**Examples:**
-```bash
-lmnr-cli dataset pull output.jsonl -n my-dataset
-lmnr-cli dataset pull -n my-dataset --json          # Print to stdout as JSON
-lmnr-cli dataset pull output.csv -n my-dataset --limit 50
-```
-
-### `dataset create`
-
-Create a new dataset from local input files.
-
-```bash
-lmnr-cli dataset create <name> <paths...> [options]
-```
-
-**Arguments:**
-- `<name>` - Name of the dataset to create
-- `<paths...>` - Paths to files or directories containing data to push
-
-**Required Options:**
-- `-o, --output-file <file>` - Path to save the pulled data
-
-**Options:**
-- `--output-format <format>` - Output format (`json`, `csv`, `jsonl`). Inferred from file extension if not provided
-- `-r, --recursive` - Recursively read files in directories
-- `--batch-size <size>` - Batch size for pushing/pulling data (default: 100)
-
-**Examples:**
-```bash
-lmnr-cli dataset create my-dataset data.jsonl -o output.jsonl
-lmnr-cli dataset create my-dataset data/ -o output.json -r
-```
-
-## Supported File Formats
-
-- **JSONL** (`.jsonl`) - One JSON object per line
-- **JSON** (`.json`) - Array of objects
-- **CSV** (`.csv`) - Comma-separated values with headers
+Import creates and populates a dataset, pulls the stored datapoints back, and
+writes them to the required output file. Supported input/output formats are
+JSON, JSONL, and CSV.

--- a/packages/lmnr-cli/src/commands/dataset/index.test.ts
+++ b/packages/lmnr-cli/src/commands/dataset/index.test.ts
@@ -4,12 +4,20 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 // The dataset handlers are now pure: the wrapper resolves the client and owns
 // the error envelope. We pass a stub client with the datasets surface directly.
 const mockListDatasets = vi.fn();
+const mockGetById = vi.fn();
+const mockCreate = vi.fn();
+const mockUpdate = vi.fn();
+const mockDelete = vi.fn();
 const mockPush = vi.fn();
 const mockPull = vi.fn();
 
 const stubClient = {
   datasets: {
     listDatasets: mockListDatasets,
+    getById: mockGetById,
+    create: mockCreate,
+    update: mockUpdate,
+    delete: mockDelete,
     push: mockPush,
     pull: mockPull,
   },
@@ -24,10 +32,14 @@ vi.mock("../../utils/file", () => ({
 // Import after mocks are set up
 import { loadFromPaths, printToConsole, writeToFile } from "../../utils/file";
 import {
-  handleDatasetsCreate,
+  handleDatasetCreate,
+  handleDatasetDelete,
+  handleDatasetGet,
+  handleDatasetsImport,
   handleDatasetsList,
   handleDatasetsPull,
   handleDatasetsPush,
+  handleDatasetUpdate,
 } from "./index";
 
 const mockedLoadFromPaths = vi.mocked(loadFromPaths);
@@ -37,9 +49,7 @@ const mockedPrintToConsole = vi.mocked(printToConsole);
 let logSpy: ReturnType<typeof vi.spyOn>;
 
 beforeEach(() => {
-  logSpy = vi.spyOn(console, "log").mockImplementation(() => {
-    /* empty */
-  });
+  logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
   vi.clearAllMocks();
 });
 
@@ -47,17 +57,11 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-const baseOpts = {
-  projectId: "fake-project",
-  baseUrl: "http://localhost",
-  port: 8080,
-};
+const baseOpts = { projectId: "fake-project", baseUrl: "http://localhost", port: 8080 };
 
 describe("handleDatasetsList", () => {
   it("outputs JSON array in json mode", async () => {
-    const datasets = [
-      { id: "abc-123", name: "test-ds", createdAt: "2024-01-01T00:00:00Z" },
-    ];
+    const datasets = [{ id: "abc-123", name: "test-ds", createdAt: "2024-01-01T00:00:00Z" }];
     mockListDatasets.mockResolvedValue(datasets);
 
     await handleDatasetsList(stubClient, { ...baseOpts, json: true });
@@ -74,9 +78,7 @@ describe("handleDatasetsList", () => {
   });
 
   it("prints table in human mode", async () => {
-    const datasets = [
-      { id: "abc-123", name: "test-ds", createdAt: "2024-01-01T00:00:00Z" },
-    ];
+    const datasets = [{ id: "abc-123", name: "test-ds", createdAt: "2024-01-01T00:00:00Z" }];
     mockListDatasets.mockResolvedValue(datasets);
 
     await handleDatasetsList(stubClient, baseOpts);
@@ -98,26 +100,56 @@ describe("handleDatasetsList", () => {
   it("propagates API failures to the wrapper", async () => {
     mockListDatasets.mockRejectedValue(new Error("unauthorized"));
 
-    await expect(handleDatasetsList(stubClient, baseOpts)).rejects.toThrow(
-      "unauthorized",
-    );
+    await expect(handleDatasetsList(stubClient, baseOpts)).rejects.toThrow("unauthorized");
+  });
+});
+
+describe("dataset CRUD handlers", () => {
+  const datasetId = "11111111-1111-1111-1111-111111111111" as const;
+  const dataset = { id: datasetId, name: "test-ds", createdAt: "2024-01-01T00:00:00Z" };
+
+  it("gets a dataset and outputs JSON", async () => {
+    mockGetById.mockResolvedValue(dataset);
+    await handleDatasetGet(stubClient, datasetId, { ...baseOpts, json: true });
+    expect(mockGetById).toHaveBeenCalledWith(datasetId);
+    expect(logSpy).toHaveBeenCalledWith(JSON.stringify(dataset));
+  });
+
+  it("creates an empty dataset", async () => {
+    mockCreate.mockResolvedValue(dataset);
+    await handleDatasetCreate(stubClient, "test-ds", { ...baseOpts, json: true });
+    expect(mockCreate).toHaveBeenCalledWith("test-ds");
+    expect(logSpy).toHaveBeenCalledWith(JSON.stringify(dataset));
+  });
+
+  it("updates a dataset by id", async () => {
+    const renamed = { ...dataset, name: "renamed" };
+    mockUpdate.mockResolvedValue(renamed);
+    await handleDatasetUpdate(stubClient, datasetId, {
+      ...baseOpts,
+      name: "renamed",
+      json: true,
+    });
+    expect(mockUpdate).toHaveBeenCalledWith(datasetId, "renamed");
+    expect(logSpy).toHaveBeenCalledWith(JSON.stringify(renamed));
+  });
+
+  it("deletes a dataset by id without prompting", async () => {
+    mockDelete.mockResolvedValue(dataset);
+    await handleDatasetDelete(stubClient, datasetId, { ...baseOpts, json: true });
+    expect(mockDelete).toHaveBeenCalledWith(datasetId);
+    expect(logSpy).toHaveBeenCalledWith(JSON.stringify(dataset));
   });
 });
 
 describe("handleDatasetsPush", () => {
   it("throws when neither name nor id provided", async () => {
-    await expect(
-      handleDatasetsPush(stubClient, [], { ...baseOpts }),
-    ).rejects.toThrow("name or id");
+    await expect(handleDatasetsPush(stubClient, [], { ...baseOpts })).rejects.toThrow("name or id");
   });
 
   it("throws when both name and id provided", async () => {
     await expect(
-      handleDatasetsPush(stubClient, [], {
-        ...baseOpts,
-        name: "x",
-        id: "y" as any,
-      }),
+      handleDatasetsPush(stubClient, [], { ...baseOpts, name: "x", id: "y" as any }),
     ).rejects.toThrow("Only one of name or id");
   });
 
@@ -135,11 +167,7 @@ describe("handleDatasetsPush", () => {
     mockedLoadFromPaths.mockResolvedValue([{ data: { x: 1 } }]);
     mockPush.mockResolvedValue({ datasetId: "ds-123" });
 
-    await handleDatasetsPush(stubClient, ["./data"], {
-      ...baseOpts,
-      name: "test",
-      json: true,
-    });
+    await handleDatasetsPush(stubClient, ["./data"], { ...baseOpts, name: "test", json: true });
 
     const output = JSON.parse(logSpy.mock.calls[0][0] as string);
     expect(output.datasetId).toBe("ds-123");
@@ -150,10 +178,7 @@ describe("handleDatasetsPush", () => {
     mockedLoadFromPaths.mockResolvedValue([{ data: { x: 1 } }]);
     mockPush.mockResolvedValue({ datasetId: "ds-123" });
 
-    await handleDatasetsPush(stubClient, ["./data"], {
-      ...baseOpts,
-      name: "test",
-    });
+    await handleDatasetsPush(stubClient, ["./data"], { ...baseOpts, name: "test" });
 
     expect(mockPush).toHaveBeenCalled();
   });
@@ -170,18 +195,14 @@ describe("handleDatasetsPush", () => {
 
 describe("handleDatasetsPull", () => {
   it("throws when neither name nor id provided", async () => {
-    await expect(
-      handleDatasetsPull(stubClient, undefined, { ...baseOpts }),
-    ).rejects.toThrow("name or id");
+    await expect(handleDatasetsPull(stubClient, undefined, { ...baseOpts })).rejects.toThrow(
+      "name or id",
+    );
   });
 
   it("throws when both name and id provided", async () => {
     await expect(
-      handleDatasetsPull(stubClient, undefined, {
-        ...baseOpts,
-        name: "x",
-        id: "y" as any,
-      }),
+      handleDatasetsPull(stubClient, undefined, { ...baseOpts, name: "x", id: "y" as any }),
     ).rejects.toThrow("Only one of name or id");
   });
 
@@ -203,10 +224,7 @@ describe("handleDatasetsPull", () => {
   it("writes to file in human mode", async () => {
     mockPull.mockResolvedValue({ items: [{ data: { a: 1 } }], totalCount: 1 });
 
-    await handleDatasetsPull(stubClient, "/tmp/out.json", {
-      ...baseOpts,
-      name: "test",
-    });
+    await handleDatasetsPull(stubClient, "/tmp/out.json", { ...baseOpts, name: "test" });
 
     expect(mockedWriteToFile).toHaveBeenCalled();
   });
@@ -215,11 +233,7 @@ describe("handleDatasetsPull", () => {
     const items = [{ data: { a: 1 } }, { data: { a: 2 } }];
     mockPull.mockResolvedValue({ items, totalCount: 2 });
 
-    await handleDatasetsPull(stubClient, undefined, {
-      ...baseOpts,
-      name: "test",
-      json: true,
-    });
+    await handleDatasetsPull(stubClient, undefined, { ...baseOpts, name: "test", json: true });
 
     const output = JSON.parse(logSpy.mock.calls[0][0] as string);
     expect(output).toEqual(items);
@@ -247,12 +261,12 @@ describe("handleDatasetsPull", () => {
   });
 });
 
-describe("handleDatasetsCreate", () => {
+describe("handleDatasetsImport", () => {
   it("throws when no data to push", async () => {
     mockedLoadFromPaths.mockResolvedValue([]);
 
     await expect(
-      handleDatasetsCreate(stubClient, "my-ds", ["./data"], {
+      handleDatasetsImport(stubClient, "my-ds", ["./data"], {
         ...baseOpts,
         outputFile: "/tmp/out.json",
       }),
@@ -267,7 +281,7 @@ describe("handleDatasetsCreate", () => {
     const items = [{ data: { x: 1 }, id: "dp-1" }];
     mockPull.mockResolvedValue({ items, totalCount: 1 });
 
-    await handleDatasetsCreate(stubClient, "my-ds", ["./data"], {
+    await handleDatasetsImport(stubClient, "my-ds", ["./data"], {
       ...baseOpts,
       outputFile: "/tmp/out.json",
       json: true,
@@ -286,7 +300,7 @@ describe("handleDatasetsCreate", () => {
     mockPush.mockRejectedValue(new Error("push failed"));
 
     await expect(
-      handleDatasetsCreate(stubClient, "my-ds", ["./data"], {
+      handleDatasetsImport(stubClient, "my-ds", ["./data"], {
         ...baseOpts,
         outputFile: "/tmp/out.json",
       }),
@@ -299,7 +313,7 @@ describe("handleDatasetsCreate", () => {
     mockPull.mockRejectedValue(new Error("pull failed"));
 
     await expect(
-      handleDatasetsCreate(stubClient, "my-ds", ["./data"], {
+      handleDatasetsImport(stubClient, "my-ds", ["./data"], {
         ...baseOpts,
         outputFile: "/tmp/out.json",
       }),

--- a/packages/lmnr-cli/src/commands/dataset/index.test.ts
+++ b/packages/lmnr-cli/src/commands/dataset/index.test.ts
@@ -49,7 +49,9 @@ const mockedPrintToConsole = vi.mocked(printToConsole);
 let logSpy: ReturnType<typeof vi.spyOn>;
 
 beforeEach(() => {
-  logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  logSpy = vi.spyOn(console, "log").mockImplementation(() => {
+    // Suppress command output during tests.
+  });
   vi.clearAllMocks();
 });
 
@@ -57,11 +59,17 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-const baseOpts = { projectId: "fake-project", baseUrl: "http://localhost", port: 8080 };
+const baseOpts = {
+  projectId: "fake-project",
+  baseUrl: "http://localhost",
+  port: 8080,
+};
 
 describe("handleDatasetsList", () => {
   it("outputs JSON array in json mode", async () => {
-    const datasets = [{ id: "abc-123", name: "test-ds", createdAt: "2024-01-01T00:00:00Z" }];
+    const datasets = [
+      { id: "abc-123", name: "test-ds", createdAt: "2024-01-01T00:00:00Z" },
+    ];
     mockListDatasets.mockResolvedValue(datasets);
 
     await handleDatasetsList(stubClient, { ...baseOpts, json: true });
@@ -78,7 +86,9 @@ describe("handleDatasetsList", () => {
   });
 
   it("prints table in human mode", async () => {
-    const datasets = [{ id: "abc-123", name: "test-ds", createdAt: "2024-01-01T00:00:00Z" }];
+    const datasets = [
+      { id: "abc-123", name: "test-ds", createdAt: "2024-01-01T00:00:00Z" },
+    ];
     mockListDatasets.mockResolvedValue(datasets);
 
     await handleDatasetsList(stubClient, baseOpts);
@@ -100,13 +110,19 @@ describe("handleDatasetsList", () => {
   it("propagates API failures to the wrapper", async () => {
     mockListDatasets.mockRejectedValue(new Error("unauthorized"));
 
-    await expect(handleDatasetsList(stubClient, baseOpts)).rejects.toThrow("unauthorized");
+    await expect(handleDatasetsList(stubClient, baseOpts)).rejects.toThrow(
+      "unauthorized",
+    );
   });
 });
 
 describe("dataset CRUD handlers", () => {
   const datasetId = "11111111-1111-1111-1111-111111111111" as const;
-  const dataset = { id: datasetId, name: "test-ds", createdAt: "2024-01-01T00:00:00Z" };
+  const dataset = {
+    id: datasetId,
+    name: "test-ds",
+    createdAt: "2024-01-01T00:00:00Z",
+  };
 
   it("gets a dataset and outputs JSON", async () => {
     mockGetById.mockResolvedValue(dataset);
@@ -117,7 +133,10 @@ describe("dataset CRUD handlers", () => {
 
   it("creates an empty dataset", async () => {
     mockCreate.mockResolvedValue(dataset);
-    await handleDatasetCreate(stubClient, "test-ds", { ...baseOpts, json: true });
+    await handleDatasetCreate(stubClient, "test-ds", {
+      ...baseOpts,
+      json: true,
+    });
     expect(mockCreate).toHaveBeenCalledWith("test-ds");
     expect(logSpy).toHaveBeenCalledWith(JSON.stringify(dataset));
   });
@@ -136,7 +155,10 @@ describe("dataset CRUD handlers", () => {
 
   it("deletes a dataset by id without prompting", async () => {
     mockDelete.mockResolvedValue(dataset);
-    await handleDatasetDelete(stubClient, datasetId, { ...baseOpts, json: true });
+    await handleDatasetDelete(stubClient, datasetId, {
+      ...baseOpts,
+      json: true,
+    });
     expect(mockDelete).toHaveBeenCalledWith(datasetId);
     expect(logSpy).toHaveBeenCalledWith(JSON.stringify(dataset));
   });
@@ -144,12 +166,18 @@ describe("dataset CRUD handlers", () => {
 
 describe("handleDatasetsPush", () => {
   it("throws when neither name nor id provided", async () => {
-    await expect(handleDatasetsPush(stubClient, [], { ...baseOpts })).rejects.toThrow("name or id");
+    await expect(
+      handleDatasetsPush(stubClient, [], { ...baseOpts }),
+    ).rejects.toThrow("name or id");
   });
 
   it("throws when both name and id provided", async () => {
     await expect(
-      handleDatasetsPush(stubClient, [], { ...baseOpts, name: "x", id: "y" as any }),
+      handleDatasetsPush(stubClient, [], {
+        ...baseOpts,
+        name: "x",
+        id: "y" as any,
+      }),
     ).rejects.toThrow("Only one of name or id");
   });
 
@@ -167,7 +195,11 @@ describe("handleDatasetsPush", () => {
     mockedLoadFromPaths.mockResolvedValue([{ data: { x: 1 } }]);
     mockPush.mockResolvedValue({ datasetId: "ds-123" });
 
-    await handleDatasetsPush(stubClient, ["./data"], { ...baseOpts, name: "test", json: true });
+    await handleDatasetsPush(stubClient, ["./data"], {
+      ...baseOpts,
+      name: "test",
+      json: true,
+    });
 
     const output = JSON.parse(logSpy.mock.calls[0][0] as string);
     expect(output.datasetId).toBe("ds-123");
@@ -178,7 +210,10 @@ describe("handleDatasetsPush", () => {
     mockedLoadFromPaths.mockResolvedValue([{ data: { x: 1 } }]);
     mockPush.mockResolvedValue({ datasetId: "ds-123" });
 
-    await handleDatasetsPush(stubClient, ["./data"], { ...baseOpts, name: "test" });
+    await handleDatasetsPush(stubClient, ["./data"], {
+      ...baseOpts,
+      name: "test",
+    });
 
     expect(mockPush).toHaveBeenCalled();
   });
@@ -195,14 +230,18 @@ describe("handleDatasetsPush", () => {
 
 describe("handleDatasetsPull", () => {
   it("throws when neither name nor id provided", async () => {
-    await expect(handleDatasetsPull(stubClient, undefined, { ...baseOpts })).rejects.toThrow(
-      "name or id",
-    );
+    await expect(
+      handleDatasetsPull(stubClient, undefined, { ...baseOpts }),
+    ).rejects.toThrow("name or id");
   });
 
   it("throws when both name and id provided", async () => {
     await expect(
-      handleDatasetsPull(stubClient, undefined, { ...baseOpts, name: "x", id: "y" as any }),
+      handleDatasetsPull(stubClient, undefined, {
+        ...baseOpts,
+        name: "x",
+        id: "y" as any,
+      }),
     ).rejects.toThrow("Only one of name or id");
   });
 
@@ -224,7 +263,10 @@ describe("handleDatasetsPull", () => {
   it("writes to file in human mode", async () => {
     mockPull.mockResolvedValue({ items: [{ data: { a: 1 } }], totalCount: 1 });
 
-    await handleDatasetsPull(stubClient, "/tmp/out.json", { ...baseOpts, name: "test" });
+    await handleDatasetsPull(stubClient, "/tmp/out.json", {
+      ...baseOpts,
+      name: "test",
+    });
 
     expect(mockedWriteToFile).toHaveBeenCalled();
   });
@@ -233,7 +275,11 @@ describe("handleDatasetsPull", () => {
     const items = [{ data: { a: 1 } }, { data: { a: 2 } }];
     mockPull.mockResolvedValue({ items, totalCount: 2 });
 
-    await handleDatasetsPull(stubClient, undefined, { ...baseOpts, name: "test", json: true });
+    await handleDatasetsPull(stubClient, undefined, {
+      ...baseOpts,
+      name: "test",
+      json: true,
+    });
 
     const output = JSON.parse(logSpy.mock.calls[0][0] as string);
     expect(output).toEqual(items);

--- a/packages/lmnr-cli/src/commands/dataset/index.ts
+++ b/packages/lmnr-cli/src/commands/dataset/index.ts
@@ -12,10 +12,12 @@ const DEFAULT_DATASET_PULL_BATCH_SIZE = 100;
 const DEFAULT_DATASET_PUSH_BATCH_SIZE = 100;
 
 const printDataset = (dataset: Dataset): void => {
-  console.log(renderTable(
-    ["ID", "Created At", "Name"],
-    [[dataset.id, new Date(dataset.createdAt).toISOString(), dataset.name]],
-  ));
+  console.log(
+    renderTable(
+      ["ID", "Created At", "Name"],
+      [[dataset.id, new Date(dataset.createdAt).toISOString(), dataset.name]],
+    ),
+  );
 };
 
 interface DatasetIdentifierOptions extends GlobalOpts {
@@ -169,7 +171,9 @@ export const handleDatasetDelete = async (
     outputJson(dataset);
     return;
   }
-  logger.info(`Deleted dataset "${dataset.name}" (${dataset.id}) and its datapoints.`);
+  logger.info(
+    `Deleted dataset "${dataset.name}" (${dataset.id}) and its datapoints.`,
+  );
 };
 
 /**

--- a/packages/lmnr-cli/src/commands/dataset/index.ts
+++ b/packages/lmnr-cli/src/commands/dataset/index.ts
@@ -1,5 +1,5 @@
 import { LaminarClient } from "@lmnr-ai/client";
-import { Datapoint, type StringUUID } from "@lmnr-ai/types";
+import { Datapoint, type Dataset, type StringUUID } from "@lmnr-ai/types";
 
 import type { GlobalOpts } from "../../auth/with-client";
 import { loadFromPaths, printToConsole, writeToFile } from "../../utils/file";
@@ -10,6 +10,13 @@ import { renderTable } from "../../utils/table";
 const logger = initializeLogger();
 const DEFAULT_DATASET_PULL_BATCH_SIZE = 100;
 const DEFAULT_DATASET_PUSH_BATCH_SIZE = 100;
+
+const printDataset = (dataset: Dataset): void => {
+  console.log(renderTable(
+    ["ID", "Created At", "Name"],
+    [[dataset.id, new Date(dataset.createdAt).toISOString(), dataset.name]],
+  ));
+};
 
 interface DatasetIdentifierOptions extends GlobalOpts {
   name?: string;
@@ -109,6 +116,62 @@ export const handleDatasetsList = async (
   console.log(`\nTotal: ${datasets.length} dataset(s)\n`);
 };
 
+/** `lmnr-cli dataset get <dataset-id>` */
+export const handleDatasetGet = async (
+  client: LaminarClient,
+  datasetId: StringUUID,
+  opts: GlobalOpts,
+): Promise<void> => {
+  const dataset = await client.datasets.getById(datasetId);
+  if (opts.json) {
+    outputJson(dataset);
+    return;
+  }
+  printDataset(dataset);
+};
+
+/** `lmnr-cli dataset create <name>` */
+export const handleDatasetCreate = async (
+  client: LaminarClient,
+  name: string,
+  opts: GlobalOpts,
+): Promise<void> => {
+  const dataset = await client.datasets.create(name);
+  if (opts.json) {
+    outputJson(dataset);
+    return;
+  }
+  logger.info(`Created dataset "${dataset.name}" (${dataset.id}).`);
+};
+
+/** `lmnr-cli dataset update <dataset-id> --name <name>` */
+export const handleDatasetUpdate = async (
+  client: LaminarClient,
+  datasetId: StringUUID,
+  opts: GlobalOpts & { name: string },
+): Promise<void> => {
+  const dataset = await client.datasets.update(datasetId, opts.name);
+  if (opts.json) {
+    outputJson(dataset);
+    return;
+  }
+  logger.info(`Updated dataset "${dataset.name}" (${dataset.id}).`);
+};
+
+/** `lmnr-cli dataset delete <dataset-id>` */
+export const handleDatasetDelete = async (
+  client: LaminarClient,
+  datasetId: StringUUID,
+  opts: GlobalOpts,
+): Promise<void> => {
+  const dataset = await client.datasets.delete(datasetId);
+  if (opts.json) {
+    outputJson(dataset);
+    return;
+  }
+  logger.info(`Deleted dataset "${dataset.name}" (${dataset.id}) and its datapoints.`);
+};
+
 /**
  * Handle datasets push command.
  */
@@ -190,9 +253,9 @@ export const handleDatasetsPull = async (
 };
 
 /**
- * Handle datasets create command.
+ * Import local files into a new dataset, then export the persisted datapoints.
  */
-export const handleDatasetsCreate = async (
+export const handleDatasetsImport = async (
   client: LaminarClient,
   name: string,
   paths: string[],

--- a/packages/lmnr-cli/src/index.ts
+++ b/packages/lmnr-cli/src/index.ts
@@ -11,10 +11,14 @@ import {
 } from "./auth/with-client";
 import { handleAsk } from "./commands/ask";
 import {
-  handleDatasetsCreate,
+  handleDatasetCreate,
+  handleDatasetDelete,
+  handleDatasetGet,
+  handleDatasetsImport,
   handleDatasetsList,
   handleDatasetsPull,
   handleDatasetsPush,
+  handleDatasetUpdate,
 } from "./commands/dataset";
 import {
   handleDebugSessionAddNote,
@@ -96,6 +100,31 @@ async function main() {
     .description("List all datasets")
     .action(withProjectClient(handleDatasetsList));
 
+  datasetsCmd
+    .command("get")
+    .description("Get a dataset by ID")
+    .argument("<dataset-id>", "Dataset UUID")
+    .action(withProjectClient(handleDatasetGet));
+
+  datasetsCmd
+    .command("create")
+    .description("Create an empty dataset")
+    .argument("<name>", "Name of the dataset to create")
+    .action(withProjectClient(handleDatasetCreate));
+
+  datasetsCmd
+    .command("update")
+    .description("Rename a dataset")
+    .argument("<dataset-id>", "Dataset UUID")
+    .requiredOption("-n, --name <name>", "New dataset name")
+    .action(withProjectClient(handleDatasetUpdate));
+
+  datasetsCmd
+    .command("delete")
+    .description("Delete a dataset and its datapoints")
+    .argument("<dataset-id>", "Dataset UUID")
+    .action(withProjectClient(handleDatasetDelete));
+
   // Datasets push command
   datasetsCmd
     .command("push")
@@ -158,10 +187,10 @@ async function main() {
     )
     .action(withProjectClient(handleDatasetsPull));
 
-  // Datasets create command
+  // Dataset import command
   datasetsCmd
-    .command("create")
-    .description("Create a dataset from input files")
+    .command("import")
+    .description("Create and populate a dataset from input files")
     .argument("<name>", "Name of the dataset to create")
     .argument(
       "<paths...>",
@@ -179,7 +208,7 @@ async function main() {
       (val) => parseInt(val, 10),
       100,
     )
-    .action(withProjectClient(handleDatasetsCreate));
+    .action(withProjectClient(handleDatasetsImport));
 
   const sqlCmd = program
     .command("sql")


### PR DESCRIPTION
## Dataset commands

- `lmnr-cli dataset list` — list datasets.
- `lmnr-cli dataset get <dataset-id>` — get a dataset by UUID.
- `lmnr-cli dataset update <dataset-id> --name <name>` — rename a dataset.
- `lmnr-cli dataset delete <dataset-id>` — delete a dataset and its datapoints.
- `lmnr-cli dataset create <name> <paths...> -o <file>` — create a dataset, push local datapoints, then save the persisted datapoints.
  - `--output-format <json|csv|jsonl>`
  - `-r, --recursive`
  - `--batch-size <size>` (default: `100`)

All dataset commands support:

- `--project-id <id>` — override the linked project.
- `--base-url <url>` and `--port <port>` — target another API.
- `--json` — emit structured JSON.

## Client API

Adds `datasets.create`, `getById`, `update`, and `delete`. Dataset UUIDs are used after creation; existing name-based push/pull remain supported.
